### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.0.0 - 2020-09-04
+
 ### Added
 
 - Added `azure_storage_table` entities
@@ -23,7 +25,9 @@ and this project adheres to
 ### Changed
 
 - Created `azure_storage_account` entities to replace
-  `azure_storage_blob_service` and `azure_storage_file_service`
+  `azure_storage_blob_service` and `azure_storage_file_service`. NOTE: This
+  change requires any existing queries using the `azure_storage_blob_service` or
+  `azure_storage_file_service` `_type` to use `azure_storage_account`.
 - Upgraded SDK to v3.2.0, ordered entity/relationship docs
 
 ## 4.4.1 - 2020-09-02

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "4.4.1",
+  "version": "5.0.0",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
I would like to release the following changes before the weekend. I'm considering this a major bump since it could break some existing queries. 

There are currently no saved queries related to either `azure_storage_file_service` or `azure_storage_blob_service`. [Prove it, Terry!](https://bitbucket.org/jupiterone/jupiter-integration-azure/src/master/deploy/terraform/data/questions.yaml)

```

### Added

- Added `azure_storage_table` entities
- Added `azure_storage_account|has|azure_storage_table` relationships
- Added `azure_storage_queue` entities
- Added `azure_storage_account|has|azure_storage_queue` relationships

### Removed

- Removed mapped `role_assignment|allows|<scope>` relationships to avoid
  creating `azure_unknown_resource_type` entities

### Changed

- Created `azure_storage_account` entities to replace
  `azure_storage_blob_service` and `azure_storage_file_service`. NOTE: This
  change requires any existing queries using the `azure_storage_blob_service` or
  `azure_storage_file_service` `_type` to use `azure_storage_account`.
- Upgraded SDK to v3.2.0, ordered entity/relationship docs

```