### PR TITLE
Log request header keys

### DIFF
--- a/src/azure/resource-manager/BunyanLogPolicy.ts
+++ b/src/azure/resource-manager/BunyanLogPolicy.ts
@@ -43,6 +43,7 @@ export class BunyanLogPolicy extends BaseRequestPolicy {
         url: httpRequest.url,
         status: response.status,
         responseHeaders: response.headers.rawHeaders(),
+        requestHeaders: Object.keys(response.request.headers.rawHeaders()),
       };
 
       this.logger.info(logData, "Received response from Azure API");


### PR DESCRIPTION
We want to log header values so that we know which header we're sending
malformed, but we don't want to log header values that could be
sensitive. This is the first step towards reaching the first goal
without violating the second.