### PR TITLE
Fix storage account relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to
 
 ### Removed
 
-- Removed mapped `role_assignment|allows|<scope>` relationships to avoid creating `azure_unknown_resource_type` entities
+- Removed mapped `role_assignment|allows|<scope>` relationships to avoid
+  creating `azure_unknown_resource_type` entities
 
 ### Changed
 
+- Created `azure_storage_account` entities to replace
+  `azure_storage_blob_service` and `azure_storage_file_service`
 - Upgraded SDK to v3.2.0, ordered entity/relationship docs
 
 ## 4.4.1 - 2020-09-02

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -86,7 +86,6 @@ The following entities are created:
 | [RM] Classic Admin          | `azure_classic_admin_group`   | `UserGroup`                     |
 | [RM] Cosmos DB Account      | `azure_cosmosdb_account`      | `Account`, `Service`            |
 | [RM] Cosmos DB Database     | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
-| [RM] File Storage Service   | `azure_storage_file_service`  | `Service`                       |
 | [RM] File Storage Share     | `azure_storage_share`         | `DataStore`                     |
 | [RM] Image                  | `azure_image`                 | `Image`                         |
 | [RM] Key Vault              | `azure_keyvault_service`      | `Service`                       |
@@ -118,8 +117,6 @@ The following relationships are created/mapped:
 | ---------------------------- | --------------------- | ------------------------------- |
 | `azure_account`              | **HAS**               | `azure_user_group`              |
 | `azure_account`              | **HAS**               | `azure_keyvault_service`        |
-| `azure_account`              | **HAS**               | `azure_storage_blob_service`    |
-| `azure_account`              | **HAS**               | `azure_storage_file_service`    |
 | `azure_account`              | **HAS**               | `azure_user`                    |
 | `azure_classic_admin_group`  | **HAS**               | `azure_user`                    |
 | `azure_cosmosdb_account`     | **HAS**               | `azure_cosmosdb_sql_database`   |
@@ -143,7 +140,6 @@ The following relationships are created/mapped:
 | `azure_resource_group`       | **HAS**               | `azure_security_group`          |
 | `azure_resource_group`       | **HAS**               | `azure_sql_server`              |
 | `azure_resource_group`       | **HAS**               | `azure_storage_blob_service`    |
-| `azure_resource_group`       | **HAS**               | `azure_storage_file_service`    |
 | `azure_resource_group`       | **HAS**               | `azure_vm`                      |
 | `azure_resource_group`       | **HAS**               | `azure_vnet`                    |
 | `azure_role_assignment`      | **ALLOWS**            | `azure_cosmosdb_account`        |
@@ -171,7 +167,7 @@ The following relationships are created/mapped:
 | `azure_security_group`       | **ALLOWS**            | `azure_subnet`                  |
 | `azure_sql_server`           | **HAS**               | `azure_sql_database`            |
 | `azure_storage_blob_service` | **HAS**               | `azure_storage_container`       |
-| `azure_storage_file_service` | **HAS**               | `azure_storage_share`           |
+| `azure_storage_blob_service` | **HAS**               | `azure_storage_share`           |
 | `azure_subnet`               | **HAS**               | `azure_vm`                      |
 | `azure_subscription`         | **HAS**               | `azure_resource_group`          |
 | `azure_vm`                   | **USES**              | `azure_managed_disk`            |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -73,107 +73,107 @@ https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources                   | Entity `_type`                | Entity `_class`                 |
-| --------------------------- | ----------------------------- | ------------------------------- |
-| [AD] Account                | `azure_account`               | `Account`                       |
-| [AD] Group                  | `azure_user_group`            | `UserGroup`                     |
-| [AD] Group Member           | `azure_group_member`          | `User`                          |
-| [AD] Service Principal      | `azure_service_principal`     | `Service`                       |
-| [AD] User                   | `azure_user`                  | `User`                          |
-| [RM] Azure Managed Disk     | `azure_managed_disk`          | `DataStore`, `Disk`             |
-| [RM] Blob Storage Container | `azure_storage_container`     | `DataStore`                     |
-| [RM] Blob Storage Service   | `azure_storage_blob_service`  | `Service`                       |
-| [RM] Classic Admin          | `azure_classic_admin_group`   | `UserGroup`                     |
-| [RM] Cosmos DB Account      | `azure_cosmosdb_account`      | `Account`, `Service`            |
-| [RM] Cosmos DB Database     | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
-| [RM] File Storage Share     | `azure_storage_share`         | `DataStore`                     |
-| [RM] Image                  | `azure_image`                 | `Image`                         |
-| [RM] Key Vault              | `azure_keyvault_service`      | `Service`                       |
-| [RM] Load Balancer          | `azure_lb`                    | `Gateway`                       |
-| [RM] MariaDB Database       | `azure_mariadb_database`      | `Database`, `DataStore`         |
-| [RM] MariaDB Server         | `azure_mariadb_server`        | `Database`, `DataStore`, `Host` |
-| [RM] MySQL Database         | `azure_mysql_database`        | `Database`, `DataStore`         |
-| [RM] MySQL Server           | `azure_mysql_server`          | `Database`, `DataStore`, `Host` |
-| [RM] Network Interface      | `azure_nic`                   | `NetworkInterface`              |
-| [RM] PostgreSQL Database    | `azure_postgresql_database`   | `Database`, `DataStore`         |
-| [RM] PostgreSQL Server      | `azure_postgresql_server`     | `Database`, `DataStore`, `Host` |
-| [RM] Public IP Address      | `azure_public_ip`             | `IpAddress`                     |
-| [RM] Resource Group         | `azure_resource_group`        | `Group`                         |
-| [RM] Role Assignment        | `azure_role_assignment`       | `AccessPolicy`                  |
-| [RM] Role Definition        | `azure_role_definition`       | `AccessRole`                    |
-| [RM] SQL Database           | `azure_sql_database`          | `Database`, `DataStore`         |
-| [RM] SQL Server             | `azure_sql_server`            | `Database`, `DataStore`, `Host` |
-| [RM] Security Group         | `azure_security_group`        | `Firewall`                      |
-| [RM] Subnet                 | `azure_subnet`                | `Network`                       |
-| [RM] Subscription           | `azure_subscription`          | `Account`                       |
-| [RM] Virtual Machine        | `azure_vm`                    | `Host`                          |
-| [RM] Virtual Network        | `azure_vnet`                  | `Network`                       |
+| Resources                | Entity `_type`                | Entity `_class`                 |
+| ------------------------ | ----------------------------- | ------------------------------- |
+| [AD] Account             | `azure_account`               | `Account`                       |
+| [AD] Group               | `azure_user_group`            | `UserGroup`                     |
+| [AD] Group Member        | `azure_group_member`          | `User`                          |
+| [AD] Service Principal   | `azure_service_principal`     | `Service`                       |
+| [AD] User                | `azure_user`                  | `User`                          |
+| [RM] Azure Managed Disk  | `azure_managed_disk`          | `DataStore`, `Disk`             |
+| [RM] Classic Admin       | `azure_classic_admin_group`   | `UserGroup`                     |
+| [RM] Cosmos DB Account   | `azure_cosmosdb_account`      | `Account`, `Service`            |
+| [RM] Cosmos DB Database  | `azure_cosmosdb_sql_database` | `Database`, `DataStore`         |
+| [RM] Image               | `azure_image`                 | `Image`                         |
+| [RM] Key Vault           | `azure_keyvault_service`      | `Service`                       |
+| [RM] Load Balancer       | `azure_lb`                    | `Gateway`                       |
+| [RM] MariaDB Database    | `azure_mariadb_database`      | `Database`, `DataStore`         |
+| [RM] MariaDB Server      | `azure_mariadb_server`        | `Database`, `DataStore`, `Host` |
+| [RM] MySQL Database      | `azure_mysql_database`        | `Database`, `DataStore`         |
+| [RM] MySQL Server        | `azure_mysql_server`          | `Database`, `DataStore`, `Host` |
+| [RM] Network Interface   | `azure_nic`                   | `NetworkInterface`              |
+| [RM] PostgreSQL Database | `azure_postgresql_database`   | `Database`, `DataStore`         |
+| [RM] PostgreSQL Server   | `azure_postgresql_server`     | `Database`, `DataStore`, `Host` |
+| [RM] Public IP Address   | `azure_public_ip`             | `IpAddress`                     |
+| [RM] Resource Group      | `azure_resource_group`        | `Group`                         |
+| [RM] Role Assignment     | `azure_role_assignment`       | `AccessPolicy`                  |
+| [RM] Role Definition     | `azure_role_definition`       | `AccessRole`                    |
+| [RM] SQL Database        | `azure_sql_database`          | `Database`, `DataStore`         |
+| [RM] SQL Server          | `azure_sql_server`            | `Database`, `DataStore`, `Host` |
+| [RM] Security Group      | `azure_security_group`        | `Firewall`                      |
+| [RM] Storage Account     | `azure_storage_account`       | `Service`                       |
+| [RM] Storage Container   | `azure_storage_container`     | `DataStore`                     |
+| [RM] Storage File Share  | `azure_storage_file_share`    | `DataStore`                     |
+| [RM] Subnet              | `azure_subnet`                | `Network`                       |
+| [RM] Subscription        | `azure_subscription`          | `Account`                       |
+| [RM] Virtual Machine     | `azure_vm`                    | `Host`                          |
+| [RM] Virtual Network     | `azure_vnet`                  | `Network`                       |
 
 ### Relationships
 
 The following relationships are created/mapped:
 
-| Source Entity `_type`        | Relationship `_class` | Target Entity `_type`           |
-| ---------------------------- | --------------------- | ------------------------------- |
-| `azure_account`              | **HAS**               | `azure_user_group`              |
-| `azure_account`              | **HAS**               | `azure_keyvault_service`        |
-| `azure_account`              | **HAS**               | `azure_user`                    |
-| `azure_classic_admin_group`  | **HAS**               | `azure_user`                    |
-| `azure_cosmosdb_account`     | **HAS**               | `azure_cosmosdb_sql_database`   |
-| `azure_user_group`           | **HAS**               | `azure_user_group`              |
-| `azure_user_group`           | **HAS**               | `azure_group_member`            |
-| `azure_user_group`           | **HAS**               | `azure_user`                    |
-| `azure_lb`                   | **CONNECTS**          | `azure_nic`                     |
-| `azure_mariadb_server`       | **HAS**               | `azure_mariadb_database`        |
-| `azure_mysql_server`         | **HAS**               | `azure_mysql_database`          |
-| `azure_postgresql_server`    | **HAS**               | `azure_postgresql_database`     |
-| `azure_resource_group`       | **HAS**               | `azure_cosmosdb_account`        |
-| `azure_resource_group`       | **HAS**               | `azure_image`                   |
-| `azure_resource_group`       | **HAS**               | `azure_keyvault_service`        |
-| `azure_resource_group`       | **HAS**               | `azure_lb`                      |
-| `azure_resource_group`       | **HAS**               | `azure_managed_disk`            |
-| `azure_resource_group`       | **HAS**               | `azure_mariadb_server`          |
-| `azure_resource_group`       | **HAS**               | `azure_mysql_server`            |
-| `azure_resource_group`       | **HAS**               | `azure_nic`                     |
-| `azure_resource_group`       | **HAS**               | `azure_postgresql_server`       |
-| `azure_resource_group`       | **HAS**               | `azure_public_ip`               |
-| `azure_resource_group`       | **HAS**               | `azure_security_group`          |
-| `azure_resource_group`       | **HAS**               | `azure_sql_server`              |
-| `azure_resource_group`       | **HAS**               | `azure_storage_blob_service`    |
-| `azure_resource_group`       | **HAS**               | `azure_vm`                      |
-| `azure_resource_group`       | **HAS**               | `azure_vnet`                    |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_cosmosdb_account`        |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_keyvault_service`        |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_nic`                     |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_public_ip`               |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_resource_group`          |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_security_group`          |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_subscription`            |
-| `azure_role_assignment`      | **ALLOWS**            | `azure_vnet`                    |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_application`             |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_directory`               |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_directory_role_template` |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_everyone`                |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_foreign_group`           |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_msi`                     |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_service_principal`       |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_unknown`                 |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_unknown_principal_type`  |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_user`                    |
-| `azure_role_assignment`      | **ASSIGNED**          | `azure_user_group`              |
-| `azure_role_assignment`      | **USES**              | `azure_role_definition`         |
-| `azure_security_group`       | **PROTECTS**          | `azure_nic`                     |
-| `azure_security_group`       | **PROTECTS**          | `azure_subnet`                  |
-| `azure_security_group`       | **ALLOWS**            | `azure_subnet`                  |
-| `azure_sql_server`           | **HAS**               | `azure_sql_database`            |
-| `azure_storage_blob_service` | **HAS**               | `azure_storage_container`       |
-| `azure_storage_blob_service` | **HAS**               | `azure_storage_share`           |
-| `azure_subnet`               | **HAS**               | `azure_vm`                      |
-| `azure_subscription`         | **HAS**               | `azure_resource_group`          |
-| `azure_vm`                   | **USES**              | `azure_managed_disk`            |
-| `azure_vm`                   | **USES**              | `azure_nic`                     |
-| `azure_vm`                   | **USES**              | `azure_public_ip`               |
-| `azure_vnet`                 | **CONTAINS**          | `azure_subnet`                  |
+| Source Entity `_type`       | Relationship `_class` | Target Entity `_type`           |
+| --------------------------- | --------------------- | ------------------------------- |
+| `azure_account`             | **HAS**               | `azure_user_group`              |
+| `azure_account`             | **HAS**               | `azure_keyvault_service`        |
+| `azure_account`             | **HAS**               | `azure_user`                    |
+| `azure_classic_admin_group` | **HAS**               | `azure_user`                    |
+| `azure_cosmosdb_account`    | **HAS**               | `azure_cosmosdb_sql_database`   |
+| `azure_user_group`          | **HAS**               | `azure_user_group`              |
+| `azure_user_group`          | **HAS**               | `azure_group_member`            |
+| `azure_user_group`          | **HAS**               | `azure_user`                    |
+| `azure_lb`                  | **CONNECTS**          | `azure_nic`                     |
+| `azure_mariadb_server`      | **HAS**               | `azure_mariadb_database`        |
+| `azure_mysql_server`        | **HAS**               | `azure_mysql_database`          |
+| `azure_postgresql_server`   | **HAS**               | `azure_postgresql_database`     |
+| `azure_resource_group`      | **HAS**               | `azure_cosmosdb_account`        |
+| `azure_resource_group`      | **HAS**               | `azure_image`                   |
+| `azure_resource_group`      | **HAS**               | `azure_keyvault_service`        |
+| `azure_resource_group`      | **HAS**               | `azure_lb`                      |
+| `azure_resource_group`      | **HAS**               | `azure_managed_disk`            |
+| `azure_resource_group`      | **HAS**               | `azure_mariadb_server`          |
+| `azure_resource_group`      | **HAS**               | `azure_mysql_server`            |
+| `azure_resource_group`      | **HAS**               | `azure_nic`                     |
+| `azure_resource_group`      | **HAS**               | `azure_postgresql_server`       |
+| `azure_resource_group`      | **HAS**               | `azure_public_ip`               |
+| `azure_resource_group`      | **HAS**               | `azure_security_group`          |
+| `azure_resource_group`      | **HAS**               | `azure_sql_server`              |
+| `azure_resource_group`      | **HAS**               | `azure_storage_account`         |
+| `azure_resource_group`      | **HAS**               | `azure_vm`                      |
+| `azure_resource_group`      | **HAS**               | `azure_vnet`                    |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_cosmosdb_account`        |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_keyvault_service`        |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_nic`                     |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_public_ip`               |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_resource_group`          |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_security_group`          |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_subscription`            |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_vnet`                    |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_application`             |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_directory`               |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_directory_role_template` |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_everyone`                |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_foreign_group`           |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_msi`                     |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_service_principal`       |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_unknown`                 |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_unknown_principal_type`  |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_user`                    |
+| `azure_role_assignment`     | **ASSIGNED**          | `azure_user_group`              |
+| `azure_role_assignment`     | **USES**              | `azure_role_definition`         |
+| `azure_security_group`      | **PROTECTS**          | `azure_nic`                     |
+| `azure_security_group`      | **PROTECTS**          | `azure_subnet`                  |
+| `azure_security_group`      | **ALLOWS**            | `azure_subnet`                  |
+| `azure_sql_server`          | **HAS**               | `azure_sql_database`            |
+| `azure_storage_account`     | **HAS**               | `azure_storage_container`       |
+| `azure_storage_account`     | **HAS**               | `azure_storage_file_share`      |
+| `azure_subnet`              | **HAS**               | `azure_vm`                      |
+| `azure_subscription`        | **HAS**               | `azure_resource_group`          |
+| `azure_vm`                  | **USES**              | `azure_managed_disk`            |
+| `azure_vm`                  | **USES**              | `azure_nic`                     |
+| `azure_vm`                  | **USES**              | `azure_public_ip`               |
+| `azure_vnet`                | **CONTAINS**          | `azure_subnet`                  |
 
 <!--
 ********************************************************************************

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -148,6 +148,7 @@ The following relationships are created/mapped:
 | `azure_role_assignment`     | **ALLOWS**            | `azure_public_ip`               |
 | `azure_role_assignment`     | **ALLOWS**            | `azure_resource_group`          |
 | `azure_role_assignment`     | **ALLOWS**            | `azure_security_group`          |
+| `azure_role_assignment`     | **ALLOWS**            | `azure_storage_account`         |
 | `azure_role_assignment`     | **ALLOWS**            | `azure_subscription`            |
 | `azure_role_assignment`     | **ALLOWS**            | `azure_vnet`                    |
 | `azure_role_assignment`     | **ASSIGNED**          | `azure_application`             |

--- a/src/steps/resource-manager/storage/constants.ts
+++ b/src/steps/resource-manager/storage/constants.ts
@@ -7,16 +7,22 @@ import {
 export const STEP_RM_STORAGE_RESOURCES = 'rm-storage-resources';
 
 // Graph objects
+/**
+ * azure_storage_account --HAS--> (azure_storage_container | azure_storage_queue | azure_storage_file_share | azure_storage_table)
+ * azure_storage_container --HAS--> azure_storage_blob
+ * azure_storage_file_share --HAS--> azure_storage_file_share_directory
+ * azure_storage_table --HAS--> azure_storage_table_entity
+ */
 export const STORAGE_ACCOUNT_ENTITY_METADATA = {
-  _type: 'azure_storage_blob_service',
+  _type: 'azure_storage_account',
   _class: ['Service'],
-  resourceName: '[RM] Blob Storage Service',
+  resourceName: '[RM] Storage Account',
 };
 
 export const STORAGE_CONTAINER_ENTITY_METADATA = {
   _type: 'azure_storage_container',
   _class: ['DataStore'],
-  resourceName: '[RM] Blob Storage Container',
+  resourceName: '[RM] Storage Container',
 };
 
 export const STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_CLASS =
@@ -33,9 +39,9 @@ export const STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_METADATA = {
 };
 
 export const STORAGE_FILE_SHARE_ENTITY_METADATA = {
-  _type: 'azure_storage_share',
+  _type: 'azure_storage_file_share',
   _class: ['DataStore'],
-  resourceName: '[RM] File Storage Share',
+  resourceName: '[RM] Storage File Share',
 };
 
 export const STORAGE_ACCOUNT_FILE_SHARE_RELATIONSHIP_CLASS =

--- a/src/steps/resource-manager/storage/constants.ts
+++ b/src/steps/resource-manager/storage/constants.ts
@@ -3,68 +3,50 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
-
 // Step IDs
 export const STEP_RM_STORAGE_RESOURCES = 'rm-storage-resources';
 
 // Graph objects
-export const STORAGE_BLOB_SERVICE_ENTITY_TYPE = 'azure_storage_blob_service';
-export const STORAGE_BLOB_SERVICE_ENTITY_CLASS = 'Service';
+export const STORAGE_ACCOUNT_ENTITY_METADATA = {
+  _type: 'azure_storage_blob_service',
+  _class: ['Service'],
+  resourceName: '[RM] Blob Storage Service',
+};
 
-export const ACCOUNT_STORAGE_BLOB_SERVICE_RELATIONSHIP_CLASS =
+export const STORAGE_CONTAINER_ENTITY_METADATA = {
+  _type: 'azure_storage_container',
+  _class: ['DataStore'],
+  resourceName: '[RM] Blob Storage Container',
+};
+
+export const STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_CLASS =
   RelationshipClass.HAS;
-export const ACCOUNT_STORAGE_BLOB_SERVICE_RELATIONSHIP_TYPE = generateRelationshipType(
-  ACCOUNT_STORAGE_BLOB_SERVICE_RELATIONSHIP_CLASS,
-  ACCOUNT_ENTITY_TYPE,
-  STORAGE_BLOB_SERVICE_ENTITY_TYPE,
-);
+export const STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_METADATA = {
+  _type: generateRelationshipType(
+    STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_CLASS,
+    STORAGE_ACCOUNT_ENTITY_METADATA._type,
+    STORAGE_CONTAINER_ENTITY_METADATA._type,
+  ),
+  sourceType: STORAGE_ACCOUNT_ENTITY_METADATA._type,
+  _class: STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_CLASS,
+  targetType: STORAGE_CONTAINER_ENTITY_METADATA._type,
+};
 
-export const STORAGE_CONTAINER_ENTITY_TYPE = 'azure_storage_container';
-export const STORAGE_CONTAINER_ENTITY_CLASS = 'DataStore';
+export const STORAGE_FILE_SHARE_ENTITY_METADATA = {
+  _type: 'azure_storage_share',
+  _class: ['DataStore'],
+  resourceName: '[RM] File Storage Share',
+};
 
-export const STORAGE_BLOB_SERVICE_CONTAINER_RELATIONSHIP_CLASS =
+export const STORAGE_ACCOUNT_FILE_SHARE_RELATIONSHIP_CLASS =
   RelationshipClass.HAS;
-export const STORAGE_BLOB_SERVICE_CONTAINER_RELATIONSHIP_TYPE = generateRelationshipType(
-  STORAGE_BLOB_SERVICE_CONTAINER_RELATIONSHIP_CLASS,
-  STORAGE_BLOB_SERVICE_ENTITY_TYPE,
-  STORAGE_CONTAINER_ENTITY_TYPE,
-);
-
-export const STORAGE_FILE_SERVICE_ENTITY_TYPE = 'azure_storage_file_service';
-export const STORAGE_FILE_SERVICE_ENTITY_CLASS = 'Service';
-
-export const ACCOUNT_STORAGE_FILE_SERVICE_RELATIONSHIP_CLASS =
-  RelationshipClass.HAS;
-export const ACCOUNT_STORAGE_FILE_SERVICE_RELATIONSHIP_TYPE = generateRelationshipType(
-  ACCOUNT_STORAGE_FILE_SERVICE_RELATIONSHIP_CLASS,
-  ACCOUNT_ENTITY_TYPE,
-  STORAGE_FILE_SERVICE_ENTITY_TYPE,
-);
-
-export const STORAGE_FILE_SHARE_ENTITY_TYPE = 'azure_storage_share';
-export const STORAGE_FILE_SHARE_ENTITY_CLASS = 'DataStore';
-
-export const STORAGE_FILE_SERVICE_SHARE_RELATIONSHIP_CLASS =
-  RelationshipClass.HAS;
-export const STORAGE_FILE_SERVICE_SHARE_RELATIONSHIP_TYPE = generateRelationshipType(
-  STORAGE_FILE_SERVICE_SHARE_RELATIONSHIP_CLASS,
-  STORAGE_FILE_SERVICE_ENTITY_TYPE,
-  STORAGE_FILE_SHARE_ENTITY_TYPE,
-);
-
-export const STORAGE_QUEUE_SERVICE_ENTITY_TYPE = 'azure_storage_queue_service';
-export const STORAGE_QUEUE_SERVICE_ENTITY_CLASS = 'Service';
-export const ACCOUNT_STORAGE_QUEUE_SERVICE_RELATIONSHIP_TYPE = generateRelationshipType(
-  RelationshipClass.HAS,
-  ACCOUNT_ENTITY_TYPE,
-  STORAGE_QUEUE_SERVICE_ENTITY_TYPE,
-);
-
-export const STORAGE_TABLE_SERVICE_ENTITY_TYPE = 'azure_storage_table_service';
-export const STORAGE_TABLE_SERVICE_ENTITY_CLASS = 'Service';
-export const ACCOUNT_STORAGE_TABLE_SERVICE_RELATIONSHIP_TYPE = generateRelationshipType(
-  RelationshipClass.HAS,
-  ACCOUNT_ENTITY_TYPE,
-  STORAGE_TABLE_SERVICE_ENTITY_TYPE,
-);
+export const STORAGE_ACCOUNT_FILE_SHARE_RELATIONSHIP_METADATA = {
+  _type: generateRelationshipType(
+    STORAGE_ACCOUNT_FILE_SHARE_RELATIONSHIP_CLASS,
+    STORAGE_ACCOUNT_ENTITY_METADATA._type,
+    STORAGE_FILE_SHARE_ENTITY_METADATA._type,
+  ),
+  sourceType: STORAGE_ACCOUNT_ENTITY_METADATA._type,
+  _class: STORAGE_ACCOUNT_FILE_SHARE_RELATIONSHIP_CLASS,
+  targetType: STORAGE_FILE_SHARE_ENTITY_METADATA._type,
+};

--- a/src/steps/resource-manager/storage/converters.test.ts
+++ b/src/steps/resource-manager/storage/converters.test.ts
@@ -8,7 +8,7 @@ import { createAzureWebLinker } from '../../../azure';
 import {
   createStorageContainerEntity,
   createStorageFileShareEntity,
-  createStorageServiceEntity,
+  createStorageAccountEntity,
 } from './converters';
 
 const webLinker = createAzureWebLinker('something.onmicrosoft.com');
@@ -55,95 +55,39 @@ describe('createStorageAccountEntity Storage (Classic)', () => {
     statusOfPrimary: 'available',
   };
 
-  test('properties transferred blob', () => {
+  test('properties transferred', () => {
     const entity = {
       _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#blob',
-      _type: 'azure_storage_blob_service',
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
+      _type: 'azure_storage_account',
       _class: ['Service'],
       _rawData: [{ name: 'default', rawData: data }],
       id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
       name: 'j1dev',
-      displayName: 'j1dev (blob)',
+      displayName: 'j1dev',
       region: 'eastus',
       environment: 'j1dev',
+      encryptedBlob: true,
+      encryptedFileShare: true,
       webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/containersList',
-      ),
-      kind: 'Storage',
-      sku: 'Standard_LRS',
-      resourceGroup: 'j1dev',
-      category: ['infrastructure'],
-      endpoints: ['https://j1dev.blob.core.windows.net/'],
-      createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
-      encrypted: true,
-      'tag.environment': 'j1dev',
-    };
-
-    expect(createStorageServiceEntity(webLinker, data, 'blob')).toEqual(entity);
-  });
-
-  test('properties transferred queue', () => {
-    const entity = {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#queue',
-      _type: 'azure_storage_queue_service',
-      _class: ['Service'],
-      _rawData: [{ name: 'default', rawData: data }],
-      id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
-      name: 'j1dev',
-      displayName: 'j1dev (queue)',
-      region: 'eastus',
-      environment: 'j1dev',
-      webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/queueList',
       ),
       kind: 'Storage',
       sku: 'Standard_LRS',
       resourceGroup: 'j1dev',
       category: ['infrastructure'],
-      endpoints: ['https://j1dev.queue.core.windows.net/'],
+      endpoints: [
+        'https://j1dev.blob.core.windows.net/',
+        'https://j1dev.queue.core.windows.net/',
+        'https://j1dev.table.core.windows.net/',
+        'https://j1dev.file.core.windows.net/',
+      ],
       createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
-      encrypted: false,
       'tag.environment': 'j1dev',
     };
 
-    expect(createStorageServiceEntity(webLinker, data, 'queue')).toEqual(
-      entity,
-    );
-  });
-
-  test('properties transferred table', () => {
-    const entity = {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#table',
-      _type: 'azure_storage_table_service',
-      _class: ['Service'],
-      _rawData: [{ name: 'default', rawData: data }],
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
-      name: 'j1dev',
-      displayName: 'j1dev (table)',
-      region: 'eastus',
-      environment: 'j1dev',
-      webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/tableList',
-      ),
-      kind: 'Storage',
-      sku: 'Standard_LRS',
-      resourceGroup: 'j1dev',
-      category: ['infrastructure'],
-      endpoints: ['https://j1dev.table.core.windows.net/'],
-      createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
-      encrypted: false,
-      'tag.environment': 'j1dev',
-    };
-
-    expect(createStorageServiceEntity(webLinker, data, 'table')).toEqual(
-      entity,
-    );
+    expect(createStorageAccountEntity(webLinker, data)).toEqual(entity);
   });
 });
 
@@ -201,62 +145,41 @@ describe('createStorageAccountEntity StorageV2', () => {
     statusOfPrimary: 'available',
   };
 
-  test('properties transferred blob', () => {
+  test('properties transferred', () => {
     const entity = {
       _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#blob',
-      _type: 'azure_storage_blob_service',
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
+      _type: 'azure_storage_account',
       _class: ['Service'],
       _rawData: [{ name: 'default', rawData: data }],
       id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
       name: 'j1dev',
-      displayName: 'j1dev (blob)',
+      displayName: 'j1dev',
       region: 'eastus',
       environment: 'j1dev',
+      encryptedBlob: true,
+      encryptedFileShare: true,
       webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/containersList',
-      ),
-      kind: 'StorageV2',
-      sku: 'Standard_LRS',
-      resourceGroup: 'j1dev',
-      category: ['infrastructure'],
-      endpoints: ['https://j1dev.blob.core.windows.net/'],
-      createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
-      encrypted: true,
-      'tag.environment': 'j1dev',
-    };
-
-    expect(createStorageServiceEntity(webLinker, data, 'blob')).toEqual(entity);
-  });
-
-  test('properties transferred file V2', () => {
-    const entity = {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev#file',
-      _type: 'azure_storage_file_service',
-      _class: ['Service'],
-      _rawData: [{ name: 'default', rawData: data }],
-      id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev',
-      name: 'j1dev',
-      displayName: 'j1dev (file)',
-      region: 'eastus',
-      environment: 'j1dev',
-      webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/fileList',
       ),
       kind: 'StorageV2',
       sku: 'Standard_LRS',
       resourceGroup: 'j1dev',
       category: ['infrastructure'],
-      endpoints: ['https://j1dev.file.core.windows.net/'],
+      endpoints: [
+        'https://j1dev.dfs.core.windows.net/',
+        'https://j1dev.z13.web.core.windows.net/',
+        'https://j1dev.blob.core.windows.net/',
+        'https://j1dev.queue.core.windows.net/',
+        'https://j1dev.table.core.windows.net/',
+        'https://j1dev.file.core.windows.net/',
+      ],
       createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
-      encrypted: true,
       'tag.environment': 'j1dev',
     };
 
-    expect(createStorageServiceEntity(webLinker, data, 'file')).toEqual(entity);
+    expect(createStorageAccountEntity(webLinker, data)).toEqual(entity);
   });
 });
 
@@ -314,31 +237,36 @@ describe('createStorageAccountEntity BlobStorage', () => {
   test('properties transferred', () => {
     const entity = {
       _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1devblobstorage#blob',
-      _type: 'azure_storage_blob_service',
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1devblobstorage',
+      _type: 'azure_storage_account',
       _class: ['Service'],
       _rawData: [{ name: 'default', rawData: data }],
       id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1devblobstorage',
       name: 'j1devblobstorage',
-      displayName: 'j1devblobstorage (blob)',
+      displayName: 'j1devblobstorage',
       region: 'eastus',
       environment: 'j1dev',
+      encryptedBlob: true,
+      encryptedFileShare: true,
       webLink: webLinker.portalResourceUrl(
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1devblobstorage/containersList',
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1devblobstorage',
       ),
       kind: 'BlobStorage',
       sku: 'Standard_LRS',
       resourceGroup: 'j1dev',
       category: ['infrastructure'],
-      endpoints: ['https://j1devblobstorage.blob.core.windows.net/'],
+      endpoints: [
+        'https://j1devblobstorage.blob.core.windows.net/',
+        'https://j1devblobstorage.dfs.core.windows.net/',
+        'https://j1devblobstorage.table.core.windows.net/',
+      ],
       createdOn: new Date('2020-04-17T13:22:05.030Z').getTime(),
       enableHttpsTrafficOnly: true,
-      encrypted: true,
       'tag.environment': 'j1dev',
     };
 
-    expect(createStorageServiceEntity(webLinker, data, 'blob')).toEqual(entity);
+    expect(createStorageAccountEntity(webLinker, data)).toEqual(entity);
   });
 });
 

--- a/src/steps/resource-manager/storage/converters.test.ts
+++ b/src/steps/resource-manager/storage/converters.test.ts
@@ -483,7 +483,7 @@ describe('createStorageFileShareEntity', () => {
   const entity = {
     _key:
       '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/j1dev/fileServices/default/shares/j1dev',
-    _type: 'azure_storage_share',
+    _type: 'azure_storage_file_share',
     _class: ['DataStore'],
     _rawData: [{ name: 'default', rawData: data }],
     createdOn: undefined,

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
@@ -19,6 +19,10 @@ import {
   STEP_RM_COSMOSDB_SQL_DATABASES,
 } from '../cosmosdb';
 import { RESOURCE_GROUP_MATCHER, EOL_MATCHER } from './matchers';
+import {
+  STORAGE_ACCOUNT_ENTITY_METADATA,
+  STEP_RM_STORAGE_RESOURCES,
+} from '../storage';
 
 export interface ResourceIdMap {
   resourceIdMatcher: RegExp;
@@ -82,6 +86,15 @@ export const RESOURCE_ID_TYPES_MAP: ResourceIdMap[] = [
     ),
     _type: RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
     dependsOn: [STEP_RM_COSMOSDB_SQL_DATABASES],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.Storage/storageAccounts/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: STORAGE_ACCOUNT_ENTITY_METADATA._type,
+    dependsOn: [STEP_RM_STORAGE_RESOURCES],
   },
 ];
 


### PR DESCRIPTION
Storage accounts have direct relationships to **Blobs**, **File Shares**, **Queues**, **Tables** and in some cases **Data Lakes** or other storage services. 

A storage account has a **Kind** property which can limit the types of storage services that can exist within a storage account,  including **Storage**, **BlobStorage,** **StorageV2**, and others. 

Previously, a storage account that had some **Blobs** and some **File Shares** would create two entities to represent the storage account. This PR creates a single `azure_storage_account` entity per storage account, and links the storage account to the `azure_resource_group` associated with the storage account.

Old graph:
<img width="829" alt="Screen Shot 2020-09-02 at 5 10 23 PM" src="https://user-images.githubusercontent.com/15333061/92037082-3ec45c00-ed3f-11ea-8d3b-0d1c5ea54602.png">


New Graph:
<img width="829" alt="Screen Shot 2020-09-02 at 5 08 47 PM" src="https://user-images.githubusercontent.com/15333061/92036923-f86efd00-ed3e-11ea-91dc-1fc9152d0eb0.png">