### PR TITLE
Hard-code test integration instance config

### DIFF
--- a/test/integrationInstanceConfig.ts
+++ b/test/integrationInstanceConfig.ts
@@ -1,12 +1,12 @@
 import { IntegrationConfig } from '../src/types';
 
+// TODO use polly matching to find/replace configuration variables in files
+// in order to allow multiple devs to generate recordings & test files.
 const config: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',
   clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
-  directoryId:
-    process.env.DIRECTORY_ID || 'a76fc728-0cba-45f0-a9eb-d45207e14513',
-  subscriptionId:
-    process.env.SUBSCRIPTION_ID || 'dccea45f-7035-4a17-8731-1fd46aaa74a0',
+  directoryId: 'a76fc728-0cba-45f0-a9eb-d45207e14513',
+  subscriptionId: 'dccea45f-7035-4a17-8731-1fd46aaa74a0',
 };
 
 export default config;


### PR DESCRIPTION
Using environment variables in `/test/integrationInstanceConfig` causes polly to re-record certain API requests that contain configuration variables (such as `subscriptionId`). For now, hard-coding the `directoryId` and `subscriptionId` that are already in the polly recordings allows other developers to come in and pass tests locally.

A longer-term solution involves getting creative with polly matchers.