### PR TITLE
Avoid duplicate subnet -> vm relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Duplicate subnet -> vm relationships would cause the step to crash.
+
+## 4.0.0 - 2020-06-30
+
 This release is a complete restructuring of the program to move to the new
 JupiterOne integration SDK. Benefits are numerous, including:
 


### PR DESCRIPTION
@ndowmon here is an example of how it can be expensive to add tests for this change because I'd need to work through the details of getting multiple nics and/or multiple ip configurations on a single nic to prove this out. I think it will be worth having that eventually, but there are currently no tests at all for this particular step.