### PR TITLE
Update classes on role assignments & definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Updated classes on `azure_role_assignment-->azure_role_definition`
+  relationship
+
 ## 4.2.0 - 2020-08-25
 
 ### Added

--- a/src/steps/resource-manager/authorization/constants.ts
+++ b/src/steps/resource-manager/authorization/constants.ts
@@ -15,7 +15,7 @@ export const STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS =
   'rm-authorization-role-assignments';
 
 export const ROLE_ASSIGNMENT_ENTITY_TYPE = 'azure_role_assignment';
-export const ROLE_ASSIGNMENT_ENTITY_CLASS = ['AccessRole'];
+export const ROLE_ASSIGNMENT_ENTITY_CLASS = ['AccessPolicy'];
 
 // Build Role Assignment to Principal Relationships
 export const STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENT_PRINCIPAL_RELATIONSHIPS =
@@ -126,9 +126,9 @@ export const STEP_RM_AUTHORIZATION_ROLE_DEFINITIONS =
   'rm-authorization-role-definitions';
 
 export const ROLE_DEFINITION_ENTITY_TYPE = 'azure_role_definition';
-export const ROLE_DEFINITION_ENTITY_CLASS = ['AccessPolicy'];
+export const ROLE_DEFINITION_ENTITY_CLASS = ['AccessRole'];
 
-export const ROLE_DEFINITION_RELATIONSHIP_CLASS = RelationshipClass.HAS;
+export const ROLE_DEFINITION_RELATIONSHIP_CLASS = RelationshipClass.USES;
 export const ROLE_DEFINITION_RELATIONSHIP_TYPE = generateRelationshipType(
   ROLE_DEFINITION_RELATIONSHIP_CLASS,
   ROLE_ASSIGNMENT_ENTITY_TYPE,

--- a/src/steps/resource-manager/authorization/converters.test.ts
+++ b/src/steps/resource-manager/authorization/converters.test.ts
@@ -47,7 +47,7 @@ describe('createRoleDefinitionEntity', () => {
       _key:
         '/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635',
       _type: 'azure_role_definition',
-      _class: ['AccessPolicy'],
+      _class: ['AccessRole'],
       _rawData: [{ name: 'default', rawData: data }],
       displayName: 'Owner',
       type: 'Microsoft.Authorization/roleDefinitions',
@@ -77,7 +77,7 @@ describe('createRoleAssignmentEntity', () => {
     };
 
     expect(createRoleAssignmentEntity(webLinker, data)).toEqual({
-      _class: ['AccessRole'],
+      _class: ['AccessPolicy'],
       _key:
         '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Authorization/roleAssignments/10000000-0000-0000-0000-000000000000',
       _rawData: [

--- a/src/steps/resource-manager/authorization/index.test.ts
+++ b/src/steps/resource-manager/authorization/index.test.ts
@@ -289,7 +289,7 @@ test('step - role assignments', async () => {
 
   expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
   expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
-    _class: 'AccessRole',
+    _class: 'AccessPolicy',
     schema: {
       additionalProperties: false,
       properties: {
@@ -438,7 +438,7 @@ test('step - role definitions', async () => {
 
   expect(context.jobState.collectedEntities.length).toBe(1);
   expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
-    _class: 'AccessPolicy',
+    _class: 'AccessRole',
     schema: {
       additionalProperties: false,
       properties: {
@@ -466,25 +466,25 @@ test('step - role definitions', async () => {
   expect(context.jobState.collectedRelationships).toEqual([
     {
       _key:
-        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c|has|/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-1',
-      _type: 'azure_role_definition_has_assignment',
-      _class: 'HAS',
-      _fromEntityKey:
-        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+        '/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-1|uses|/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+      _type: 'azure_role_assignment_uses_definition',
+      _class: 'USES',
       _toEntityKey:
+        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+      _fromEntityKey:
         '/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-1',
-      displayName: 'HAS',
+      displayName: 'USES',
     },
     {
       _key:
-        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c|has|/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-2',
-      _type: 'azure_role_definition_has_assignment',
-      _class: 'HAS',
-      _fromEntityKey:
-        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+        '/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-2|uses|/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+      _type: 'azure_role_assignment_uses_definition',
+      _class: 'USES',
       _toEntityKey:
+        '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
+      _fromEntityKey:
         '/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignments/role-assignment-id-2',
-      displayName: 'HAS',
+      displayName: 'USES',
     },
   ]);
 });

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -214,8 +214,8 @@ export async function fetchRoleDefinitions(
       await jobState.addRelationship(
         createDirectRelationship({
           _class: ROLE_DEFINITION_RELATIONSHIP_CLASS,
-          from: roleDefinitionEntity,
-          to: roleAssignmentEntity,
+          from: roleAssignmentEntity,
+          to: roleDefinitionEntity,
         }),
       );
     },


### PR DESCRIPTION
Changes based on slack conversation: https://jptrone.slack.com/archives/C0174AZA75J/p1598375320074200

**Previously**
`azure_role_definition[AccessPolicy]--HAS-->azure_role_assignment[AccessRole]`
note: the direction was a typo/switched (was supposed to have been `<--HAS--`)

**Now**
`azure_role_definition[AccessRole]<--USES--azure_role_assignment[AccessPolicy]`