### PR TITLE
Add yarn tf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You may use use Node to execute directly on your machine.
 
 Prerequisites:
 
-1.  Install Docker and Docker Compose (both included in Docker for Mac installs)
+1.  Install terraform and tfenv (see [Development](development.md))
 1.  Provide credentials in `.env` (see
     [Environment Variable](#environment-variables))
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,18 +164,14 @@ env `grep -v '^#' .env` terraform init
 env `grep -v '^#' .env` terraform plan
 ```
 
-### Using Docker
-
-You may prefer to use the [Terraform Docker Container][3] to run Terraform.
-
-Initialize Terraform:
+Developers can use the `tf` script in `package.json` to execute terraform
+commands in the project.
 
 ```sh
-docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light init
-```
-
-```sh
-docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light plan
+yarn tf init
+yarn tf plan
+yarn tf apply
+yarn tf destroy
 ```
 
 ## Execute the Integration
@@ -210,7 +206,6 @@ collection][4].
 [1]:
   https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest
 [2]: https://docs.microsoft.com/en-us/cli/azure/
-[3]: https://hub.docker.com/r/hashicorp/terraform/
 [4]: https://docs.microsoft.com/en-us/graph/use-postman?view=graph-rest-1.0
 [5]: https://docs.microsoft.com/en-us/graph/auth-v2-service
 [6]:

--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "prepush": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration",
     "prepack": "yarn build",
-    "tf:init": "docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light init",
-    "tf:plan": "docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light plan",
-    "tf:apply": "docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light apply",
-    "tf:destroy": "docker run --env-file terraform/.env -i -t -v `pwd`/terraform:/azure -w /azure hashicorp/terraform:light destroy"
+    "tf": "cd terraform && env `grep -v '^#' .env` terraform $1"
   },
   "dependencies": {
     "@azure/arm-compute": "^14.0.0",


### PR DESCRIPTION
Use `tfenv` deployment strategy as the only suggested deployment option. Usage: 

```sh
yarn tf init
yarn tf plan
yarn tf apply
yarn tf destroy
```

Remove references to using docker to deploy.