### PR TITLE
Provide optional limits on Terraformed resources

### DIFF
--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -10,10 +10,10 @@ resource "azurerm_virtual_network" "j1dev" {
 }
 
 resource "azurerm_subnet" "j1dev" {
-  name                      = "j1dev"
-  resource_group_name       = azurerm_resource_group.j1dev.name
-  virtual_network_name      = azurerm_virtual_network.j1dev.name
-  address_prefix            = "10.0.2.0/24"
+  name                 = "j1dev"
+  resource_group_name  = azurerm_resource_group.j1dev.name
+  virtual_network_name = azurerm_virtual_network.j1dev.name
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_subnet_network_security_group_association" "j1dev" {
@@ -22,10 +22,10 @@ resource "azurerm_subnet_network_security_group_association" "j1dev" {
 }
 
 resource "azurerm_public_ip" "j1dev" {
-  name                         = "j1dev"
-  location                     = "eastus"
-  resource_group_name          = azurerm_resource_group.j1dev.name
-  allocation_method            = "Dynamic"
+  name                = "j1dev"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.j1dev.name
+  allocation_method   = "Dynamic"
 
   tags = {
     environment = "${local.j1env}"
@@ -38,15 +38,15 @@ resource "azurerm_network_security_group" "j1dev" {
   resource_group_name = azurerm_resource_group.j1dev.name
 
   security_rule {
-      name                       = "SSH"
-      priority                   = 1001
-      direction                  = "Inbound"
-      access                     = "Allow"
-      protocol                   = "Tcp"
-      source_port_range          = "*"
-      destination_port_range     = "22"
-      source_address_prefix      = "*"
-      destination_address_prefix = "*"
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
   }
 
   tags = {
@@ -77,6 +77,8 @@ resource "azurerm_network_interface_security_group_association" "j1dev" {
 }
 
 resource "azurerm_virtual_machine" "j1dev" {
+  count = var.azurerm_compute_virtual_machines
+
   name                  = "j1dev"
   location              = "eastus"
   resource_group_name   = azurerm_resource_group.j1dev.name

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,9 +1,9 @@
 resource "azurerm_storage_account" "j1dev" {
-  name                = "j1dev"
-  resource_group_name = azurerm_resource_group.j1dev.name
-  location            = "eastus"
+  name                     = "j1dev"
+  resource_group_name      = azurerm_resource_group.j1dev.name
+  location                 = "eastus"
   account_replication_type = "LRS"
-  account_tier = "Standard"
+  account_tier             = "Standard"
 
   tags = {
     environment = "${local.j1env}"
@@ -11,11 +11,13 @@ resource "azurerm_storage_account" "j1dev" {
 }
 
 resource "azurerm_storage_container" "j1dev" {
-  name = "j1dev"
+  name                 = "j1dev"
   storage_account_name = azurerm_storage_account.j1dev.name
 }
 
 resource "azurerm_sql_server" "j1dev" {
+  count = var.azurerm_storage_sql_servers
+
   name                         = "j1dev-sqlserver"
   resource_group_name          = azurerm_resource_group.j1dev.name
   location                     = "eastus"
@@ -29,10 +31,12 @@ resource "azurerm_sql_server" "j1dev" {
 }
 
 resource "azurerm_sql_database" "j1dev" {
+  count = var.azurerm_storage_sql_databases
+
   name                = "j1dev-sqldatabase"
   resource_group_name = azurerm_resource_group.j1dev.name
   location            = "eastus"
-  server_name         = azurerm_sql_server.j1dev.name
+  server_name         = azurerm_sql_server.j1dev[count.index].name
 
   tags = {
     environment = "${local.j1env}"
@@ -40,6 +44,8 @@ resource "azurerm_sql_database" "j1dev" {
 }
 
 resource "azurerm_mysql_server" "j1dev" {
+  count = var.azurerm_storage_mysql_servers
+
   name                = "j1dev-mysqlserver"
   location            = azurerm_resource_group.j1dev.location
   resource_group_name = azurerm_resource_group.j1dev.name
@@ -63,9 +69,11 @@ resource "azurerm_mysql_server" "j1dev" {
 }
 
 resource "azurerm_mysql_database" "j1dev" {
+  count = var.azurerm_storage_mysql_databases
+
   name                = "j1dev-mysqldb"
   resource_group_name = azurerm_resource_group.j1dev.name
-  server_name         = azurerm_mysql_server.j1dev.name
+  server_name         = azurerm_mysql_server.j1dev[count.index].name
   charset             = "utf8"
   collation           = "utf8_unicode_ci"
 
@@ -76,12 +84,12 @@ resource "azurerm_mysql_database" "j1dev" {
 }
 
 resource "random_string" "administrator_login" {
-  length = 13
-  special = true
+  length           = 13
+  special          = true
   override_special = "_"
 }
 
 resource "random_password" "administrator_password" {
-  length = 16
+  length  = 16
   special = true
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,0 +1,24 @@
+variable "azurerm_compute_virtual_machines" {
+  type    = number
+  default = 0
+}
+
+variable "azurerm_storage_sql_servers" {
+  type    = number
+  default = 0
+}
+
+variable "azurerm_storage_sql_databases" {
+  type    = number
+  default = 0
+}
+
+variable "azurerm_storage_mysql_servers" {
+  type    = number
+  default = 0
+}
+
+variable "azurerm_storage_mysql_databases" {
+  type    = number
+  default = 0
+}


### PR DESCRIPTION
When not working on ingesting some resource or other, do not create them. The default is to create no expensive resources unless enabled.