### PR TITLE
Add classic administrators

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -95,6 +95,7 @@ though the `Account` entity will always be ingested.
 |                      | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
 | Role Definition      | `azure_role_definition`       | `AccessRole`, `AccessPolicy`    |
 | Service Principal    | `azure_service_principal`     | `Service`                       |
+| Classic Admin        | `azure_classic_admin_group`   | `UserGroup`                     |
 
 ## Relationships
 
@@ -134,6 +135,7 @@ The following relationships are created/mapped:
 | `azure_role_definition`      | **ASSIGNED** | `azure_msi`                     |
 | `azure_role_definition`      | **ASSIGNED** | `azure_service_principal`       |
 | `azure_role_definition`      | **ASSIGNED** | `azure_unknown`                 |
+| `azure_classic_admin_group`  | **HAS**      | `azure_user`                    |
 
 [1]: https://docs.microsoft.com/en-us/graph/auth-v2-service
 [2]:

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -35,7 +35,10 @@ import {
 } from './steps/resource-manager/network';
 import { STEP_RM_STORAGE_RESOURCES } from './steps/resource-manager/storage';
 import { IntegrationConfig } from './types';
-import { STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS } from './steps/resource-manager/authorization';
+import {
+  STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS,
+  STEP_RM_CLASSIC_ADMINISTRATORS,
+} from './steps/resource-manager/authorization';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {
@@ -74,6 +77,7 @@ describe('getStepStartStates', () => {
       [STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS]: {
         disabled: true,
       },
+      [STEP_RM_CLASSIC_ADMINISTRATORS]: { disabled: true },
     });
   });
 
@@ -108,6 +112,7 @@ describe('getStepStartStates', () => {
       [STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS]: {
         disabled: true,
       },
+      [STEP_RM_CLASSIC_ADMINISTRATORS]: { disabled: true },
     });
   });
 
@@ -142,6 +147,7 @@ describe('getStepStartStates', () => {
       [STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS]: {
         disabled: false,
       },
+      [STEP_RM_CLASSIC_ADMINISTRATORS]: { disabled: false },
     });
   });
 });

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -10,7 +10,10 @@ import {
   STEP_AD_USERS,
   STEP_AD_SERVICE_PRINCIPALS,
 } from './steps/active-directory';
-import { STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS } from './steps/resource-manager/authorization';
+import {
+  STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS,
+  STEP_RM_CLASSIC_ADMINISTRATORS,
+} from './steps/resource-manager/authorization';
 import {
   STEP_RM_COMPUTE_VIRTUAL_MACHINE_DISKS,
   STEP_RM_COMPUTE_VIRTUAL_MACHINE_IMAGES,
@@ -70,5 +73,6 @@ export default function getStepStartStates(
     [STEP_RM_STORAGE_RESOURCES]: resourceManager,
     [STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS]: resourceManager,
     [STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS_AND_DEFINITIONS]: resourceManager,
+    [STEP_RM_CLASSIC_ADMINISTRATORS]: resourceManager,
   };
 }

--- a/src/steps/resource-manager/authorization/__recordings__/active-directory-step-classic-administrators_3012456868/recording.har
+++ b/src/steps/resource-manager/authorization/__recordings__/active-directory-step-classic-administrators_3012456868/recording.har
@@ -1,0 +1,504 @@
+{
+  "log": {
+    "_recordingName": "active-directory-step-classic-administrators",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "4f42b877-e04e-4a73-8185-e6e984e684d3"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1367,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1367,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1596562197\",\"not_before\":\"1596558297\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-09-03T16:29:57.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "client-request-id",
+              "value": "4f42b877-e04e-4a73-8185-e6e984e684d3"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7d28b269-7b6b-440c-b0e2-b399035b2900"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.10897.16 - EST ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 16:29:56 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1367"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T16:29:56.961Z",
+        "time": 332,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 332
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "98618a21-f874-4e75-b57e-64a1f0ca9427"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v13.11.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1594,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f53ceab2-bfad-4867-b31a-05e7f3c53a03"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f53ceab2-bfad-4867-b31a-05e7f3c53a03"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "NORTHCENTRALUS:20200804T162957Z:f53ceab2-bfad-4867-b31a-05e7f3c53a03"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 16:29:56 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T16:29:57.326Z",
+        "time": 412,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 412
+        }
+      },
+      {
+        "_id": "06c4ae8065f008441e9bd82dc8b7bdc3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9f9f178a-ac23-4fef-a4a7-1d1dc0c2e470"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-authorization/8.3.2 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v13.11.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1741,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators?api-version=2015-06-01"
+        },
+        "response": {
+          "bodySize": 761,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 761,
+            "text": "{\"value\":[{\"properties\":{\"emailAddress\":\"\",\"role\":\"ServiceAdministrator;AccountAdministrator\"},\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators/\",\"type\":\"Microsoft.Authorization/classicAdministrators\",\"name\":\"\"},{\"properties\":{\"emailAddress\":\"ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com\",\"role\":\"CoAdministrator\"},\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators/00030000D25AEAF7\",\"type\":\"Microsoft.Authorization/classicAdministrators\",\"name\":\"00030000D25AEAF7\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "northcentralus:dae60ff0-03b6-4ba7-86ea-5baaa80d3e3f"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5d13b76b-d69a-48e8-a380-361041f7d95a"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "NORTHCENTRALUS:20200804T162958Z:5d13b76b-d69a-48e8-a380-361041f7d95a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 16:29:58 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 633,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T16:29:57.750Z",
+        "time": 909,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 909
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/authorization/__recordings__/iterateClassicAdministrators_2362991753/recording.har
+++ b/src/steps/resource-manager/authorization/__recordings__/iterateClassicAdministrators_2362991753/recording.har
@@ -1,0 +1,504 @@
+{
+  "log": {
+    "_recordingName": "iterateClassicAdministrators",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "34534230-17b8-40ab-a09f-aec109d5ee7b"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1367,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1367,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1596554236\",\"not_before\":\"1596550336\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-09-03T14:17:16.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "client-request-id",
+              "value": "34534230-17b8-40ab-a09f-aec109d5ee7b"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7d28b269-7b6b-440c-b0e2-b399ed142200"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.10897.16 - EST ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 14:17:16 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1367"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T14:17:16.550Z",
+        "time": 320,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 320
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "62d97cba-3046-4779-95bb-39033874231c"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v13.11.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1594,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "ab81e9ee-9a60-48e8-bf8e-5ec13cfc4cef"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "ab81e9ee-9a60-48e8-bf8e-5ec13cfc4cef"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "NORTHCENTRALUS:20200804T141717Z:ab81e9ee-9a60-48e8-bf8e-5ec13cfc4cef"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 14:17:16 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T14:17:16.874Z",
+        "time": 442,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 442
+        }
+      },
+      {
+        "_id": "06c4ae8065f008441e9bd82dc8b7bdc3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3bcddc11-f268-4973-8f56-8618f1604bbf"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-authorization/8.3.2 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v13.11.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1741,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators?api-version=2015-06-01"
+        },
+        "response": {
+          "bodySize": 761,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 761,
+            "text": "{\"value\":[{\"properties\":{\"emailAddress\":\"\",\"role\":\"ServiceAdministrator;AccountAdministrator\"},\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators/\",\"type\":\"Microsoft.Authorization/classicAdministrators\",\"name\":\"\"},{\"properties\":{\"emailAddress\":\"ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com\",\"role\":\"CoAdministrator\"},\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators/00030000D25AEAF7\",\"type\":\"Microsoft.Authorization/classicAdministrators\",\"name\":\"00030000D25AEAF7\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "northcentralus:7369f610-67a1-4868-805b-c3de334da65b"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "b5ccfc8e-ed84-4b58-8884-03fa967420db"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "NORTHCENTRALUS:20200804T141717Z:b5ccfc8e-ed84-4b58-8884-03fa967420db"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 04 Aug 2020 14:17:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 633,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-04T14:17:17.323Z",
+        "time": 572,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 572
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/authorization/client.test.ts
+++ b/src/steps/resource-manager/authorization/client.test.ts
@@ -5,7 +5,10 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { AuthorizationClient } from './client';
-import { RoleAssignment } from '@azure/arm-authorization/esm/models';
+import {
+  RoleAssignment,
+  ClassicAdministrator,
+} from '@azure/arm-authorization/esm/models';
 import { IntegrationConfig } from '../../../types';
 
 // developer used different creds than ~/test/integrationInstanceConfig
@@ -22,7 +25,7 @@ afterEach(async () => {
   await recording.stop();
 });
 
-describe('iterateRoleDefinitions', () => {
+describe('getRoleDefinition', () => {
   test('CustomRole', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
@@ -95,5 +98,36 @@ describe('iterateRoleAssignments', () => {
         name: '10000000-0000-0000-0000-000000000000',
       }),
     );
+  });
+});
+
+describe('iterateClassicAdministrators', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iterateClassicAdministrators',
+    });
+
+    const client = new AuthorizationClient(
+      config,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const resources: ClassicAdministrator[] = [];
+    await client.iterateClassicAdministrators((e) => {
+      resources.push(e);
+    });
+
+    expect(resources).toEqual([
+      expect.objectContaining({
+        name: '',
+        role: 'ServiceAdministrator;AccountAdministrator',
+      }),
+      expect.objectContaining({
+        name: '00030000D25AEAF7',
+        role: 'CoAdministrator',
+      }),
+    ]);
   });
 });

--- a/src/steps/resource-manager/authorization/client.ts
+++ b/src/steps/resource-manager/authorization/client.ts
@@ -2,6 +2,7 @@ import { AuthorizationManagementClient } from '@azure/arm-authorization';
 import {
   RoleDefinition,
   RoleAssignment,
+  ClassicAdministrator,
 } from '@azure/arm-authorization/esm/models';
 import { Client } from '../../../azure/resource-manager/client';
 import { IntegrationProviderAPIError } from '@jupiterone/integration-sdk-core';
@@ -53,6 +54,32 @@ export class AuthorizationClient extends Client {
         throw new IntegrationProviderAPIError({
           cause: err,
           endpoint: 'authorization.roleAssignments',
+          status: err.statusCode,
+          statusText: err.statusText,
+        });
+      }
+    }
+  }
+
+  public async iterateClassicAdministrators(
+    callback: (ca: ClassicAdministrator) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      AuthorizationManagementClient,
+    );
+    try {
+      const items = await serviceClient.classicAdministrators.list();
+      for (const item of items) {
+        await callback(item);
+      }
+    } catch (err) {
+      /* istanbul ignore else */
+      if (err.statusCode === 404) {
+        this.logger.warn({ err }, 'Resources not found');
+      } else {
+        throw new IntegrationProviderAPIError({
+          cause: err,
+          endpoint: 'authorization.classicAdministrators',
           status: err.statusCode,
           statusText: err.statusText,
         });

--- a/src/steps/resource-manager/authorization/constants.ts
+++ b/src/steps/resource-manager/authorization/constants.ts
@@ -111,3 +111,13 @@ export const ROLE_ASSIGNMENT_RELATIONSHIP_TYPES = [
     createRoleAssignmentRelationshipType,
   ),
 ];
+
+// Fetch Classic Administrators
+export const STEP_RM_CLASSIC_ADMINISTRATORS =
+  'rm-authorization-classic-administrators';
+
+export const CLASSIC_ADMINISTRATOR_ENTITY_KEY = 'azure_classic_admin_group';
+export const CLASSIC_ADMINISTRATOR_ENTITY_TYPE = 'azure_classic_admin_group';
+export const CLASSIC_ADMINISTRATOR_RELATIONSHIP_TYPE =
+  'azure_classic_admin_group_has_user';
+export const CLASSIC_ADMINISTRATOR_ENTITY_CLASS = 'UserGroup';

--- a/src/steps/resource-manager/authorization/converters.test.ts
+++ b/src/steps/resource-manager/authorization/converters.test.ts
@@ -5,10 +5,13 @@ import {
   createRoleDefinitionEntity,
   createRoleAssignmentDirectRelationship,
   createRoleAssignmentMappedRelationship,
+  createClassicAdministratorEntity,
+  createClassicAdministratorHasUserRelationship,
 } from './converters';
 import {
   RoleDefinition,
   RoleAssignment,
+  ClassicAdministrator,
 } from '@azure/arm-authorization/esm/models';
 
 const webLinker = createAzureWebLinker('something.onmicrosoft.com');
@@ -173,6 +176,66 @@ describe('createRoleAssignmentMappedRelationship', () => {
       type: 'Microsoft.Authorization/roleAssignments',
       webLink:
         'https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/roleAssignments/c967042a-aad6-4e3b-8485-1c85d5e6f9e8',
+    });
+  });
+});
+
+describe('createClassicAdministratorEntity', () => {
+  test('classicAdministratorEntity created', () => {
+    expect(createClassicAdministratorEntity()).toEqual({
+      _key: 'azure_classic_admin_group',
+      _class: ['UserGroup'],
+      _rawData: [],
+      _type: 'azure_classic_admin_group',
+      createdOn: undefined,
+      displayName: 'Azure Classic Administrator',
+      name: 'Azure Classic Administrator',
+    });
+  });
+});
+
+describe('createClassicAdministratorHasUserRelationship', () => {
+  test('properties transferred', () => {
+    const classicAdministratorGroupEntity = createClassicAdministratorEntity();
+    const classicAdministrator: ClassicAdministrator = {
+      id:
+        '/subscriptions/subscription-id/providers/Microsoft.Authorization/classicAdministrators/id',
+      name: 'id',
+      type: 'Microsoft.Authorization/classicAdministrators',
+      emailAddress: 'user-principal-name',
+      role: 'CoAdministrator',
+    };
+
+    expect(
+      createClassicAdministratorHasUserRelationship({
+        webLinker,
+        classicAdministratorGroupEntity,
+        data: classicAdministrator,
+      }),
+    ).toEqual({
+      _class: 'HAS',
+      _key:
+        'azure_classic_admin_group|has|FORWARD:_type=azure_user:userPrincipalName=user-principal-name',
+      _type: 'azure_classic_admin_group_has_user',
+      _mapping: {
+        relationshipDirection: 'FORWARD',
+        sourceEntityKey: 'azure_classic_admin_group',
+        sourceEntityType: 'azure_classic_admin_group',
+        targetEntity: {
+          _type: 'azure_user',
+          userPrincipalName: 'user-principal-name',
+        },
+        targetFilterKeys: [['_type', 'userPrincipalName']],
+      },
+      displayName: 'HAS',
+      emailAddress: 'user-principal-name',
+      id:
+        '/subscriptions/subscription-id/providers/Microsoft.Authorization/classicAdministrators/id',
+      name: 'id',
+      role: 'CoAdministrator',
+      type: 'Microsoft.Authorization/classicAdministrators',
+      webLink:
+        'https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/subscription-id/providers/Microsoft.Authorization/classicAdministrators/id',
     });
   });
 });


### PR DESCRIPTION
From Microsoft ([reference](https://docs.microsoft.com/en-us/azure/role-based-access-control/classic-administrators)): 

> Microsoft recommends that you manage access to Azure resources using Azure role-based access control (Azure RBAC). However, if you are still using the classic deployment model, you'll need to use a classic subscription administrator role: Service Administrator and Co-Administrator.

This is useful to check who has classic administrator privileges or create rules to ensure there are no classic administrators.

I created a singleton `azure_classic_admin_group`, and relationships for `azure_classic_admin_group|HAS|<target_user>`. The relationships are mapped as opposed to direct, since the data returned from the `classicAdministrator` client has no user ID.

User:
```{
  businessPhones: [],
  displayName: 'Nick Dowmon',
  givenName: 'Nick',
  jobTitle: null,
  mail: null,
  mobilePhone: null,
  officeLocation: null,
  preferredLanguage: 'en',
  surname: 'Dowmon',
  userPrincipalName: 'ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com',
  id: 'b6e7f627-8731-47bd-be0e-477d1cbc6e17'
}
```

Classic Administrator:
```
{
  id: '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/classicAdministrators/00030000D25AEAF7',
  name: '00030000D25AEAF7',
  type: 'Microsoft.Authorization/classicAdministrators',
  emailAddress: 'ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com',
  role: 'CoAdministrator'
}
```