### PR TITLE
Use IntegrationValidationError in validation check

### DIFF
--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -1,7 +1,4 @@
-import {
-  IntegrationProviderAuthenticationError,
-  IntegrationValidationError,
-} from '@jupiterone/integration-sdk-core';
+import { IntegrationValidationError } from '@jupiterone/integration-sdk-core';
 import { createMockExecutionContext } from '@jupiterone/integration-sdk-testing';
 
 import { IntegrationConfig } from './types';
@@ -28,9 +25,11 @@ it('auth error', async () => {
     },
   });
 
-  try {
+  const exec = async () => {
     await validateInvocation(executionContext);
-  } catch (e) {
-    expect(e instanceof IntegrationProviderAuthenticationError).toBe(true);
-  }
+  };
+
+  await expect(exec).rejects.toThrow(
+    "Provider API failed at https://login.microsoftonline.com/INVALID/oauth2/v2.0/token: invalid_request AADSTS90002: Tenant 'invalid' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator.",
+  );
 });

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -1,7 +1,7 @@
 import {
   IntegrationExecutionContext,
-  IntegrationProviderAuthenticationError,
   IntegrationValidationError,
+  IntegrationError,
 } from '@jupiterone/integration-sdk-core';
 
 import { default as authenticateGraph } from './azure/graph/authenticate';
@@ -25,7 +25,10 @@ export default async function validateInvocation(
       await authenticateResourceManager(config);
     }
   } catch (err) {
-    validationContext.logger.error({ err });
-    throw new IntegrationProviderAuthenticationError(err);
+    if (!(err instanceof IntegrationError)) {
+      throw new IntegrationValidationError(err);
+    } else {
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
A little annoying issue - the reason we kept seeing `Provider authentication failed at undefined: undefined undefined` in the azure integration is we were re-throwing `IntegrationProviderAuthenticationError`s which are not idempotent. 

The constructor for `IntegrationProviderAuthenticationError` has the properties `cause`, `endpoint`, `status`, and `statusText`, but the class itself is a subclass of `IntegrationError` (which have the properties `message`, `code`, 'cause', and 'fatal').

It automatically generates an error message based on `Provider API failed at ${options.endpoint}: ${options.status} ${options.statusText}`. Since the Error itself has none of those properties, we (and the customer) is missing out on valuable error messages, and instead getting garbage.