### PR TITLE
Update SDK

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   ],
   "rules": {
     "require-atomic-updates": "off",
-    "@typescript-eslint/no-use-before-define": "off"
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@azure/arm-network": "^16.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "^30.1.1",
+    "@jupiterone/jupiter-managed-integration-sdk": "^31.0.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@azure/arm-network": "^16.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "^28.3.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "^30.1.1",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/src/azure/fetchBatchOfGroupMembers.ts
+++ b/src/azure/fetchBatchOfGroupMembers.ts
@@ -31,14 +31,12 @@ export default async function fetchBatchOfGroupMembers(
   let fetchErrorOccurred = false;
 
   await groupsCache.forEach(
-    async (
-      groupEntry: IntegrationCacheEntry,
-      groupEntryIndex: number,
-      groupEntryCount: number,
-    ) => {
-      totalGroups = groupEntryCount;
-
+    async e => {
+      const groupEntry = e.entry;
+      const groupEntryIndex = e.entryIndex;
       const group = groupEntry.data as Group;
+
+      totalGroups = e.totalEntries;
 
       // load up accumulated list of members
       const groupMembers: GroupMember[] =
@@ -46,6 +44,7 @@ export default async function fetchBatchOfGroupMembers(
 
       // fetch members for group
       do {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const response = await azure.fetchGroupMembers(group.id!, {
           nextLink,
           limit,
@@ -86,7 +85,7 @@ export default async function fetchBatchOfGroupMembers(
         return pagesProcessed === batchPages;
       }
     },
-    groupIndex,
+    { skip: groupIndex },
   );
 
   const groupMembersFetchCompleted =

--- a/src/azure/graph/createGraphClient.test.ts
+++ b/src/azure/graph/createGraphClient.test.ts
@@ -14,7 +14,7 @@ test("createGraphClient accessToken fetched and cached", async () => {
   let requests = 0;
 
   p = polly(__dirname, "createGraphClient");
-  p.server.any().on("request", req => requests++);
+  p.server.any().on("request", _req => requests++);
 
   const client = createGraphClient(config);
   await expect(client.api("/").get()).resolves.toMatchObject({

--- a/src/azure/resource-manager/ResourceManagerClient.test.ts
+++ b/src/azure/resource-manager/ResourceManagerClient.test.ts
@@ -22,22 +22,22 @@ test("client accessToken fetched once and used across resources", async () => {
   let requests = 0;
 
   p = polly(__dirname, "accessTokenCaching");
-  p.server.any().on("request", req => requests++);
+  p.server.any().on("request", () => requests++);
 
   const client = new ResourceManagerClient(config);
 
   await expect(
-    client.iterateNetworkInterfaces(e => undefined),
+    client.iterateNetworkInterfaces(() => undefined),
   ).resolves.toBeUndefined();
   expect(requests).toEqual(3);
 
   await expect(
-    client.iterateNetworkInterfaces(e => undefined),
+    client.iterateNetworkInterfaces(() => undefined),
   ).resolves.toBeUndefined();
   expect(requests).toEqual(4);
 
   await expect(
-    client.iterateVirtualMachines(e => undefined),
+    client.iterateVirtualMachines(() => undefined),
   ).resolves.toBeUndefined();
   expect(requests).toEqual(5);
 });

--- a/src/azure/resource-manager/ResourceManagerClient.ts
+++ b/src/azure/resource-manager/ResourceManagerClient.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { ComputeManagementClient } from "@azure/arm-compute";
 import { VirtualMachine } from "@azure/arm-compute/esm/models";
 import { NetworkManagementClient } from "@azure/arm-network";

--- a/src/converters/graph.test.ts
+++ b/src/converters/graph.test.ts
@@ -1,7 +1,9 @@
-import { IntegrationInstance } from "@jupiterone/jupiter-managed-integration-sdk";
+import {
+  IntegrationInstance,
+  EntityFromIntegration,
+} from "@jupiterone/jupiter-managed-integration-sdk";
 import { Organization } from "@microsoft/microsoft-graph-types";
 
-import { AccountEntity } from "../jupiterone";
 import {
   createAccountEntity,
   createGroupEntity,
@@ -30,10 +32,18 @@ describe("createAccountEntity", () => {
     };
     const accountEntity = createAccountEntity(instance, organization);
 
-    const expected: AccountEntity = {
-      _class: "Account",
+    const expected: EntityFromIntegration & {
+      name: string;
+      defaultDomain: string;
+      organizationName: string;
+      verifiedDomains: string[];
+    } = {
+      _class: ["Account"],
       _key: "azure_account_the-instance-id",
       _type: "azure_account",
+      _scope: "azure_account",
+      _rawData: [{ name: "default", rawData: organization }],
+      name: "Org Display Name",
       displayName: "instance.config.name configured by customer",
       defaultDomain: "something.onmicrosoft.com",
       organizationName: "Org Display Name",
@@ -74,6 +84,7 @@ describe("createGroupEntity", () => {
       _class: "UserGroup",
       _key: "azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792",
       _type: "azure_user_group",
+      _scope: "azure_user_group",
       classification: undefined,
       createdOn: 1556042765000,
       deletedOn: undefined,
@@ -110,6 +121,7 @@ describe("createUserEntity", () => {
       _class: "User",
       _key: "azure_user_abf00eda-02d6-4053-a077-eef036e1a4c8",
       _type: "azure_user",
+      _scope: "azure_user",
       displayName: "Andrew Kulakov",
       givenName: "Andrew",
       id: "abf00eda-02d6-4053-a077-eef036e1a4c8",

--- a/src/converters/graph.ts
+++ b/src/converters/graph.ts
@@ -1,12 +1,16 @@
-import { IntegrationInstance } from "@jupiterone/jupiter-managed-integration-sdk";
-import { Organization } from "@microsoft/microsoft-graph-types";
 import map from "lodash.map";
+
+import {
+  createIntegrationEntity,
+  EntityFromIntegration,
+  IntegrationInstance,
+} from "@jupiterone/jupiter-managed-integration-sdk";
+import { Organization } from "@microsoft/microsoft-graph-types";
 
 import { Group, User } from "../azure";
 import {
   ACCOUNT_ENTITY_CLASS,
   ACCOUNT_ENTITY_TYPE,
-  AccountEntity,
   GROUP_ENTITY_CLASS,
   GROUP_ENTITY_TYPE,
   GroupEntity,
@@ -20,24 +24,30 @@ import getTime from "../utils/getTime";
 export function createAccountEntity(
   instance: IntegrationInstance,
   organization: Organization,
-): AccountEntity {
+): EntityFromIntegration {
   let defaultDomain: string | undefined;
   const verifiedDomains = map(organization.verifiedDomains, e => {
-    if (e.isDefault!) {
+    if (e.isDefault) {
       defaultDomain = e.name;
     }
-    return e.name!;
+    return e.name as string;
   });
 
-  return {
-    _class: ACCOUNT_ENTITY_CLASS,
-    _key: generateEntityKey(ACCOUNT_ENTITY_TYPE, instance.id),
-    _type: ACCOUNT_ENTITY_TYPE,
-    displayName: instance.name,
-    organizationName: organization.displayName,
-    defaultDomain,
-    verifiedDomains,
-  };
+  return createIntegrationEntity({
+    entityData: {
+      source: organization,
+      assign: {
+        _class: ACCOUNT_ENTITY_CLASS,
+        _key: generateEntityKey(ACCOUNT_ENTITY_TYPE, instance.id),
+        _type: ACCOUNT_ENTITY_TYPE,
+        name: organization.displayName,
+        displayName: instance.name,
+        organizationName: organization.displayName,
+        defaultDomain,
+        verifiedDomains,
+      },
+    },
+  });
 }
 
 export function createGroupEntity(d: Group): GroupEntity {
@@ -45,6 +55,7 @@ export function createGroupEntity(d: Group): GroupEntity {
     _class: GROUP_ENTITY_CLASS,
     _key: generateEntityKey(GROUP_ENTITY_TYPE, d.id),
     _type: GROUP_ENTITY_TYPE,
+    _scope: GROUP_ENTITY_TYPE,
     displayName: d.displayName,
     id: d.id,
     deletedOn: getTime(d.deletedDateTime),
@@ -64,6 +75,7 @@ export function createUserEntity(data: User): UserEntity {
     _class: USER_ENTITY_CLASS,
     _key: generateEntityKey(USER_ENTITY_TYPE, data.id),
     _type: USER_ENTITY_TYPE,
+    _scope: USER_ENTITY_TYPE,
     displayName: data.displayName,
     givenName: data.givenName,
     jobTitle: data.jobTitle,

--- a/src/converters/relationships.test.ts
+++ b/src/converters/relationships.test.ts
@@ -6,15 +6,14 @@ import {
   Subnet,
   VirtualNetwork,
 } from "@azure/arm-network/esm/models";
-import { RelationshipDirection } from "@jupiterone/jupiter-managed-integration-sdk";
+import {
+  RelationshipDirection,
+  RelationshipFromIntegration,
+  MappedRelationshipFromIntegration,
+} from "@jupiterone/jupiter-managed-integration-sdk";
 
 import { Group, GroupMember } from "../azure";
-import {
-  AccountEntity,
-  GroupMemberRelationship,
-  VirtualMachineNetworkInterfaceRelationship,
-  VirtualMachinePublicIPAddressRelationship,
-} from "../jupiterone";
+import { AccountEntity } from "../jupiterone";
 import {
   createAccountGroupRelationship,
   createAccountUserRelationship,
@@ -64,6 +63,8 @@ describe("createAccountGroupRelationship", () => {
         "azure_account_id_azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792",
       _toEntityKey: "azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792",
       _type: "azure_account_has_group",
+      _scope: "azure_account_has_azure_user_group",
+      displayName: "HAS",
     });
   });
 });
@@ -91,6 +92,8 @@ describe("createAccountUserRelationship", () => {
       _key: "azure_account_id_azure_user_abf00eda-02d6-4053-a077-eef036e1a4c8",
       _toEntityKey: "azure_user_abf00eda-02d6-4053-a077-eef036e1a4c8",
       _type: "azure_account_has_user",
+      _scope: "azure_account_has_azure_user",
+      displayName: "HAS",
     });
   });
 });
@@ -109,11 +112,16 @@ describe("createGroupMemberRelationship", () => {
       mail: "user@example.com",
     };
 
-    const relationship: GroupMemberRelationship = {
+    const relationship: MappedRelationshipFromIntegration & {
+      groupId: string;
+      memberId: string;
+      memberType: string;
+    } = {
       _class: "HAS",
       _key:
         "azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792_azure_user_324e8daa-9c29-42a4-a74b-b9893e6d9750",
       _type: "azure_group_has_member",
+      _scope: "azure_group_has_member",
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         sourceEntityKey:
@@ -131,6 +139,7 @@ describe("createGroupMemberRelationship", () => {
       groupId: "89fac263-2430-48fd-9278-dacfdfc89792",
       memberId: "324e8daa-9c29-42a4-a74b-b9893e6d9750",
       memberType: "#microsoft.graph.user",
+      displayName: "HAS",
     };
 
     expect(createGroupMemberRelationship(group, member)).toEqual(relationship);
@@ -145,11 +154,16 @@ describe("createGroupMemberRelationship", () => {
       mail: null,
     };
 
-    const relationship: GroupMemberRelationship = {
+    const relationship: MappedRelationshipFromIntegration & {
+      groupId: string;
+      memberId: string;
+      memberType: string;
+    } = {
       _class: "HAS",
       _key:
         "azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792_azure_user_group_324e8daa-9c29-42a4-a74b-b9893e6d9750",
       _type: "azure_group_has_member",
+      _scope: "azure_group_has_member",
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         sourceEntityKey:
@@ -167,6 +181,7 @@ describe("createGroupMemberRelationship", () => {
       groupId: "89fac263-2430-48fd-9278-dacfdfc89792",
       memberId: "324e8daa-9c29-42a4-a74b-b9893e6d9750",
       memberType: "#microsoft.graph.group",
+      displayName: "HAS",
     };
 
     expect(createGroupMemberRelationship(group, member)).toEqual(relationship);
@@ -180,11 +195,16 @@ describe("createGroupMemberRelationship", () => {
       jobTitle: null,
     };
 
-    const relationship: GroupMemberRelationship = {
+    const relationship: MappedRelationshipFromIntegration & {
+      groupId: string;
+      memberId: string;
+      memberType: string;
+    } = {
       _class: "HAS",
       _key:
         "azure_user_group_89fac263-2430-48fd-9278-dacfdfc89792_azure_group_member_324e8daa-9c29-42a4-a74b-b9893e6d9750",
       _type: "azure_group_has_member",
+      _scope: "azure_group_has_member",
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         sourceEntityKey:
@@ -202,6 +222,7 @@ describe("createGroupMemberRelationship", () => {
       groupId: "89fac263-2430-48fd-9278-dacfdfc89792",
       memberId: "324e8daa-9c29-42a4-a74b-b9893e6d9750",
       memberType: "#microsoft.graph.directoryObject",
+      displayName: "HAS",
     };
 
     expect(createGroupMemberRelationship(group, member)).toEqual(relationship);
@@ -220,10 +241,11 @@ describe("createVirtualNetworkSubnetRelationship", () => {
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev",
     };
 
-    const relationship = {
+    const relationship: RelationshipFromIntegration = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_contains_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev",
       _type: "azure_vnet_contains_subnet",
+      _scope: "azure_vnet_contains_azure_subnet",
       _class: "CONTAINS",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev",
@@ -250,10 +272,11 @@ describe("createSecurityGroupSubnetRelationship", () => {
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev",
     };
 
-    const relationship = {
+    const relationship: RelationshipFromIntegration = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev_protects_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev",
       _type: "azure_security_group_protects_subnet",
+      _scope: "azure_security_group_protects_azure_subnet",
       _class: "PROTECTS",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev",
@@ -280,10 +303,11 @@ describe("createNetworkSecurityGroupNicRelationship", () => {
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev",
     };
 
-    const relationship = {
+    const relationship: RelationshipFromIntegration = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev_protects_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev",
       _type: "azure_security_group_protects_nic",
+      _scope: "azure_security_group_protects_azure_nic",
       _class: "PROTECTS",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev",
@@ -312,10 +336,11 @@ describe("createVirtualMachinePublicIPAddressRelationship", () => {
       location: "eastus",
     };
 
-    const relationship = {
+    const relationship: RelationshipFromIntegration = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_has_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev",
       _type: "azure_subnet_has_vm",
+      _scope: "azure_subnet_has_azure_vm",
       _class: "HAS",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev",
@@ -344,10 +369,11 @@ describe("createVirtualMachinePublicIPAddressRelationship", () => {
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev",
     };
 
-    const relationship: VirtualMachinePublicIPAddressRelationship = {
+    const relationship: RelationshipFromIntegration & { vmId: string } = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev_uses_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev",
       _type: "azure_vm_uses_public_ip",
+      _scope: "azure_vm_uses_azure_public_ip",
       _class: "USES",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev",
@@ -377,10 +403,11 @@ describe("createVirtualMachineNetworkInterfaceRelationship", () => {
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev",
     };
 
-    const relationship: VirtualMachineNetworkInterfaceRelationship = {
+    const relationship: RelationshipFromIntegration & { vmId: string } = {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev_uses_/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev",
       _type: "azure_vm_uses_network_interface",
+      _scope: "azure_vm_uses_azure_nic",
       _class: "USES",
       _fromEntityKey:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev",

--- a/src/converters/resources.test.ts
+++ b/src/converters/resources.test.ts
@@ -85,6 +85,7 @@ describe("createNetworkInterfaceEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev",
       _type: "azure_nic",
+      _scope: "azure_nic",
       _class: "NetworkInterface",
       _rawData: [{ name: "default", rawData: data }],
       resourceGuid: "ab964820-ee40-4f8d-bfd9-0349b8b4f316",
@@ -146,6 +147,7 @@ describe("createPublicIPAddressEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev",
       _type: "azure_public_ip",
+      _scope: "azure_public_ip",
       _class: "IpAddress",
       _rawData: [{ name: "default", rawData: data }],
       resourceGuid: "d908c31d-c93a-4359-987f-8cfdd1b65a61",
@@ -247,6 +249,7 @@ describe("createVirtualMachineEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev",
       _type: "azure_vm",
+      _scope: "azure_vm",
       _class: "Host",
       _rawData: [{ name: "default", rawData: data }],
       displayName: "j1dev",
@@ -441,6 +444,7 @@ describe("createNetworkSecurityGroupEntity", () => {
     _key:
       "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev",
     _type: "azure_security_group",
+    _scope: "azure_security_group",
     _class: ["Firewall"],
     _rawData: [{ name: "default", rawData: data }],
     name: "j1dev",
@@ -524,6 +528,7 @@ describe("createVirtualNetworkEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev",
       _type: "azure_vnet",
+      _scope: "azure_vnet",
       _class: ["Network"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",
@@ -593,6 +598,7 @@ describe("createSubnetEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev",
       _type: "azure_subnet",
+      _scope: "azure_subnet",
       _class: ["Network"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",

--- a/src/converters/resources.ts
+++ b/src/converters/resources.ts
@@ -44,6 +44,7 @@ export function createNetworkInterfaceEntity(
   const entity: NetworkInterfaceEntity = {
     _key: data.id as string,
     _type: NETWORK_INTERFACE_ENTITY_TYPE,
+    _scope: NETWORK_INTERFACE_ENTITY_TYPE,
     _class: NETWORK_INTERFACE_ENTITY_CLASS,
     _rawData: [{ name: "default", rawData: data }],
     resourceGuid: data.resourceGuid,
@@ -74,6 +75,7 @@ export function createPublicIPAddressEntity(
   const entity = {
     _key: data.id as string,
     _type: PUBLIC_IP_ADDRESS_ENTITY_TYPE,
+    _scope: PUBLIC_IP_ADDRESS_ENTITY_TYPE,
     _class: PUBLIC_IP_ADDRESS_ENTITY_CLASS,
     _rawData: [{ name: "default", rawData: data }],
     resourceGuid: data.resourceGuid,
@@ -100,6 +102,7 @@ export function createVirtualMachineEntity(
   const entity = {
     _key: data.id as string,
     _type: VIRTUAL_MACHINE_ENTITY_TYPE,
+    _scope: VIRTUAL_MACHINE_ENTITY_TYPE,
     _class: VIRTUAL_MACHINE_ENTITY_CLASS,
     _rawData: [{ name: "default", rawData: data }],
     displayName: data.name,

--- a/src/converters/resources/storage.test.ts
+++ b/src/converters/resources/storage.test.ts
@@ -57,6 +57,7 @@ describe("createStorageAccountEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#blob",
       _type: "azure_storage_blob_service",
+      _scope: "azure_storage_blob_service",
       _class: ["Service"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",
@@ -81,6 +82,7 @@ describe("createStorageAccountEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#file",
       _type: "azure_storage_file_service",
+      _scope: "azure_storage_file_service",
       _class: ["Service"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",
@@ -105,6 +107,7 @@ describe("createStorageAccountEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#queue",
       _type: "azure_storage_queue_service",
+      _scope: "azure_storage_queue_service",
       _class: ["Service"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",
@@ -131,6 +134,7 @@ describe("createStorageAccountEntity", () => {
       _key:
         "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#table",
       _type: "azure_storage_table_service",
+      _scope: "azure_storage_table_service",
       _class: ["Service"],
       _rawData: [{ name: "default", rawData: data }],
       name: "j1dev",
@@ -172,6 +176,7 @@ describe("createStorageBlobContainerEntity", () => {
     _key:
       "/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/blobServices/default/containers/bootdiagnostics-j1dev-58e204bf-f42b-4fdf-ac34-37409045a752",
     _type: "azure_storage_container",
+    _scope: "azure_storage_container",
     _class: ["DataStore"],
     _rawData: [{ name: "default", rawData: data }],
     name: "bootdiagnostics-j1dev-58e204bf-f42b-4fdf-ac34-37409045a752",

--- a/src/jupiterone/relationships.ts
+++ b/src/jupiterone/relationships.ts
@@ -1,31 +1,11 @@
-import {
-  MappedRelationshipFromIntegration,
-  RelationshipFromIntegration,
-} from "@jupiterone/jupiter-managed-integration-sdk";
-
 export const ACCOUNT_GROUP_RELATIONSHIP_TYPE = "azure_account_has_group";
 export const ACCOUNT_GROUP_RELATIONSHIP_CLASS = "HAS";
-
-export interface AccountGroupRelationship extends RelationshipFromIntegration {
-  id?: number;
-}
 
 export const ACCOUNT_USER_RELATIONSHIP_TYPE = "azure_account_has_user";
 export const ACCOUNT_USER_RELATIONSHIP_CLASS = "HAS";
 
-export interface AccountUserRelationship extends RelationshipFromIntegration {
-  id?: number;
-}
-
 export const GROUP_MEMBER_RELATIONSHIP_TYPE = "azure_group_has_member";
 export const GROUP_MEMBER_RELATIONSHIP_CLASS = "HAS";
-
-export interface GroupMemberRelationship
-  extends MappedRelationshipFromIntegration {
-  groupId: string;
-  memberId: string;
-  memberType: string;
-}
 
 export const SECURITY_GROUP_NIC_RELATIONSHIP_TYPE =
   "azure_security_group_protects_nic";
@@ -46,16 +26,6 @@ export const VIRTUAL_MACHINE_NIC_RELATIONSHIP_TYPE =
   "azure_vm_uses_network_interface";
 export const VIRTUAL_MACHINE_NIC_RELATIONSHIP_CLASS = "USES";
 
-export interface VirtualMachineNetworkInterfaceRelationship
-  extends RelationshipFromIntegration {
-  vmId: string;
-}
-
 export const VIRTUAL_MACHINE_PUBLIC_IP_ADDRESS_RELATIONSHIP_TYPE =
   "azure_vm_uses_public_ip";
 export const VIRTUAL_MACHINE_PUBLIC_IP_ADDRESS_RELATIONSHIP_CLASS = "USES";
-
-export interface VirtualMachinePublicIPAddressRelationship
-  extends RelationshipFromIntegration {
-  vmId: string;
-}

--- a/src/synchronizers/synchronizeGroupMembers.ts
+++ b/src/synchronizers/synchronizeGroupMembers.ts
@@ -2,16 +2,14 @@ import {
   IntegrationCacheEntry,
   IntegrationError,
   IntegrationExecutionResult,
+  IntegrationRelationship,
   PersisterOperationsResult,
   summarizePersisterOperationsResults,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 
 import { Group, GroupMember } from "../azure";
 import { createGroupMemberRelationship } from "../converters";
-import {
-  GROUP_MEMBER_RELATIONSHIP_TYPE,
-  GroupMemberRelationship,
-} from "../jupiterone";
+import { GROUP_MEMBER_RELATIONSHIP_TYPE } from "../jupiterone";
 import { AzureExecutionContext, GroupsCacheState } from "../types";
 
 export default async function synchronizeGroupMembers(
@@ -31,9 +29,9 @@ export default async function synchronizeGroupMembers(
 
   const operationResults: PersisterOperationsResult[] = [];
 
-  await groupsCache.forEach(async (e, i, t) => {
-    const newGroupRelationships: GroupMemberRelationship[] = [];
-    const group: Group = e.data;
+  await groupsCache.forEach(async e => {
+    const newGroupRelationships: IntegrationRelationship[] = [];
+    const group: Group = e.entry.data;
     if (group.members) {
       for (const member of group.members as GroupMember[]) {
         newGroupRelationships.push(

--- a/src/synchronizers/synchronizeGroups.ts
+++ b/src/synchronizers/synchronizeGroups.ts
@@ -4,6 +4,7 @@ import {
   IntegrationExecutionResult,
   PersisterOperationsResult,
   summarizePersisterOperationsResults,
+  IntegrationRelationship,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 
 import {
@@ -13,7 +14,6 @@ import {
 import {
   ACCOUNT_GROUP_RELATIONSHIP_TYPE,
   AccountEntity,
-  AccountGroupRelationship,
   GROUP_ENTITY_TYPE,
   GroupEntity,
 } from "../jupiterone";
@@ -43,12 +43,12 @@ export default async function synchronizeGroups(
   }
 
   const newGroupEntities: GroupEntity[] = [];
-  const newGroupRelationships: AccountGroupRelationship[] = [];
+  const newGroupRelationships: IntegrationRelationship[] = [];
 
-  await groupsCache.forEach((e, i, t) => {
-    newGroupEntities.push(createGroupEntity(e.data));
+  await groupsCache.forEach(e => {
+    newGroupEntities.push(createGroupEntity(e.entry.data));
     newGroupRelationships.push(
-      createAccountGroupRelationship(accountEntity, e.data),
+      createAccountGroupRelationship(accountEntity, e.entry.data),
     );
   });
 
@@ -82,7 +82,7 @@ async function processGroups(
 
 async function processAccountGroups(
   executionContext: AzureExecutionContext,
-  newAccountGroupRelationships: AccountGroupRelationship[],
+  newAccountGroupRelationships: IntegrationRelationship[],
 ): Promise<PersisterOperationsResult> {
   const { graph, persister } = executionContext;
   const oldRelationships = await graph.findRelationshipsByType(

--- a/src/synchronizers/synchronizeStorageAccounts.ts
+++ b/src/synchronizers/synchronizeStorageAccounts.ts
@@ -73,11 +73,11 @@ async function synchronizeBlobStorage(
     "blob",
   );
 
-  const newAccountServiceRelationship = createIntegrationRelationship(
-    "HAS",
-    accountEntity,
-    newServiceEntity,
-  );
+  const newAccountServiceRelationship = createIntegrationRelationship({
+    _class: "HAS",
+    from: accountEntity,
+    to: newServiceEntity,
+  });
 
   const newContainerEntities: EntityFromIntegration[] = [];
   const newServiceContainerRelationships: IntegrationRelationship[] = [];
@@ -90,7 +90,11 @@ async function synchronizeBlobStorage(
     );
     newContainerEntities.push(containerEntity);
     newServiceContainerRelationships.push(
-      createIntegrationRelationship("HAS", newServiceEntity, containerEntity),
+      createIntegrationRelationship({
+        _class: "HAS",
+        from: newServiceEntity,
+        to: containerEntity,
+      }),
     );
   });
 

--- a/src/synchronizers/syncronizeComputeResources.ts
+++ b/src/synchronizers/syncronizeComputeResources.ts
@@ -13,8 +13,8 @@ import {
   IntegrationError,
   IntegrationExecutionResult,
   PersisterOperationsResult,
-  RelationshipFromIntegration,
   summarizePersisterOperationsResults,
+  IntegrationRelationship,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 
 import {
@@ -53,8 +53,6 @@ import {
   VIRTUAL_NETWORK_ENTITY_TYPE,
   VIRTUAL_NETWORK_SUBNET_RELATIONSHIP_TYPE,
   VirtualMachineEntity,
-  VirtualMachineNetworkInterfaceRelationship,
-  VirtualMachinePublicIPAddressRelationship,
 } from "../jupiterone";
 import { AzureExecutionContext } from "../types";
 
@@ -88,9 +86,9 @@ export default async function synchronizeComputeResources(
     fetchVirtualMachines(azrm, webLinker),
   ]);
 
-  const newSubnetVmRelationships: RelationshipFromIntegration[] = [];
-  const newVMNicRelationships: VirtualMachineNetworkInterfaceRelationship[] = [];
-  const newVMAddressRelationships: VirtualMachinePublicIPAddressRelationship[] = [];
+  const newSubnetVmRelationships: IntegrationRelationship[] = [];
+  const newVMNicRelationships: IntegrationRelationship[] = [];
+  const newVMAddressRelationships: IntegrationRelationship[] = [];
 
   forEach(newVms, vm => {
     const vmData = getRawData(vm) as VirtualMachine;
@@ -211,7 +209,7 @@ async function synchronizeNetworkResources(
   const subnetSecurityGroupMap: {
     [subnetId: string]: NetworkSecurityGroup;
   } = {};
-  const newSecurityGroupNicRelationships: RelationshipFromIntegration[] = [];
+  const newSecurityGroupNicRelationships: IntegrationRelationship[] = [];
 
   for (const sge of newSecurityGroups) {
     const sg = getRawData(sge) as NetworkSecurityGroup;
@@ -230,8 +228,8 @@ async function synchronizeNetworkResources(
   }
 
   const newSubnets: EntityFromIntegration[] = [];
-  const newVnetSubnetRelationships: RelationshipFromIntegration[] = [];
-  const newSecurityGroupSubnetRelationships: RelationshipFromIntegration[] = [];
+  const newVnetSubnetRelationships: IntegrationRelationship[] = [];
+  const newSecurityGroupSubnetRelationships: IntegrationRelationship[] = [];
 
   for (const vnetEntity of newVirtualNetworks) {
     const vnet = getRawData(vnetEntity) as VirtualNetwork;

--- a/src/synchronizers/syncronizeUsers.ts
+++ b/src/synchronizers/syncronizeUsers.ts
@@ -2,6 +2,7 @@ import {
   IntegrationCacheEntry,
   IntegrationError,
   IntegrationExecutionResult,
+  IntegrationRelationship,
   PersisterOperationsResult,
   summarizePersisterOperationsResults,
 } from "@jupiterone/jupiter-managed-integration-sdk";
@@ -10,7 +11,6 @@ import { createAccountUserRelationship, createUserEntity } from "../converters";
 import {
   ACCOUNT_USER_RELATIONSHIP_TYPE,
   AccountEntity,
-  AccountUserRelationship,
   USER_ENTITY_TYPE,
   UserEntity,
 } from "../jupiterone";
@@ -40,12 +40,12 @@ export default async function synchronizeUsers(
   }
 
   const newUserEntities: UserEntity[] = [];
-  const newUserRelationships: AccountUserRelationship[] = [];
+  const newUserRelationships: IntegrationRelationship[] = [];
 
-  await usersCache.forEach((e, i, t) => {
-    newUserEntities.push(createUserEntity(e.data));
+  await usersCache.forEach(e => {
+    newUserEntities.push(createUserEntity(e.entry.data));
     newUserRelationships.push(
-      createAccountUserRelationship(accountEntity, e.data),
+      createAccountUserRelationship(accountEntity, e.entry.data),
     );
   });
 
@@ -79,7 +79,7 @@ async function processUsers(
 
 async function processAccountUsers(
   executionContext: AzureExecutionContext,
-  newAccountUserRelationships: AccountUserRelationship[],
+  newAccountUserRelationships: IntegrationRelationship[],
 ): Promise<PersisterOperationsResult> {
   const { graph, persister } = executionContext;
   const oldRelationships = await graph.findRelationshipsByType(

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,10 +941,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@^30.1.1":
-  version "30.1.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-30.1.1.tgz#1103dcaf16bf54f4b6aaeb7bb2684b375e1a91d5"
-  integrity sha512-icHWgGcWl9mlQK8lk1FnPikeT/OJUUBEYSdbdXeD2YreTZgJONB3w0RaRYsxXaEzMlq2OH+3p5ryu5YHGLJEoQ==
+"@jupiterone/jupiter-managed-integration-sdk@^31.0.0":
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-31.0.0.tgz#a823fcebdf85e7044f8f04bcb55e06ff0a9cdaf1"
+  integrity sha512-ir8t6AW2NXam2R3ff/Ix/Rh0d7DgWUsQVKySiALAvb+YaE5HJ8gXXloV8w8K4qpZKDcs2gf+C37wIho57AWv+g==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,10 +941,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@^28.3.0":
-  version "28.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-28.3.0.tgz#2f0b1069086556845291131d56d2330b75b8fd18"
-  integrity sha512-b76ZiGaIrh9HtjUfm5lZUCd4hkXmt5FMPKK5BBn7M6L6/7sKTqV3U8PU0cod27i6jn3aEdrF2OfUIETqTvkcOQ==
+"@jupiterone/jupiter-managed-integration-sdk@^30.1.1":
+  version "30.1.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-30.1.1.tgz#1103dcaf16bf54f4b6aaeb7bb2684b375e1a91d5"
+  integrity sha512-icHWgGcWl9mlQK8lk1FnPikeT/OJUUBEYSdbdXeD2YreTZgJONB3w0RaRYsxXaEzMlq2OH+3p5ryu5YHGLJEoQ==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"
@@ -1183,9 +1183,9 @@
   integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
 
 "@types/node@^10.12.20":
-  version "10.14.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.18.tgz#b7d45fc950e6ffd7edc685e890d13aa7b8535dce"
-  integrity sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
+  version "10.17.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
+  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
 "@types/node@^8.0.47":
   version "8.10.54"


### PR DESCRIPTION
This updates to the soon-to-be-released latest SDK. Please note that there are less types in the integration, in places where the SDK `createIntegrationRelationship()` is now used. It is going to be important that converter tests exist/are written to ensure the evolving SDK changes do not break the expected output of integration converters. It may be that we could also write test helpers, but for now it seems really good to express the exact and complete expectation of what is delivered to J1. These tests obviate the need for creating a TypeScript type for everything generated by the integration.