### PR TITLE
Add azure resource group to resource relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Added `azure_role_assignment|allows|<scope>` relationships
 - Added `azure_resource_group` entities
+- Added `azure_resource_group|has|<resource>` relationships
 
 ### Changed
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -78,6 +78,7 @@ The following entities are created:
 | [AD] Account                | `azure_account`               | `Account`                       |
 | [AD] Group                  | `azure_user_group`            | `UserGroup`                     |
 | [AD] Group Member           | `azure_group_member`          | `User`                          |
+| [RM] Resource Group         | `azure_resource_group`        | `Group`                         |
 | [RM] Image                  | `azure_image`                 | `Image`                         |
 | [RM] MariaDB Server         | `azure_mariadb_server`        | `Database`, `DataStore`, `Host` |
 | [RM] MariaDB Database       | `azure_mariadb_database`      | `Database`, `DataStore`         |
@@ -105,7 +106,6 @@ The following entities are created:
 | [RM] Key Vault              | `azure_keyvault_service`      | `Service`                       |
 | [RM] Cosmos DB Account      | `azure_cosmosdb_account`      | `Account`, `Service`            |
 | [RM] Cosmos DB Database     | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
-| [RM] Resource Group         | `azure_resource_group`        | `Group`                         |
 | [RM] Role Definition        | `azure_role_definition`       | `AccessRole`                    |
 | [RM] Classic Admin          | `azure_classic_admin_group`   | `UserGroup`                     |
 
@@ -119,20 +119,34 @@ The following relationships are created/mapped:
 | `azure_user_group`           | **HAS**               | `azure_user`                    |
 | `azure_user_group`           | **HAS**               | `azure_user_group`              |
 | `azure_user_group`           | **HAS**               | `azure_group_member`            |
+| `azure_resource_group`       | **HAS**               | `azure_image`                   |
 | `azure_mariadb_server`       | **HAS**               | `azure_mariadb_database`        |
+| `azure_resource_group`       | **HAS**               | `azure_mariadb_server`          |
 | `azure_mysql_server`         | **HAS**               | `azure_mysql_database`          |
+| `azure_resource_group`       | **HAS**               | `azure_mysql_server`            |
 | `azure_postgresql_server`    | **HAS**               | `azure_postgresql_database`     |
+| `azure_resource_group`       | **HAS**               | `azure_postgresql_server`       |
 | `azure_sql_server`           | **HAS**               | `azure_sql_database`            |
+| `azure_resource_group`       | **HAS**               | `azure_sql_server`              |
 | `azure_lb`                   | **CONNECTS**          | `azure_nic`                     |
+| `azure_resource_group`       | **HAS**               | `azure_lb`                      |
+| `azure_resource_group`       | **HAS**               | `azure_public_ip`               |
+| `azure_resource_group`       | **HAS**               | `azure_nic`                     |
 | `azure_security_group`       | **PROTECTS**          | `azure_nic`                     |
+| `azure_resource_group`       | **HAS**               | `azure_security_group`          |
 | `azure_vnet`                 | **CONTAINS**          | `azure_subnet`                  |
 | `azure_security_group`       | **PROTECTS**          | `azure_subnet`                  |
+| `azure_resource_group`       | **HAS**               | `azure_vnet`                    |
 | `azure_security_group`       | **ALLOWS**            | `azure_subnet`                  |
 | `azure_account`              | **HAS**               | `azure_storage_blob_service`    |
+| `azure_resource_group`       | **HAS**               | `azure_storage_blob_service`    |
 | `azure_storage_blob_service` | **HAS**               | `azure_storage_container`       |
 | `azure_account`              | **HAS**               | `azure_storage_file_service`    |
+| `azure_resource_group`       | **HAS**               | `azure_storage_file_service`    |
 | `azure_storage_file_service` | **HAS**               | `azure_storage_share`           |
+| `azure_resource_group`       | **HAS**               | `azure_managed_disk`            |
 | `azure_vm`                   | **USES**              | `azure_managed_disk`            |
+| `azure_resource_group`       | **HAS**               | `azure_vm`                      |
 | `azure_subnet`               | **HAS**               | `azure_vm`                      |
 | `azure_vm`                   | **USES**              | `azure_nic`                     |
 | `azure_vm`                   | **USES**              | `azure_public_ip`               |
@@ -149,7 +163,9 @@ The following relationships are created/mapped:
 | `azure_role_assignment`      | **ASSIGNED**          | `azure_unknown`                 |
 | `azure_role_assignment`      | **ASSIGNED**          | `azure_user`                    |
 | `azure_account`              | **HAS**               | `azure_keyvault_service`        |
+| `azure_resource_group`       | **HAS**               | `azure_keyvault_service`        |
 | `azure_cosmosdb_account`     | **HAS**               | `azure_cosmosdb_sql_database`   |
+| `azure_resource_group`       | **HAS**               | `azure_cosmosdb_account`        |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_unknown_resource_type`   |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_keyvault_service`        |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_nic`                     |
@@ -161,13 +177,6 @@ The following relationships are created/mapped:
 | `azure_role_assignment`      | **ALLOWS**            | `azure_resource_group`          |
 | `azure_role_assignment`      | **USES**              | `azure_role_definition`         |
 | `azure_classic_admin_group`  | **HAS**               | `azure_user`                    |
-| `azure_resource_group`       | **HAS**               | `azure_unknown_resource_type`   |
-| `azure_resource_group`       | **HAS**               | `azure_keyvault_service`        |
-| `azure_resource_group`       | **HAS**               | `azure_nic`                     |
-| `azure_resource_group`       | **HAS**               | `azure_security_group`          |
-| `azure_resource_group`       | **HAS**               | `azure_public_ip`               |
-| `azure_resource_group`       | **HAS**               | `azure_vnet`                    |
-| `azure_resource_group`       | **HAS**               | `azure_cosmosdb_account`        |
 
 <!--
 ********************************************************************************

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -102,10 +102,10 @@ The following entities are created:
 | [RM] Role Assignment        | `azure_role_assignment`       | `AccessPolicy`                  |
 | [AD] Service Principal      | `azure_service_principal`     | `Service`                       |
 | [AD] User                   | `azure_user`                  | `User`                          |
-| [RM] Resource Group         | `azure_resource_group`        | `Group`                         |
 | [RM] Key Vault              | `azure_keyvault_service`      | `Service`                       |
 | [RM] Cosmos DB Account      | `azure_cosmosdb_account`      | `Account`, `Service`            |
 | [RM] Cosmos DB Database     | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
+| [RM] Resource Group         | `azure_resource_group`        | `Group`                         |
 | [RM] Role Definition        | `azure_role_definition`       | `AccessRole`                    |
 | [RM] Classic Admin          | `azure_classic_admin_group`   | `UserGroup`                     |
 
@@ -151,16 +151,23 @@ The following relationships are created/mapped:
 | `azure_account`              | **HAS**               | `azure_keyvault_service`        |
 | `azure_cosmosdb_account`     | **HAS**               | `azure_cosmosdb_sql_database`   |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_unknown_resource_type`   |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_subscription`            |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_resource_group`          |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_keyvault_service`        |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_nic`                     |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_security_group`          |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_public_ip`               |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_vnet`                    |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_cosmosdb_account`        |
+| `azure_role_assignment`      | **ALLOWS**            | `azure_subscription`            |
+| `azure_role_assignment`      | **ALLOWS**            | `azure_resource_group`          |
 | `azure_role_assignment`      | **USES**              | `azure_role_definition`         |
 | `azure_classic_admin_group`  | **HAS**               | `azure_user`                    |
+| `azure_resource_group`       | **HAS**               | `azure_unknown_resource_type`   |
+| `azure_resource_group`       | **HAS**               | `azure_keyvault_service`        |
+| `azure_resource_group`       | **HAS**               | `azure_nic`                     |
+| `azure_resource_group`       | **HAS**               | `azure_security_group`          |
+| `azure_resource_group`       | **HAS**               | `azure_public_ip`               |
+| `azure_resource_group`       | **HAS**               | `azure_vnet`                    |
+| `azure_resource_group`       | **HAS**               | `azure_cosmosdb_account`        |
 
 <!--
 ********************************************************************************

--- a/src/steps/resource-manager/authorization/constants.ts
+++ b/src/steps/resource-manager/authorization/constants.ts
@@ -16,9 +16,6 @@ import {
   DEFAULT_RESOURCE_TYPE,
   ResourceIdMap,
   RESOURCE_ID_TYPES_MAP,
-  SUBSCRIPTION_MATCHER,
-  EOL_MATCHER,
-  RESOURCE_GROUP_MATCHER,
   makeMatcherDependsOn,
   makeMatcherEntityTypes,
 } from '../utils/findOrBuildResourceEntityFromResourceId';
@@ -26,6 +23,11 @@ import {
   RESOURCE_GROUP_ENTITY,
   STEP_RM_RESOURCES_RESOURCE_GROUPS,
 } from '../resources';
+import {
+  SUBSCRIPTION_MATCHER,
+  EOL_MATCHER,
+  RESOURCE_GROUP_MATCHER,
+} from '../utils/matchers';
 
 // Fetch Role Assignments
 export const STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS =

--- a/src/steps/resource-manager/authorization/index.test.ts
+++ b/src/steps/resource-manager/authorization/index.test.ts
@@ -5,7 +5,6 @@ import {
   fetchRoleAssignments,
   buildRoleAssignmentPrincipalRelationships,
   fetchRoleDefinitions,
-  findOrBuildScopeEntityForRoleAssignment,
   buildRoleAssignmentScopeRelationships,
 } from '.';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
@@ -22,7 +21,6 @@ import {
   getJupiterTypeForPrincipalType,
   ROLE_ASSIGNMENT_ENTITY_TYPE,
   ROLE_ASSIGNMENT_ENTITY_CLASS,
-  getJupiterTypeForScope,
 } from './constants';
 import {
   PrincipalType,
@@ -32,6 +30,9 @@ import { generateEntityKey } from '../../../utils/generateKeys';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { USER_ENTITY_TYPE, USER_ENTITY_CLASS } from '../../active-directory';
 import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
+import findOrBuildResourceEntityFromResourceId, {
+  getJupiterTypeForResourceId,
+} from '../utils/findOrBuildResourceEntityFromResourceId';
 
 let recording: Recording;
 
@@ -278,10 +279,9 @@ describe('#findOrBuildScopeEntityForRoleAssignment', () => {
   test('should find scope entity that exists in the job state', async () => {
     const scope =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
-    const entityType = getJupiterTypeForScope(scope);
     const targetEntity: Entity = {
       _class: ['Service'],
-      _type: entityType,
+      _type: 'azure_key_vault',
       _key: scope,
     };
 
@@ -290,8 +290,8 @@ describe('#findOrBuildScopeEntityForRoleAssignment', () => {
       entities: [targetEntity],
     });
 
-    const response = await findOrBuildScopeEntityForRoleAssignment(context, {
-      scope,
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: scope,
     });
 
     expect(response).toBe(targetEntity);
@@ -300,15 +300,15 @@ describe('#findOrBuildScopeEntityForRoleAssignment', () => {
   test('should build placeholder scope entity that does not exist in the job state', async () => {
     const scope =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
-    const entityType = getJupiterTypeForScope(scope);
+    const entityType = getJupiterTypeForResourceId(scope);
 
     const context = createMockStepExecutionContext<IntegrationConfig>({
       instanceConfig,
       entities: [],
     });
 
-    const response = await findOrBuildScopeEntityForRoleAssignment(context, {
-      scope,
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: scope,
     });
 
     expect(response).toEqual({

--- a/src/steps/resource-manager/authorization/index.test.ts
+++ b/src/steps/resource-manager/authorization/index.test.ts
@@ -30,9 +30,6 @@ import { generateEntityKey } from '../../../utils/generateKeys';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { USER_ENTITY_TYPE, USER_ENTITY_CLASS } from '../../active-directory';
 import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
-import findOrBuildResourceEntityFromResourceId, {
-  getJupiterTypeForResourceId,
-} from '../utils/findOrBuildResourceEntityFromResourceId';
 
 let recording: Recording;
 
@@ -271,49 +268,6 @@ describe('#findOrBuildTargetEntityForRoleDefinition', () => {
     expect(response).toEqual({
       _type: entityType,
       _key: generateEntityKey(principalId),
-    });
-  });
-});
-
-describe('#findOrBuildScopeEntityForRoleAssignment', () => {
-  test('should find scope entity that exists in the job state', async () => {
-    const scope =
-      '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
-    const targetEntity: Entity = {
-      _class: ['Service'],
-      _type: 'azure_key_vault',
-      _key: scope,
-    };
-
-    const context = createMockStepExecutionContext<IntegrationConfig>({
-      instanceConfig,
-      entities: [targetEntity],
-    });
-
-    const response = await findOrBuildResourceEntityFromResourceId(context, {
-      resourceId: scope,
-    });
-
-    expect(response).toBe(targetEntity);
-  });
-
-  test('should build placeholder scope entity that does not exist in the job state', async () => {
-    const scope =
-      '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
-    const entityType = getJupiterTypeForResourceId(scope);
-
-    const context = createMockStepExecutionContext<IntegrationConfig>({
-      instanceConfig,
-      entities: [],
-    });
-
-    const response = await findOrBuildResourceEntityFromResourceId(context, {
-      resourceId: scope,
-    });
-
-    expect(response).toEqual({
-      _type: entityType,
-      _key: scope,
     });
   });
 });

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -38,9 +38,8 @@ import {
   CLASSIC_ADMINISTRATOR_RELATIONSHIP_CLASS,
   STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENT_SCOPE_RELATIONSHIPS,
   ROLE_ASSIGNMENT_SCOPE_RELATIONSHIP_TYPES,
-  ROLE_ASSIGNMENT_SCOPE_DEPENDS_ON,
-  getJupiterTypeForScope,
   ROLE_ASSIGNMENT_SCOPE_RELATIONSHIP_CLASS,
+  SCOPE_MATCHER_DEPENDS_ON,
 } from './constants';
 import {
   createRoleDefinitionEntity,
@@ -50,10 +49,12 @@ import {
 } from './converters';
 import { PrincipalType } from '@azure/arm-authorization/esm/models';
 import { generateEntityKey } from '../../../utils/generateKeys';
+import findOrBuildResourceEntityFromResourceId, {
+  PlaceholderEntity,
+  isPlaceholderEntity,
+} from '../utils/findOrBuildResourceEntityFromResourceId';
 
 export * from './constants';
-
-type PlaceholderEntity = { _type: string; _key: string };
 
 /**
  * Tries to fetch the role definition from the present job state.
@@ -127,12 +128,6 @@ export async function findOrBuildPrincipalEntityForRoleAssignment(
   return targetEntity;
 }
 
-function isPlaceholderEntity(
-  targetEntity: Entity | PlaceholderEntity,
-): targetEntity is PlaceholderEntity {
-  return (targetEntity as any)._class === undefined;
-}
-
 export async function fetchRoleAssignments(
   executionContext: IntegrationStepContext,
 ): Promise<void> {
@@ -188,29 +183,6 @@ export async function buildRoleAssignmentPrincipalRelationships(
   );
 }
 
-/**
- * Tries to fetch the scope entity from the job state.
- * If the entity is not in the job state, returns {_key, _type} for mapper.
- */
-export async function findOrBuildScopeEntityForRoleAssignment(
-  executionContext: IntegrationStepContext,
-  options: {
-    scope: string;
-  },
-): Promise<Entity | PlaceholderEntity> {
-  const { jobState } = executionContext;
-  const { scope } = options;
-  const targetType = getJupiterTypeForScope(scope);
-  let targetEntity: Entity | PlaceholderEntity | null = await jobState.findEntity(scope);
-  if (targetEntity === null) {
-    targetEntity = {
-      _type: targetType,
-      _key: scope,
-    };
-  }
-  return targetEntity;
-}
-
 export async function buildRoleAssignmentScopeRelationships(
   executionContext: IntegrationStepContext,
 ): Promise<void> {
@@ -219,10 +191,10 @@ export async function buildRoleAssignmentScopeRelationships(
   await jobState.iterateEntities(
     { _type: ROLE_ASSIGNMENT_ENTITY_TYPE },
     async (roleAssignmentEntity: Entity) => {
-      const targetEntity = await findOrBuildScopeEntityForRoleAssignment(
+      const targetEntity = await findOrBuildResourceEntityFromResourceId(
         executionContext,
         {
-          scope: roleAssignmentEntity.scope as string,
+          resourceId: roleAssignmentEntity.scope as string,
         },
       );
 
@@ -352,7 +324,7 @@ export const authorizationSteps: Step<
     relationships: ROLE_ASSIGNMENT_SCOPE_RELATIONSHIP_TYPES,
     dependsOn: [
       STEP_RM_AUTHORIZATION_ROLE_ASSIGNMENTS,
-      ...ROLE_ASSIGNMENT_SCOPE_DEPENDS_ON,
+      ...SCOPE_MATCHER_DEPENDS_ON,
     ],
     executionHandler: buildRoleAssignmentScopeRelationships,
   },

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -40,6 +40,7 @@ import {
   ROLE_ASSIGNMENT_SCOPE_RELATIONSHIP_TYPES,
   ROLE_ASSIGNMENT_SCOPE_RELATIONSHIP_CLASS,
   SCOPE_MATCHER_DEPENDS_ON,
+  SCOPE_TYPES_MAP,
 } from './constants';
 import {
   createRoleDefinitionEntity,
@@ -195,6 +196,7 @@ export async function buildRoleAssignmentScopeRelationships(
         executionContext,
         {
           resourceId: roleAssignmentEntity.scope as string,
+          resourceIdMap: SCOPE_TYPES_MAP,
         },
       );
 

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -40,6 +40,8 @@ import {
   IntegrationStepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
 import { IntegrationConfig } from '../../../types';
+import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
 
 export * from './constants';
 
@@ -68,8 +70,11 @@ export const databaseSteps: Step<
         _class: RM_MARIADB_SERVER_DATABASE_RELATIONSHIP_CLASS,
         targetType: RM_MARIADB_DATABASE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        RM_MARIADB_SERVER_ENTITY_TYPE,
+      ),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMariaDBDatabases,
   },
   {
@@ -94,8 +99,11 @@ export const databaseSteps: Step<
         _class: RM_MYSQL_SERVER_DATABASE_RELATIONSHIP_CLASS,
         targetType: RM_MYSQL_DATABASE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        RM_MYSQL_SERVER_ENTITY_TYPE,
+      ),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMySQLDatabases,
   },
   {
@@ -120,8 +128,11 @@ export const databaseSteps: Step<
         _class: RM_POSTGRESQL_SERVER_DATABASE_RELATIONSHIP_CLASS,
         targetType: RM_POSTGRESQL_DATABASE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        RM_POSTGRESQL_SERVER_ENTITY_TYPE,
+      ),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPostgreSQLDatabases,
   },
   {
@@ -146,8 +157,11 @@ export const databaseSteps: Step<
         _class: RM_SQL_SERVER_DATABASE_RELATIONSHIP_CLASS,
         targetType: RM_SQL_DATABASE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        RM_SQL_SERVER_ENTITY_TYPE,
+      ),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchSQLDatabases,
   },
 ];

--- a/src/steps/resource-manager/databases/mariadb/index.ts
+++ b/src/steps/resource-manager/databases/mariadb/index.ts
@@ -13,6 +13,7 @@ import {
   RM_MARIADB_DATABASE_ENTITY_TYPE,
   RM_MARIADB_SERVER_ENTITY_TYPE,
 } from './constants';
+import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 
 export * from './constants';
 
@@ -32,6 +33,13 @@ export async function fetchMariaDBDatabases(
       RM_MARIADB_SERVER_ENTITY_TYPE,
     );
     await jobState.addEntity(serverEntity);
+
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        serverEntity,
+      ),
+    );
 
     try {
       await client.iterateDatabases(server, async (database) => {

--- a/src/steps/resource-manager/databases/mysql/index.ts
+++ b/src/steps/resource-manager/databases/mysql/index.ts
@@ -13,6 +13,7 @@ import {
   RM_MYSQL_DATABASE_ENTITY_TYPE,
   RM_MYSQL_SERVER_ENTITY_TYPE,
 } from './constants';
+import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 
 export * from './constants';
 
@@ -32,6 +33,13 @@ export async function fetchMySQLDatabases(
       RM_MYSQL_SERVER_ENTITY_TYPE,
     );
     await jobState.addEntity(serverEntity);
+
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        serverEntity,
+      ),
+    );
 
     try {
       await client.iterateDatabases(server, async (e) => {

--- a/src/steps/resource-manager/databases/postgresql/index.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.ts
@@ -13,6 +13,7 @@ import {
   RM_POSTGRESQL_DATABASE_ENTITY_TYPE,
   RM_POSTGRESQL_SERVER_ENTITY_TYPE,
 } from './constants';
+import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 
 export * from './constants';
 
@@ -32,6 +33,13 @@ export async function fetchPostgreSQLDatabases(
       RM_POSTGRESQL_SERVER_ENTITY_TYPE,
     );
     await jobState.addEntity(serverEntity);
+
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        serverEntity,
+      ),
+    );
 
     try {
       await client.iterateDatabases(server, async (database) => {

--- a/src/steps/resource-manager/databases/sql/index.ts
+++ b/src/steps/resource-manager/databases/sql/index.ts
@@ -18,6 +18,7 @@ import {
   setDatabaseEncryption,
   setServerSecurityAlerting,
 } from './converters';
+import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 
 export * from './constants';
 
@@ -47,6 +48,13 @@ export async function fetchSQLDatabases(
     );
 
     await jobState.addEntity(serverEntity);
+
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        serverEntity,
+      ),
+    );
 
     try {
       await client.iterateDatabases(server, async (database) => {

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -18,6 +18,10 @@ import {
   ACCOUNT_KEY_VAULT_RELATIONSHIP_CLASS,
 } from './constants';
 import { createKeyVaultEntity } from './converters';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
+import createResourceGroupResourceRelationship, {
+  createResourceGroupResourceRelationshipMetadata,
+} from '../utils/createResourceGroupResourceRelationship';
 
 export * from './constants';
 
@@ -33,6 +37,12 @@ export async function fetchKeyVaults(
   await client.iterateKeyVaults(async (vault) => {
     const vaultEntity = createKeyVaultEntity(webLinker, vault);
     await jobState.addEntity(vaultEntity);
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        vaultEntity,
+      ),
+    );
     await jobState.addRelationship(
       createDirectRelationship({
         _class: RelationshipClass.HAS,
@@ -63,8 +73,11 @@ export const keyvaultSteps: Step<
         _class: ACCOUNT_KEY_VAULT_RELATIONSHIP_CLASS,
         targetType: KEY_VAULT_SERVICE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        KEY_VAULT_SERVICE_ENTITY_TYPE,
+      ),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchKeyVaults,
   },
 ];

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -314,8 +314,6 @@ test('network steps', async () => {
     },
   );
 
-  console.log(context.jobState.collectedRelationships);
-
   expect(context.jobState.collectedRelationships).toContainOnlyGraphObjects(
     // VPC default, eastus
     {

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -101,8 +101,16 @@ test('network steps', async () => {
     name: 'network-steps',
   });
 
+  const resouceGroupEntity: Entity = {
+    _key:
+      '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+    _type: 'azure_resource_group',
+    _class: ['Group'],
+  };
+
   const context = createMockStepExecutionContext<IntegrationConfig>({
     instanceConfig,
+    entities: [resouceGroupEntity],
   });
 
   // Simulates dependency order of execution
@@ -305,6 +313,8 @@ test('network steps', async () => {
         'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
     },
   );
+
+  console.log(context.jobState.collectedRelationships);
 
   expect(context.jobState.collectedRelationships).toContainOnlyGraphObjects(
     // VPC default, eastus
@@ -748,6 +758,63 @@ test('network steps', async () => {
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
       _type: 'azure_vnet_contains_subnet',
       displayName: 'CONTAINS',
+    },
+
+    // Resource Group
+    {
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      _type: 'azure_resource_group_has_nic',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      displayName: 'HAS',
+    },
+    {
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      _type: 'azure_resource_group_has_public_ip',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      displayName: 'HAS',
+    },
+    {
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _type: 'azure_resource_group_has_security_group',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      displayName: 'HAS',
+    },
+    {
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      _type: 'azure_resource_group_has_vnet',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      displayName: 'HAS',
+    },
+    {
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      _type: 'azure_resource_group_has_vnet',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      displayName: 'HAS',
     },
   );
 }, 120000);

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -34,6 +34,10 @@ import {
   createStorageFileShareEntity,
   createStorageServiceEntity,
 } from './converters';
+import createResourceGroupResourceRelationship, {
+  createResourceGroupResourceRelationshipMetadata,
+} from '../utils/createResourceGroupResourceRelationship';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
 
 export * from './constants';
 
@@ -141,6 +145,10 @@ async function synchronizeBlobStorage(
     }),
   );
 
+  await jobState.addRelationship(
+    await createResourceGroupResourceRelationship(context, serviceEntity),
+  );
+
   await client.iterateStorageBlobContainers(
     storageAccount,
     async (container) => {
@@ -190,6 +198,10 @@ async function synchronizeFileStorage(
       from: accountEntity,
       to: serviceEntity,
     }),
+  );
+
+  await jobState.addRelationship(
+    await createResourceGroupResourceRelationship(context, serviceEntity),
   );
 
   await client.iterateFileShares(storageAccount, async (e) => {
@@ -249,6 +261,9 @@ export const storageSteps: Step<
         _class: ACCOUNT_STORAGE_BLOB_SERVICE_RELATIONSHIP_CLASS,
         targetType: STORAGE_BLOB_SERVICE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        STORAGE_BLOB_SERVICE_ENTITY_TYPE,
+      ),
       {
         _type: STORAGE_BLOB_SERVICE_CONTAINER_RELATIONSHIP_TYPE,
         sourceType: STORAGE_BLOB_SERVICE_ENTITY_TYPE,
@@ -261,6 +276,9 @@ export const storageSteps: Step<
         _class: ACCOUNT_STORAGE_FILE_SERVICE_RELATIONSHIP_CLASS,
         targetType: STORAGE_FILE_SERVICE_ENTITY_TYPE,
       },
+      createResourceGroupResourceRelationshipMetadata(
+        STORAGE_FILE_SERVICE_ENTITY_TYPE,
+      ),
       {
         _type: STORAGE_FILE_SERVICE_SHARE_RELATIONSHIP_TYPE,
         sourceType: STORAGE_FILE_SERVICE_ENTITY_TYPE,
@@ -274,7 +292,7 @@ export const storageSteps: Step<
 
     // STORAGE_TABLE_SERVICE_ENTITY_TYPE,
     // ACCOUNT_STORAGE_TABLE_SERVICE_RELATIONSHIP_TYPE,
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchStorageResources,
   },
 ];

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
@@ -44,7 +44,7 @@ describe('#createResourceGroupResourceRelationship', () => {
     });
   });
 
-  test('should return mapped relationship when resourceGroup does not exist in jobState', async () => {
+  test('should throw when resourceGroup does not exist in jobState', async () => {
     const resourceGroupId =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id';
 
@@ -60,29 +60,12 @@ describe('#createResourceGroupResourceRelationship', () => {
         resourceGroupId + '/providers/Microsoft/KeyVault/vaults/key-vault-id',
     };
 
-    const result = await createResourceGroupResourceRelationship(
-      context,
-      resourceEntity,
-    );
+    const exec = async () =>
+      createResourceGroupResourceRelationship(context, resourceEntity);
 
-    expect(result).toEqual({
-      _class: 'HAS',
-      _key:
-        '/subscriptions/subscription-id/resourceGroups/resource-group-id|has|/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
-      _mapping: {
-        relationshipDirection: 'REVERSE',
-        sourceEntityKey:
-          '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
-        targetEntity: {
-          _key:
-            '/subscriptions/subscription-id/resourceGroups/resource-group-id',
-          _type: 'azure_resource_group',
-        },
-        targetFilterKeys: [['_type', '_key']],
-      },
-      _type: 'azure_resource_group_has_keyvault_service',
-      displayName: 'HAS',
-    });
+    await expect(exec).rejects.toThrow(
+      'Could not find the resource group "/subscriptions/subscription-id/resourceGroups/resource-group-id" in this subscription',
+    );
   });
 
   test('should throw when resourceGroup cannot be extracted from entity _key', async () => {

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
@@ -1,0 +1,107 @@
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
+import instanceConfig from '../../../../test/integrationInstanceConfig';
+import { IntegrationConfig } from '../../../types';
+import { Entity } from '@jupiterone/integration-sdk-core';
+import createResourceGroupResourceRelationship from './createResourceGroupResourceRelationship';
+
+describe('#createResourceGroupResourceRelationship', () => {
+  test('should return direct relationship when resourceGroup exists in jobState', async () => {
+    const resourceGroupId =
+      '/subscriptions/subscription-id/resourceGroups/resource-group-id';
+    const resourceGroupEntity: Entity = {
+      _class: ['Group'],
+      _type: 'azure_resource_group',
+      _key: resourceGroupId,
+    };
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [resourceGroupEntity],
+    });
+
+    const resourceEntity: Entity = {
+      _class: ['Service'],
+      _type: 'azure_keyvault_service',
+      _key:
+        resourceGroupId + '/providers/Microsoft/KeyVault/vaults/key-vault-id',
+    };
+
+    const result = await createResourceGroupResourceRelationship(
+      context,
+      resourceEntity,
+    );
+
+    expect(result).toEqual({
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/subscription-id/resourceGroups/resource-group-id',
+      _key:
+        '/subscriptions/subscription-id/resourceGroups/resource-group-id|has|/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
+      _toEntityKey:
+        '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
+      _type: 'azure_resource_group_has_keyvault_service',
+      displayName: 'HAS',
+    });
+  });
+
+  test('should return mapped relationship when resourceGroup does not exist in jobState', async () => {
+    const resourceGroupId =
+      '/subscriptions/subscription-id/resourceGroups/resource-group-id';
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const resourceEntity: Entity = {
+      _class: ['Service'],
+      _type: 'azure_keyvault_service',
+      _key:
+        resourceGroupId + '/providers/Microsoft/KeyVault/vaults/key-vault-id',
+    };
+
+    const result = await createResourceGroupResourceRelationship(
+      context,
+      resourceEntity,
+    );
+
+    expect(result).toEqual({
+      _class: 'HAS',
+      _key:
+        '/subscriptions/subscription-id/resourceGroups/resource-group-id|has|/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
+      _mapping: {
+        relationshipDirection: 'REVERSE',
+        sourceEntityKey:
+          '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft/KeyVault/vaults/key-vault-id',
+        targetEntity: {
+          _key:
+            '/subscriptions/subscription-id/resourceGroups/resource-group-id',
+          _type: 'azure_resource_group',
+        },
+        targetFilterKeys: [['_type', '_key']],
+      },
+      _type: 'azure_resource_group_has_keyvault_service',
+      displayName: 'HAS',
+    });
+  });
+
+  test('should throw when resourceGroup cannot be extracted from entity _key', async () => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const resourceEntity: Entity = {
+      _class: ['Service'],
+      _type: 'azure_keyvault_service',
+      _key: 'some-key-without-resource-group',
+    };
+
+    const exec = async () =>
+      createResourceGroupResourceRelationship(context, resourceEntity);
+
+    await expect(exec).rejects.toThrow(
+      'Could not identify a resource group ID in the entity _key: some-key-without-resource-group',
+    );
+  });
+});

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.ts
@@ -1,0 +1,80 @@
+import {
+  Entity,
+  StepExecutionContext,
+  createDirectRelationship,
+  createMappedRelationship,
+  Relationship,
+  RelationshipDirection,
+  IntegrationError,
+  RelationshipClass,
+  StepRelationshipMetadata,
+  generateRelationshipType,
+  generateRelationshipKey,
+} from '@jupiterone/integration-sdk-core';
+import { RESOURCE_GROUP_ENTITY } from '../resources';
+import { RESOURCE_GROUP_MATCHER } from './matchers';
+
+export const RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS = RelationshipClass.HAS;
+
+export function createResourceGroupResourceRelationshipMetadata(
+  targetEntityType: string,
+): StepRelationshipMetadata {
+  return {
+    _type: generateRelationshipType(
+      RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS,
+      RESOURCE_GROUP_ENTITY._type,
+      targetEntityType,
+    ),
+    sourceType: RESOURCE_GROUP_ENTITY._type,
+    _class: RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS,
+    targetType: targetEntityType,
+  };
+}
+
+const resourceRegex = new RegExp(RESOURCE_GROUP_MATCHER);
+
+export async function createResourceGroupResourceRelationship(
+  executionContext: StepExecutionContext,
+  resourceEntity: Entity,
+): Promise<Relationship> {
+  const resourceGroupIdMatch = resourceEntity._key.match(resourceRegex);
+  if (!resourceGroupIdMatch) {
+    throw new IntegrationError({
+      message: `Could not identify a resource group ID in the entity _key: ${resourceEntity._key}`,
+      code: 'UNMATCHED_RESOURCE_GROUP',
+    });
+  }
+  const { jobState } = executionContext;
+  const resourceGroupId = resourceGroupIdMatch[0];
+
+  const resourceGroupEntity = await jobState.findEntity(resourceGroupId);
+  if (resourceGroupEntity) {
+    return createDirectRelationship({
+      _class: RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS,
+      from: resourceGroupEntity,
+      to: resourceEntity,
+    });
+  } else {
+    const relationshipMetadata = createResourceGroupResourceRelationshipMetadata(
+      resourceEntity._type,
+    );
+    return createMappedRelationship({
+      _key: generateRelationshipKey(
+        relationshipMetadata._class,
+        resourceGroupId,
+        resourceEntity._key,
+      ),
+      _type: relationshipMetadata._type,
+      _class: relationshipMetadata._class,
+      relationshipDirection: RelationshipDirection.REVERSE,
+      source: resourceEntity,
+      target: {
+        _type: RESOURCE_GROUP_ENTITY._type,
+        _key: resourceGroupId,
+      },
+      targetFilterKeys: [['_type', '_key']],
+    });
+  }
+}
+
+export default createResourceGroupResourceRelationship;

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.ts
@@ -2,14 +2,11 @@ import {
   Entity,
   StepExecutionContext,
   createDirectRelationship,
-  createMappedRelationship,
-  Relationship,
-  RelationshipDirection,
   IntegrationError,
   RelationshipClass,
   StepRelationshipMetadata,
   generateRelationshipType,
-  generateRelationshipKey,
+  ExplicitRelationship,
 } from '@jupiterone/integration-sdk-core';
 import { RESOURCE_GROUP_ENTITY } from '../resources';
 import { RESOURCE_GROUP_MATCHER } from './matchers';
@@ -36,7 +33,7 @@ const resourceRegex = new RegExp(RESOURCE_GROUP_MATCHER);
 export async function createResourceGroupResourceRelationship(
   executionContext: StepExecutionContext,
   resourceEntity: Entity,
-): Promise<Relationship> {
+): Promise<ExplicitRelationship> {
   const resourceGroupIdMatch = resourceEntity._key.match(resourceRegex);
   if (!resourceGroupIdMatch) {
     throw new IntegrationError({
@@ -55,24 +52,9 @@ export async function createResourceGroupResourceRelationship(
       to: resourceEntity,
     });
   } else {
-    const relationshipMetadata = createResourceGroupResourceRelationshipMetadata(
-      resourceEntity._type,
-    );
-    return createMappedRelationship({
-      _key: generateRelationshipKey(
-        relationshipMetadata._class,
-        resourceGroupId,
-        resourceEntity._key,
-      ),
-      _type: relationshipMetadata._type,
-      _class: relationshipMetadata._class,
-      relationshipDirection: RelationshipDirection.REVERSE,
-      source: resourceEntity,
-      target: {
-        _type: RESOURCE_GROUP_ENTITY._type,
-        _key: resourceGroupId,
-      },
-      targetFilterKeys: [['_type', '_key']],
+    throw new IntegrationError({
+      message: `Could not find the resource group "${resourceGroupId}" in this subscription.`,
+      code: 'MISSING_RESOURCE_GROUP',
     });
   }
 }

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
@@ -1,10 +1,11 @@
 import findOrBuildResourceEntityFromResourceId, {
-  getJupiterTypeForResourceId,
+  DEFAULT_RESOURCE_TYPE,
 } from './findOrBuildResourceEntityFromResourceId';
 import { Entity } from '@jupiterone/integration-sdk-core';
 import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
 import { IntegrationConfig } from '../../../types';
+import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
 
 describe('#findOrBuildResourceEntityFromResourceId', () => {
   test('should find resource entity that exists in the job state', async () => {
@@ -12,7 +13,7 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
       '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
     const targetEntity: Entity = {
       _class: ['Service'],
-      _type: 'azure_keyvault_service',
+      _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
       _key: id,
     };
 
@@ -28,10 +29,9 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
     expect(response).toBe(targetEntity);
   });
 
-  test('should build placeholder entity that does not exist in the job state', async () => {
+  test('should build placeholder entity that does not exist in the job state by id', async () => {
     const id =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
-    const entityType = getJupiterTypeForResourceId(id);
 
     const context = createMockStepExecutionContext<IntegrationConfig>({
       instanceConfig,
@@ -43,7 +43,65 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
     });
 
     expect(response).toEqual({
-      _type: entityType,
+      _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
+      _key: id,
+    });
+  });
+
+  test('should return default _type placeholder entity if resourceId does not match', async () => {
+    const id = 'some-random-id';
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: id,
+    });
+
+    expect(response).toEqual({
+      _type: DEFAULT_RESOURCE_TYPE,
+      _key: id,
+    });
+  });
+
+  test('should build placeholder entity that does not exist in the job state by type', async () => {
+    const id = 'some-random-id';
+    const type = 'Microsoft.KeyVault/vault';
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: id,
+      type,
+    });
+
+    expect(response).toEqual({
+      _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
+      _key: id,
+    });
+  });
+
+  test('should return default _type placeholder entity if _type does not match', async () => {
+    const id = 'some-random-id';
+    const type = 'some-random-type';
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: id,
+      type,
+    });
+
+    expect(response).toEqual({
+      _type: DEFAULT_RESOURCE_TYPE,
       _key: id,
     });
   });

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
@@ -1,0 +1,50 @@
+import findOrBuildResourceEntityFromResourceId, {
+  getJupiterTypeForResourceId,
+} from './findOrBuildResourceEntityFromResourceId';
+import { Entity } from '@jupiterone/integration-sdk-core';
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
+import instanceConfig from '../../../../test/integrationInstanceConfig';
+import { IntegrationConfig } from '../../../types';
+
+describe('#findOrBuildResourceEntityFromResourceId', () => {
+  test('should find resource entity that exists in the job state', async () => {
+    const id =
+      '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
+    const targetEntity: Entity = {
+      _class: ['Service'],
+      _type: 'azure_keyvault_service',
+      _key: id,
+    };
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [targetEntity],
+    });
+
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: id,
+    });
+
+    expect(response).toBe(targetEntity);
+  });
+
+  test('should build placeholder entity that does not exist in the job state', async () => {
+    const id =
+      '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
+    const entityType = getJupiterTypeForResourceId(id);
+
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [],
+    });
+
+    const response = await findOrBuildResourceEntityFromResourceId(context, {
+      resourceId: id,
+    });
+
+    expect(response).toEqual({
+      _type: entityType,
+      _key: id,
+    });
+  });
+});

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
@@ -18,6 +18,7 @@ import {
   RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
   STEP_RM_COSMOSDB_SQL_DATABASES,
 } from '../cosmosdb';
+import { RESOURCE_GROUP_MATCHER, EOL_MATCHER } from './matchers';
 
 export interface ResourceIdMap {
   resourceIdMatcher: RegExp;
@@ -25,12 +26,6 @@ export interface ResourceIdMap {
   _type: string;
   dependsOn: string[];
 }
-
-export const EOL_MATCHER = '$';
-
-export const SUBSCRIPTION_MATCHER = '/subscriptions/[^/]+';
-export const RESOURCE_GROUP_MATCHER =
-  SUBSCRIPTION_MATCHER + '/resourceGroups/[^/]+';
 
 export const RESOURCE_ID_TYPES_MAP: ResourceIdMap[] = [
   {

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
@@ -1,0 +1,167 @@
+import { IntegrationStepContext } from '../../../types';
+import { Entity } from '@jupiterone/integration-sdk-core';
+import {
+  KEY_VAULT_SERVICE_ENTITY_TYPE,
+  STEP_RM_KEYVAULT_VAULTS,
+} from '../key-vault';
+import {
+  NETWORK_INTERFACE_ENTITY_TYPE,
+  STEP_RM_NETWORK_INTERFACES,
+  SECURITY_GROUP_ENTITY_TYPE,
+  STEP_RM_NETWORK_SECURITY_GROUPS,
+  PUBLIC_IP_ADDRESS_ENTITY_TYPE,
+  STEP_RM_NETWORK_PUBLIC_IP_ADDRESSES,
+  VIRTUAL_NETWORK_ENTITY_TYPE,
+  STEP_RM_NETWORK_VIRTUAL_NETWORKS,
+} from '../network';
+import {
+  RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
+  STEP_RM_COSMOSDB_SQL_DATABASES,
+} from '../cosmosdb';
+
+export interface ResourceIdMap {
+  resourceIdMatcher: RegExp;
+  azureType?: string;
+  _type: string;
+  dependsOn: string[];
+}
+
+export const EOL_MATCHER = '$';
+
+export const SUBSCRIPTION_MATCHER = '/subscriptions/[^/]+';
+export const RESOURCE_GROUP_MATCHER =
+  SUBSCRIPTION_MATCHER + '/resourceGroups/[^/]+';
+
+export const RESOURCE_ID_TYPES_MAP: ResourceIdMap[] = [
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.KeyVault/vaults/[^/]+' +
+        EOL_MATCHER,
+    ),
+    azureType: 'Microsoft.KeyVault/vault',
+    _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
+    dependsOn: [STEP_RM_KEYVAULT_VAULTS],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.Network/networkInterfaces/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: NETWORK_INTERFACE_ENTITY_TYPE,
+    dependsOn: [STEP_RM_NETWORK_INTERFACES],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.Network/networkSecurityGroups/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: SECURITY_GROUP_ENTITY_TYPE,
+    dependsOn: [STEP_RM_NETWORK_SECURITY_GROUPS],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.Network/publicIPAddresses/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: PUBLIC_IP_ADDRESS_ENTITY_TYPE,
+    dependsOn: [STEP_RM_NETWORK_PUBLIC_IP_ADDRESSES],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.Network/virtualNetworks/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: VIRTUAL_NETWORK_ENTITY_TYPE,
+    dependsOn: [STEP_RM_NETWORK_VIRTUAL_NETWORKS],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.DocumentDB/databaseAccounts/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
+    dependsOn: [STEP_RM_COSMOSDB_SQL_DATABASES],
+  },
+];
+
+export const DEFAULT_RESOURCE_TYPE = 'azure_unknown_resource_type';
+
+export function makeMatcherDependsOn(resourceIdMap: ResourceIdMap[]): string[] {
+  return ([] as string[]).concat(...resourceIdMap.map((t) => t.dependsOn));
+}
+export const RESOURCE_ID_MATCHER_DEPENDS_ON = makeMatcherDependsOn(
+  RESOURCE_ID_TYPES_MAP,
+);
+
+export function makeMatcherEntityTypes(
+  resourceIdMap: ResourceIdMap[],
+): string[] {
+  return ([] as string[]).concat(...resourceIdMap.map((t) => t._type));
+}
+export const RESOURCE_ID_MATCHER_ENTITY_TYPES = makeMatcherEntityTypes(
+  RESOURCE_ID_TYPES_MAP,
+);
+
+export function getJupiterTypeForResourceId(
+  resourceId: string,
+  resourceIdMap?: ResourceIdMap[],
+): string | undefined {
+  return (resourceIdMap || RESOURCE_ID_TYPES_MAP).find((t) =>
+    t.resourceIdMatcher.test(resourceId),
+  )?._type;
+}
+
+export function getJupiterTypeForAzureType(
+  azureType: string,
+  resourceIdMap?: ResourceIdMap[],
+): string | undefined {
+  return (resourceIdMap || RESOURCE_ID_TYPES_MAP).find(
+    (t) => t.azureType === azureType,
+  )?._type;
+}
+
+export type PlaceholderEntity = { _type: string; _key: string };
+
+export function isPlaceholderEntity(
+  targetEntity: Entity | PlaceholderEntity,
+): targetEntity is PlaceholderEntity {
+  return (targetEntity as any)._class === undefined;
+}
+
+/**
+ * Tries to fetch the scope entity from the job state.
+ * If the entity is not in the job state, returns {_key, _type} for mapper.
+ */
+export async function findOrBuildResourceEntityFromResourceId(
+  executionContext: IntegrationStepContext,
+  options: {
+    resourceId: string;
+    type?: string;
+    resourceIdMap?: ResourceIdMap[];
+  },
+): Promise<Entity | PlaceholderEntity> {
+  const { jobState } = executionContext;
+  const { resourceId, type, resourceIdMap } = options;
+  let targetEntity:
+    | Entity
+    | PlaceholderEntity
+    | null = await jobState.findEntity(resourceId);
+  if (targetEntity === null) {
+    targetEntity = {
+      _type:
+        getJupiterTypeForAzureType(type || 'NO_TYPE', resourceIdMap) ||
+        getJupiterTypeForResourceId(resourceId, resourceIdMap) ||
+        DEFAULT_RESOURCE_TYPE,
+      _key: resourceId,
+    };
+  }
+  return targetEntity;
+}
+
+export default findOrBuildResourceEntityFromResourceId;

--- a/src/steps/resource-manager/utils/matchers.ts
+++ b/src/steps/resource-manager/utils/matchers.ts
@@ -1,0 +1,5 @@
+export const EOL_MATCHER = '$';
+
+export const SUBSCRIPTION_MATCHER = '/subscriptions/[^/]+';
+export const RESOURCE_GROUP_MATCHER =
+  SUBSCRIPTION_MATCHER + '/resourceGroups/[^/]+';


### PR DESCRIPTION
The first couple commits are centralizing the `ROLE_ASSIGNMENT_SCOPE_TYPES_MAP` from the `authorization` steps into `RESOURCE_ID_TYPES_MAP`. That utility code can be used to identify any type and is super helpful in constructing direct relationships between resources.

The main change is in the final commit.