### PR TITLE
Add missing group member list reading perms

### DIFF
--- a/docs/jupiterone-io/graph-azure.md
+++ b/docs/jupiterone-io/graph-azure.md
@@ -36,7 +36,8 @@ Grant permission to read Microsoft Graph information:
 
 1. Navigate to **API permissions**, choose **Microsoft Graph**, then
    **Application Permissions**
-1. Grant `Group.Read.All` and `User.Read.All` permissions
+1. Grant `Group.Read.All`, `User.Read.All`, and `OrgContact.Read.All`
+   permissions
 1. Grant admin consent for this directory for the permissions above
 
 Please note that [`User.Read` is required][3] even when AD ingestion is


### PR DESCRIPTION
This is required to allow reading member listings where the group contains an organization "Contact" type. I'd really like to have data returned from the test org that includes an org contact, but that requires a paid Office 365 account, to manage org data, as far as I can tell.