### PR TITLE
typo & 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to
 - Added `azure_role_definition|assigned|<type>` relationships
 - Added `azure_classic_admin_group` singleton entity
 - Added `azure_classic_admin_group|has|azure_user` relationships
-- Added `azuer_service_principal` entities
+- Added `azure_service_principal` entities
 
 ### Fixed
 


### PR DESCRIPTION
This screenshot shows v4.1.1. as the commit with hash `90668b4`. Matches the single commit of this PR.

<img width="644" alt="Screen Shot 2020-08-18 at 4 42 14 PM" src="https://user-images.githubusercontent.com/15333061/90563454-d471c000-e171-11ea-9ff1-b07e736bab8f.png">
