### PR TITLE
Fix duplicate load balancer -> nic relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Duplicate load balancer -> nic relationships would cause the step to crash.
+
+## 4.0.0 - 2020-06-30
+
 This release is a complete restructuring of the program to move to the new
 JupiterOne integration SDK. Benefits are numerous, including:
 


### PR DESCRIPTION
Another duplicate relationship preventing a step from completing. This is a great feature of the SDK 😄 

```
Error: Duplicate _key detected (_key=/subscriptions/abc/resourceGroups/thegroup/providers/Microsoft.Network/loadBalancers/kubernetes|connects|/subscriptions/abc/resourceGroups/thegroup/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-123-vmss/virtualMachines/0/networkInterfaces/aks-agentpool-123-vmss)
at DuplicateKeyTracker.registerKey (/opt/lifeomic/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/execution/jobState.js:11:19)
at /opt/lifeomic/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/execution/jobState.js:52:33
at Array.forEach (<anonymous>)
at Object.addRelationships (/opt/lifeomic/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/execution/jobState.js:50:23)
at /opt/lifeomic/app/node_modules/@jupiterone/graph-azure/dist/steps/resource-manager/network/index.js:88:28
at processTicksAndRejections (internal/process/task_queues.js:93:5)
at async Object.iterateAllResources (/opt/lifeomic/app/node_modules/@jupiterone/graph-azure/dist/azure/resource-manager/client.js:188:17)
at async Object.fetchLoadBalancers [as executionHandler] (/opt/lifeomic/app/node_modules/@jupiterone/graph-azure/dist/steps/resource-manager/network/index.js:84:5)
at async executeStep (/opt/lifeomic/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/execution/dependencyGraph.js:199:17)
at async Object.timeOperation (/opt/lifeomic/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/metrics/index.js:6:12)
```