### PR TITLE
tag 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
 - Added `azure_role_definition` entities
 - Added `azure_role_definition|assigned|<type>` relationships
 - Added `azure_classic_admin_group` singleton entity
-- Added `azure_classic_admin_group|has|azure_user` relatinoships
+- Added `azure_classic_admin_group|has|azure_user` relationships
 - Added `azuer_service_principal` entities
 
 ### Fixed


### PR DESCRIPTION
The `v4.1.1` tags were not pushed to the previous PR. This commit has the tag.