### PR TITLE
Update SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "^33.2.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-3.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/jest": "^24.0.0",
     "@types/lodash.foreach": "^4.5.6",
     "@types/lodash.map": "^4.6.13",
+    "@types/lodash.snakecase": "^4.1.6",
     "@types/nock": "^9.3.1",
     "@types/node": "^10.12.20",
     "@types/pollyjs__adapter-node-http": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-6.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-9.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-3.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-5.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-10.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "33.4.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-9.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-10.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/arm-sql": "^7.0.0",
     "@azure/arm-storage": "^11.0.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
-    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-5.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "34.0.1-275-6.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "lodash.foreach": "^4.5.0",

--- a/src/converters/securityGroups.ts
+++ b/src/converters/securityGroups.ts
@@ -1,4 +1,4 @@
-import snakeCase from "lodash.snakeCase";
+import snakeCase from "lodash.snakecase";
 
 import {
   SecurityRule,

--- a/src/converters/securityGroups.ts
+++ b/src/converters/securityGroups.ts
@@ -1,4 +1,4 @@
-import snakeCase from "lodash/snakeCase";
+import snakeCase from "lodash.snakeCase";
 
 import {
   SecurityRule,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.snakecase@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.snakecase/-/lodash.snakecase-4.1.6.tgz#85f2b68f67b36c39875f26484b3a78b158ebf060"
+  integrity sha512-qGTf27ncTRUhSwvxD0hzYFmelmTrzEBGvBigrLyx6PRN1rKuy0ZEK+A3X3QnW7k+CwEjIJeAM6XBN4Ay6F03IQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-5.0":
-  version "34.0.1-275-5.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-5.0.tgz#b0fecc0acb6154ca0e5899a8e74163522c5d3dda"
-  integrity sha512-aY0Aj/Ghe6Yjg+dZYAuYshQMUfECtilY5UKpcmSXs3X1mtPnWG2OP+K1fI/l63E58Ic4DSA8wDLsgyw91b8xkQ==
+"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-6.0":
+  version "34.0.1-275-6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-6.0.tgz#67a3f47af6eac307f88088856a27e3f91d00ddac"
+  integrity sha512-SFfC64+nzo2WPySgm9cjTNvtivmsWXpA8UmixhSYqYv2SRgUmPq84Accu0a5GPBGyLwHy5R1HOtk8g7QkSBxUA==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-3.0":
-  version "34.0.1-275-3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-3.0.tgz#e34ec364b0f661a7f83eb1b7c102dbec919f2e92"
-  integrity sha512-h1BpsJmxElGm9o3C6k8KQ3aDmstNSDbC1/BS7DlXm/rwEErFfggh36Bq7vF13QeDu2TLQarf/Rob+hTWrTEOAg==
+"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-5.0":
+  version "34.0.1-275-5.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-5.0.tgz#b0fecc0acb6154ca0e5899a8e74163522c5d3dda"
+  integrity sha512-aY0Aj/Ghe6Yjg+dZYAuYshQMUfECtilY5UKpcmSXs3X1mtPnWG2OP+K1fI/l63E58Ic4DSA8wDLsgyw91b8xkQ==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@^33.2.0":
-  version "33.2.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-33.2.0.tgz#f58ee02c697c2851f4da2031baf7258f675c1641"
-  integrity sha512-9ds70+r50Qy951VCzgM8TDLH3LcV+9BUtzUlGB7Lf0kgs3p5lSCSjKLt2fZpD3iGVMm9wEFTuPqUlZ6BHdb8SA==
+"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-3.0":
+  version "34.0.1-275-3.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-3.0.tgz#e34ec364b0f661a7f83eb1b7c102dbec919f2e92"
+  integrity sha512-h1BpsJmxElGm9o3C6k8KQ3aDmstNSDbC1/BS7DlXm/rwEErFfggh36Bq7vF13QeDu2TLQarf/Rob+hTWrTEOAg==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-9.0":
-  version "34.0.1-275-9.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-9.0.tgz#f462d8146af1b79c7c5f988b3ea36d55c17a11dc"
-  integrity sha512-9fPcYvvUngrcTV0wd5XctZPXsXiu1QYHPh5VeEeFO/tmwKZyDtcduD3CZL+T+i6bQ+dFldpdvGX61WXZCh6Lvg==
+"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-10.0":
+  version "34.0.1-275-10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-10.0.tgz#0dc8b897315fa1345965ffe7874c058d0285ed07"
+  integrity sha512-NKxsjBDWxnoE9FhNKxDhA1lwIPzt8pZMsl7nXdXa7lOJc05Mu0VtjBB/HgD5RkL8PmlwJeuTfgmEPPuDE2K+EQ==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-6.0":
-  version "34.0.1-275-6.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-6.0.tgz#67a3f47af6eac307f88088856a27e3f91d00ddac"
-  integrity sha512-SFfC64+nzo2WPySgm9cjTNvtivmsWXpA8UmixhSYqYv2SRgUmPq84Accu0a5GPBGyLwHy5R1HOtk8g7QkSBxUA==
+"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-9.0":
+  version "34.0.1-275-9.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-9.0.tgz#f462d8146af1b79c7c5f988b3ea36d55c17a11dc"
+  integrity sha512-9fPcYvvUngrcTV0wd5XctZPXsXiu1QYHPh5VeEeFO/tmwKZyDtcduD3CZL+T+i6bQ+dFldpdvGX61WXZCh6Lvg==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jupiterone/jupiter-managed-integration-sdk@34.0.1-275-10.0":
-  version "34.0.1-275-10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-34.0.1-275-10.0.tgz#0dc8b897315fa1345965ffe7874c058d0285ed07"
-  integrity sha512-NKxsjBDWxnoE9FhNKxDhA1lwIPzt8pZMsl7nXdXa7lOJc05Mu0VtjBB/HgD5RkL8PmlwJeuTfgmEPPuDE2K+EQ==
+"@jupiterone/jupiter-managed-integration-sdk@33.4.0":
+  version "33.4.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-33.4.0.tgz#856e718e2f1d1305dd38ab96f09288c63cda2143"
+  integrity sha512-V4lUIPEF4S48ZdQQuhKz1MG0+GgPvN4feSbUU8RVixZsREtuQVuNHa0BIS7lDZ/M8c2kMQnlR3BrmYoEN7nkpg==
 
 "@microsoft/microsoft-graph-client@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
The SDK can be upgraded to this version without upgrading the deployment tools; this version is required in order to upgrade the deployment tools to 6.0.0.