### PR TITLE
Prefix globally unique tf resources with `developer_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Security group rules step had wrong step function assigned, duplicated load
   balancer ingestion.
+- Prefix globally unique terraform resources using `developer_id` environment
+  variable.
 
 ## 4.0.1 - 2020-07-14
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,12 @@ ARM_TENANT_ID=your_tenant_id
 
 # Not needed for public, required for usgovernment, german, china
 ARM_ENVIRONMENT=public
+
+# developer_id is used to prefix azure resources that are globally unique.
+# requirements:
+#  - l/t or equal to 8 characters
+#  - ONLY lowercase letters or numbers
+TF_VAR_developer_id=ndowmon1
 ```
 
 ## Terraforming for Development

--- a/terraform/cosmosdb.tf
+++ b/terraform/cosmosdb.tf
@@ -1,5 +1,5 @@
 resource "azurerm_cosmosdb_account" "j1dev" {
-  name                = "j1dev"
+  name                = "${var.developer_id}-j1dev"
   location            = azurerm_resource_group.j1dev.location
   resource_group_name = azurerm_resource_group.j1dev.name
   offer_type          = "Standard"

--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "j1dev" {
-  name                        = "j1dev"
+  name                        = "${var.developer_id}-j1dev"
   location                    = azurerm_resource_group.j1dev.location
   resource_group_name         = azurerm_resource_group.j1dev.name
   enabled_for_disk_encryption = true

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "j1dev" {
-  name                     = "j1dev"
+  name                     = "${var.developer_id}j1dev"
   resource_group_name      = azurerm_resource_group.j1dev.name
   location                 = "eastus"
   account_replication_type = "LRS"
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "j1dev" {
 }
 
 resource "azurerm_storage_account" "j1dev_blobstorage" {
-  name                     = "j1devblobstorage"
+  name                     = "${var.developer_id}j1devblobstorage"
   resource_group_name      = azurerm_resource_group.j1dev.name
   location                 = "eastus"
   account_replication_type = "LRS"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -27,3 +27,8 @@ variable "azurerm_storage_mysql_databases" {
   type    = number
   default = 0
 }
+
+variable "developer_id" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
This PR enables developers to deploy `azurerm_storage_account`, `azurerm_cosmosdb_account`, and `azurerm_key_vault` resources with globally unique names. This enables multiple developers to deploy terraform at the same time with conflicting names.