### PR TITLE
V4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+### 4.2.1 - 2020-08-25
+
 ### Changed
 
 - Updated classes on `azure_role_assignment-->azure_role_definition`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
Cutting a new version for release so that `azure_role_definition[AccessRole]<--USES--azure_role_assignment[AccessPolicy]`