### PR TITLE
Add dbsync logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 3.15.4 - 2020-05-06
+
+### Added
+
+- Logging in DB synchronization code, since there is so much going on in one
+  step, cannot see how far it gets before failing.
+
 ## 3.15.3 - 2020-05-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "3.15.3",
+  "version": "3.15.4",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
This step does not complete in some large accounts. There are logs only up to about 6 minutes in, and then silence until minute 15 when the Lambda times out.