### PR TITLE
Add container registry resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to
 - Added `azure_resource_group|has|azure_private_dns_zone` relationships
 - Added `azure_private_dns_record_set` entities
 - Added `azure_private_dns_zone|has|azure_private_dns_record_set` relationships
+- Added `azure_container_registry` entities
+- Added `azure_resource_group|has|azure_container_registry` relationships
+- Added `azure_container_registry_webhook` entities
+- Added `azure_container_registry|has|azure_container_registry_webhook`
+  relationships
 
 ## 5.1.0 - 2020-09-09
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -73,127 +73,132 @@ https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources                   | Entity `_type`                 | Entity `_class`                 |
-| --------------------------- | ------------------------------ | ------------------------------- |
-| [AD] Account                | `azure_account`                | `Account`                       |
-| [AD] Group                  | `azure_user_group`             | `UserGroup`                     |
-| [AD] Group Member           | `azure_group_member`           | `User`                          |
-| [AD] Service Principal      | `azure_service_principal`      | `Service`                       |
-| [AD] User                   | `azure_user`                   | `User`                          |
-| [RM] API Management API     | `azure_api_management_api`     | `ApplicationEndpoint`           |
-| [RM] API Management Service | `azure_api_management_service` | `Gateway`                       |
-| [RM] Azure Managed Disk     | `azure_managed_disk`           | `DataStore`, `Disk`             |
-| [RM] Classic Admin          | `azure_classic_admin_group`    | `UserGroup`                     |
-| [RM] Cosmos DB Account      | `azure_cosmosdb_account`       | `Account`, `Service`            |
-| [RM] Cosmos DB Database     | `azure_cosmosdb_sql_database`  | `Database`, `DataStore`         |
-| [RM] DNS Record Set         | `azure_dns_record_set`         | `DomainRecord`                  |
-| [RM] DNS Zone               | `azure_dns_zone`               | `DomainZone`                    |
-| [RM] Image                  | `azure_image`                  | `Image`                         |
-| [RM] Key Vault              | `azure_keyvault_service`       | `Service`                       |
-| [RM] Load Balancer          | `azure_lb`                     | `Gateway`                       |
-| [RM] MariaDB Database       | `azure_mariadb_database`       | `Database`, `DataStore`         |
-| [RM] MariaDB Server         | `azure_mariadb_server`         | `Database`, `DataStore`, `Host` |
-| [RM] MySQL Database         | `azure_mysql_database`         | `Database`, `DataStore`         |
-| [RM] MySQL Server           | `azure_mysql_server`           | `Database`, `DataStore`, `Host` |
-| [RM] Network Interface      | `azure_nic`                    | `NetworkInterface`              |
-| [RM] PostgreSQL Database    | `azure_postgresql_database`    | `Database`, `DataStore`         |
-| [RM] PostgreSQL Server      | `azure_postgresql_server`      | `Database`, `DataStore`, `Host` |
-| [RM] Private DNS Record Set | `azure_private_dns_record_set` | `DomainRecord`                  |
-| [RM] Private DNS Zone       | `azure_private_dns_zone`       | `DomainZone`                    |
-| [RM] Public IP Address      | `azure_public_ip`              | `IpAddress`                     |
-| [RM] Resource Group         | `azure_resource_group`         | `Group`                         |
-| [RM] Role Assignment        | `azure_role_assignment`        | `AccessPolicy`                  |
-| [RM] Role Definition        | `azure_role_definition`        | `AccessRole`                    |
-| [RM] SQL Database           | `azure_sql_database`           | `Database`, `DataStore`         |
-| [RM] SQL Server             | `azure_sql_server`             | `Database`, `DataStore`, `Host` |
-| [RM] Security Group         | `azure_security_group`         | `Firewall`                      |
-| [RM] Storage Account        | `azure_storage_account`        | `Service`                       |
-| [RM] Storage Container      | `azure_storage_container`      | `DataStore`                     |
-| [RM] Storage File Share     | `azure_storage_file_share`     | `DataStore`                     |
-| [RM] Storage Queue          | `azure_storage_queue`          | `Queue`                         |
-| [RM] Storage Table          | `azure_storage_table`          | `DataStore`, `Database`         |
-| [RM] Subnet                 | `azure_subnet`                 | `Network`                       |
-| [RM] Subscription           | `azure_subscription`           | `Account`                       |
-| [RM] Virtual Machine        | `azure_vm`                     | `Host`                          |
-| [RM] Virtual Network        | `azure_vnet`                   | `Network`                       |
+| Resources                       | Entity `_type`                     | Entity `_class`                 |
+| ------------------------------- | ---------------------------------- | ------------------------------- |
+| [AD] Account                    | `azure_account`                    | `Account`                       |
+| [AD] Group                      | `azure_user_group`                 | `UserGroup`                     |
+| [AD] Group Member               | `azure_group_member`               | `User`                          |
+| [AD] Service Principal          | `azure_service_principal`          | `Service`                       |
+| [AD] User                       | `azure_user`                       | `User`                          |
+| [RM] API Management API         | `azure_api_management_api`         | `ApplicationEndpoint`           |
+| [RM] API Management Service     | `azure_api_management_service`     | `Gateway`                       |
+| [RM] Azure Managed Disk         | `azure_managed_disk`               | `DataStore`, `Disk`             |
+| [RM] Classic Admin              | `azure_classic_admin_group`        | `UserGroup`                     |
+| [RM] Container Registry         | `azure_container_registry`         | `DataStore`                     |
+| [RM] Container Registry Webhook | `azure_container_registry_webhook` | `ApplicationEndpoint`           |
+| [RM] Cosmos DB Account          | `azure_cosmosdb_account`           | `Account`, `Service`            |
+| [RM] Cosmos DB Database         | `azure_cosmosdb_sql_database`      | `Database`, `DataStore`         |
+| [RM] DNS Record Set             | `azure_dns_record_set`             | `DomainRecord`                  |
+| [RM] DNS Zone                   | `azure_dns_zone`                   | `DomainZone`                    |
+| [RM] Image                      | `azure_image`                      | `Image`                         |
+| [RM] Key Vault                  | `azure_keyvault_service`           | `Service`                       |
+| [RM] Load Balancer              | `azure_lb`                         | `Gateway`                       |
+| [RM] MariaDB Database           | `azure_mariadb_database`           | `Database`, `DataStore`         |
+| [RM] MariaDB Server             | `azure_mariadb_server`             | `Database`, `DataStore`, `Host` |
+| [RM] MySQL Database             | `azure_mysql_database`             | `Database`, `DataStore`         |
+| [RM] MySQL Server               | `azure_mysql_server`               | `Database`, `DataStore`, `Host` |
+| [RM] Network Interface          | `azure_nic`                        | `NetworkInterface`              |
+| [RM] PostgreSQL Database        | `azure_postgresql_database`        | `Database`, `DataStore`         |
+| [RM] PostgreSQL Server          | `azure_postgresql_server`          | `Database`, `DataStore`, `Host` |
+| [RM] Private DNS Record Set     | `azure_private_dns_record_set`     | `DomainRecord`                  |
+| [RM] Private DNS Zone           | `azure_private_dns_zone`           | `DomainZone`                    |
+| [RM] Public IP Address          | `azure_public_ip`                  | `IpAddress`                     |
+| [RM] Resource Group             | `azure_resource_group`             | `Group`                         |
+| [RM] Role Assignment            | `azure_role_assignment`            | `AccessPolicy`                  |
+| [RM] Role Definition            | `azure_role_definition`            | `AccessRole`                    |
+| [RM] SQL Database               | `azure_sql_database`               | `Database`, `DataStore`         |
+| [RM] SQL Server                 | `azure_sql_server`                 | `Database`, `DataStore`, `Host` |
+| [RM] Security Group             | `azure_security_group`             | `Firewall`                      |
+| [RM] Storage Account            | `azure_storage_account`            | `Service`                       |
+| [RM] Storage Container          | `azure_storage_container`          | `DataStore`                     |
+| [RM] Storage File Share         | `azure_storage_file_share`         | `DataStore`                     |
+| [RM] Storage Queue              | `azure_storage_queue`              | `Queue`                         |
+| [RM] Storage Table              | `azure_storage_table`              | `DataStore`, `Database`         |
+| [RM] Subnet                     | `azure_subnet`                     | `Network`                       |
+| [RM] Subscription               | `azure_subscription`               | `Account`                       |
+| [RM] Virtual Machine            | `azure_vm`                         | `Host`                          |
+| [RM] Virtual Network            | `azure_vnet`                       | `Network`                       |
 
 ### Relationships
 
 The following relationships are created/mapped:
 
-| Source Entity `_type`          | Relationship `_class` | Target Entity `_type`           |
-| ------------------------------ | --------------------- | ------------------------------- |
-| `azure_account`                | **HAS**               | `azure_user_group`              |
-| `azure_account`                | **HAS**               | `azure_keyvault_service`        |
-| `azure_account`                | **HAS**               | `azure_user`                    |
-| `azure_api_management_service` | **HAS**               | `azure_api_management_api`      |
-| `azure_classic_admin_group`    | **HAS**               | `azure_user`                    |
-| `azure_cosmosdb_account`       | **HAS**               | `azure_cosmosdb_sql_database`   |
-| `azure_dns_zone`               | **HAS**               | `azure_dns_record_set`          |
-| `azure_user_group`             | **HAS**               | `azure_user_group`              |
-| `azure_user_group`             | **HAS**               | `azure_group_member`            |
-| `azure_user_group`             | **HAS**               | `azure_user`                    |
-| `azure_lb`                     | **CONNECTS**          | `azure_nic`                     |
-| `azure_mariadb_server`         | **HAS**               | `azure_mariadb_database`        |
-| `azure_mysql_server`           | **HAS**               | `azure_mysql_database`          |
-| `azure_postgresql_server`      | **HAS**               | `azure_postgresql_database`     |
-| `azure_private_dns_zone`       | **HAS**               | `azure_private_dns_record_set`  |
-| `azure_resource_group`         | **HAS**               | `azure_api_management_service`  |
-| `azure_resource_group`         | **HAS**               | `azure_cosmosdb_account`        |
-| `azure_resource_group`         | **HAS**               | `azure_dns_zone`                |
-| `azure_resource_group`         | **HAS**               | `azure_image`                   |
-| `azure_resource_group`         | **HAS**               | `azure_keyvault_service`        |
-| `azure_resource_group`         | **HAS**               | `azure_lb`                      |
-| `azure_resource_group`         | **HAS**               | `azure_managed_disk`            |
-| `azure_resource_group`         | **HAS**               | `azure_mariadb_server`          |
-| `azure_resource_group`         | **HAS**               | `azure_mysql_server`            |
-| `azure_resource_group`         | **HAS**               | `azure_nic`                     |
-| `azure_resource_group`         | **HAS**               | `azure_postgresql_server`       |
-| `azure_resource_group`         | **HAS**               | `azure_private_dns_zone`        |
-| `azure_resource_group`         | **HAS**               | `azure_public_ip`               |
-| `azure_resource_group`         | **HAS**               | `azure_security_group`          |
-| `azure_resource_group`         | **HAS**               | `azure_sql_server`              |
-| `azure_resource_group`         | **HAS**               | `azure_storage_account`         |
-| `azure_resource_group`         | **HAS**               | `azure_vm`                      |
-| `azure_resource_group`         | **HAS**               | `azure_vnet`                    |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_api_management_service`  |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_cosmosdb_account`        |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_dns_zone`                |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_keyvault_service`        |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_nic`                     |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_private_dns_zone`        |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_public_ip`               |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_resource_group`          |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_security_group`          |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_storage_account`         |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_subscription`            |
-| `azure_role_assignment`        | **ALLOWS**            | `azure_vnet`                    |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_application`             |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_directory`               |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_directory_role_template` |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_everyone`                |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_foreign_group`           |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_msi`                     |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_service_principal`       |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_unknown`                 |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_unknown_principal_type`  |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_user`                    |
-| `azure_role_assignment`        | **ASSIGNED**          | `azure_user_group`              |
-| `azure_role_assignment`        | **USES**              | `azure_role_definition`         |
-| `azure_security_group`         | **PROTECTS**          | `azure_nic`                     |
-| `azure_security_group`         | **PROTECTS**          | `azure_subnet`                  |
-| `azure_security_group`         | **ALLOWS**            | `azure_subnet`                  |
-| `azure_sql_server`             | **HAS**               | `azure_sql_database`            |
-| `azure_storage_account`        | **HAS**               | `azure_storage_container`       |
-| `azure_storage_account`        | **HAS**               | `azure_storage_file_share`      |
-| `azure_storage_account`        | **HAS**               | `azure_storage_queue`           |
-| `azure_storage_account`        | **HAS**               | `azure_storage_table`           |
-| `azure_subnet`                 | **HAS**               | `azure_vm`                      |
-| `azure_subscription`           | **HAS**               | `azure_resource_group`          |
-| `azure_vm`                     | **USES**              | `azure_managed_disk`            |
-| `azure_vm`                     | **USES**              | `azure_nic`                     |
-| `azure_vm`                     | **USES**              | `azure_public_ip`               |
-| `azure_vnet`                   | **CONTAINS**          | `azure_subnet`                  |
+| Source Entity `_type`          | Relationship `_class` | Target Entity `_type`              |
+| ------------------------------ | --------------------- | ---------------------------------- |
+| `azure_account`                | **HAS**               | `azure_user_group`                 |
+| `azure_account`                | **HAS**               | `azure_keyvault_service`           |
+| `azure_account`                | **HAS**               | `azure_user`                       |
+| `azure_api_management_service` | **HAS**               | `azure_api_management_api`         |
+| `azure_classic_admin_group`    | **HAS**               | `azure_user`                       |
+| `azure_container_registry`     | **HAS**               | `azure_container_registry_webhook` |
+| `azure_cosmosdb_account`       | **HAS**               | `azure_cosmosdb_sql_database`      |
+| `azure_dns_zone`               | **HAS**               | `azure_dns_record_set`             |
+| `azure_user_group`             | **HAS**               | `azure_user_group`                 |
+| `azure_user_group`             | **HAS**               | `azure_group_member`               |
+| `azure_user_group`             | **HAS**               | `azure_user`                       |
+| `azure_lb`                     | **CONNECTS**          | `azure_nic`                        |
+| `azure_mariadb_server`         | **HAS**               | `azure_mariadb_database`           |
+| `azure_mysql_server`           | **HAS**               | `azure_mysql_database`             |
+| `azure_postgresql_server`      | **HAS**               | `azure_postgresql_database`        |
+| `azure_private_dns_zone`       | **HAS**               | `azure_private_dns_record_set`     |
+| `azure_resource_group`         | **HAS**               | `azure_api_management_service`     |
+| `azure_resource_group`         | **HAS**               | `azure_container_registry`         |
+| `azure_resource_group`         | **HAS**               | `azure_cosmosdb_account`           |
+| `azure_resource_group`         | **HAS**               | `azure_dns_zone`                   |
+| `azure_resource_group`         | **HAS**               | `azure_image`                      |
+| `azure_resource_group`         | **HAS**               | `azure_keyvault_service`           |
+| `azure_resource_group`         | **HAS**               | `azure_lb`                         |
+| `azure_resource_group`         | **HAS**               | `azure_managed_disk`               |
+| `azure_resource_group`         | **HAS**               | `azure_mariadb_server`             |
+| `azure_resource_group`         | **HAS**               | `azure_mysql_server`               |
+| `azure_resource_group`         | **HAS**               | `azure_nic`                        |
+| `azure_resource_group`         | **HAS**               | `azure_postgresql_server`          |
+| `azure_resource_group`         | **HAS**               | `azure_private_dns_zone`           |
+| `azure_resource_group`         | **HAS**               | `azure_public_ip`                  |
+| `azure_resource_group`         | **HAS**               | `azure_security_group`             |
+| `azure_resource_group`         | **HAS**               | `azure_sql_server`                 |
+| `azure_resource_group`         | **HAS**               | `azure_storage_account`            |
+| `azure_resource_group`         | **HAS**               | `azure_vm`                         |
+| `azure_resource_group`         | **HAS**               | `azure_vnet`                       |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_api_management_service`     |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_container_registry`         |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_cosmosdb_account`           |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_dns_zone`                   |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_keyvault_service`           |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_nic`                        |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_private_dns_zone`           |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_public_ip`                  |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_resource_group`             |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_security_group`             |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_storage_account`            |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_subscription`               |
+| `azure_role_assignment`        | **ALLOWS**            | `azure_vnet`                       |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_application`                |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_directory`                  |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_directory_role_template`    |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_everyone`                   |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_foreign_group`              |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_msi`                        |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_service_principal`          |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_unknown`                    |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_unknown_principal_type`     |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_user`                       |
+| `azure_role_assignment`        | **ASSIGNED**          | `azure_user_group`                 |
+| `azure_role_assignment`        | **USES**              | `azure_role_definition`            |
+| `azure_security_group`         | **PROTECTS**          | `azure_nic`                        |
+| `azure_security_group`         | **PROTECTS**          | `azure_subnet`                     |
+| `azure_security_group`         | **ALLOWS**            | `azure_subnet`                     |
+| `azure_sql_server`             | **HAS**               | `azure_sql_database`               |
+| `azure_storage_account`        | **HAS**               | `azure_storage_container`          |
+| `azure_storage_account`        | **HAS**               | `azure_storage_file_share`         |
+| `azure_storage_account`        | **HAS**               | `azure_storage_queue`              |
+| `azure_storage_account`        | **HAS**               | `azure_storage_table`              |
+| `azure_subnet`                 | **HAS**               | `azure_vm`                         |
+| `azure_subscription`           | **HAS**               | `azure_resource_group`             |
+| `azure_vm`                     | **USES**              | `azure_managed_disk`               |
+| `azure_vm`                     | **USES**              | `azure_nic`                        |
+| `azure_vm`                     | **USES**              | `azure_public_ip`                  |
+| `azure_vnet`                   | **CONTAINS**          | `azure_subnet`                     |
 
 <!--
 ********************************************************************************

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@azure/arm-apimanagement": "^6.0.0",
     "@azure/arm-authorization": "^8.3.2",
     "@azure/arm-compute": "^14.0.0",
+    "@azure/arm-containerregistry": "^8.0.0",
     "@azure/arm-cosmosdb": "^7.0.0",
     "@azure/arm-dns": "^4.0.0",
     "@azure/arm-keyvault": "^1.2.1",

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -60,6 +60,10 @@ import {
   STEP_RM_PRIVATE_DNS_ZONES,
   STEP_RM_PRIVATE_DNS_RECORD_SETS,
 } from './steps/resource-manager/private-dns';
+import {
+  STEP_RM_CONTAINER_REGISTRIES,
+  STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
+} from './steps/resource-manager/container-registry';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {
@@ -114,6 +118,8 @@ describe('getStepStartStates', () => {
       [STEP_RM_DNS_RECORD_SETS]: { disabled: true },
       [STEP_RM_PRIVATE_DNS_ZONES]: { disabled: true },
       [STEP_RM_PRIVATE_DNS_RECORD_SETS]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRIES]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRY_WEBHOOKS]: { disabled: true },
     });
   });
 
@@ -164,6 +170,8 @@ describe('getStepStartStates', () => {
       [STEP_RM_DNS_RECORD_SETS]: { disabled: true },
       [STEP_RM_PRIVATE_DNS_ZONES]: { disabled: true },
       [STEP_RM_PRIVATE_DNS_RECORD_SETS]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRIES]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRY_WEBHOOKS]: { disabled: true },
     });
   });
 
@@ -214,6 +222,8 @@ describe('getStepStartStates', () => {
       [STEP_RM_DNS_RECORD_SETS]: { disabled: false },
       [STEP_RM_PRIVATE_DNS_ZONES]: { disabled: false },
       [STEP_RM_PRIVATE_DNS_RECORD_SETS]: { disabled: false },
+      [STEP_RM_CONTAINER_REGISTRIES]: { disabled: false },
+      [STEP_RM_CONTAINER_REGISTRY_WEBHOOKS]: { disabled: false },
     });
   });
 });

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -59,6 +59,10 @@ import {
   STEP_RM_PRIVATE_DNS_ZONES,
   STEP_RM_PRIVATE_DNS_RECORD_SETS,
 } from './steps/resource-manager/private-dns';
+import {
+  STEP_RM_CONTAINER_REGISTRIES,
+  STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
+} from './steps/resource-manager/container-registry';
 
 export default function getStepStartStates(
   executionContext: IntegrationExecutionContext<IntegrationConfig>,
@@ -108,5 +112,7 @@ export default function getStepStartStates(
     [STEP_RM_DNS_RECORD_SETS]: resourceManager,
     [STEP_RM_PRIVATE_DNS_ZONES]: resourceManager,
     [STEP_RM_PRIVATE_DNS_RECORD_SETS]: resourceManager,
+    [STEP_RM_CONTAINER_REGISTRIES]: resourceManager,
+    [STEP_RM_CONTAINER_REGISTRY_WEBHOOKS]: resourceManager,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { subscriptionSteps } from './steps/resource-manager/subscriptions';
 import { apiManagementSteps } from './steps/resource-manager/api-management';
 import { dnsSteps } from './steps/resource-manager/dns';
 import { privateDnsSteps } from './steps/resource-manager/private-dns';
+import { containerRegistrySteps } from './steps/resource-manager/container-registry';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields: {
@@ -60,5 +61,6 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...apiManagementSteps,
     ...dnsSteps,
     ...privateDnsSteps,
+    ...containerRegistrySteps,
   ],
 };

--- a/src/steps/resource-manager/container-registry/__recordings__/iterateRegistries_3890134918/recording.har
+++ b/src/steps/resource-manager/container-registry/__recordings__/iterateRegistries_3890134918/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "iterateRegistries",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "b4c890bb-5be3-41e7-a80f-405ff7eaca16"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1599698985\",\"not_before\":\"1599695085\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-10-09T23:49:45.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "b4c890bb-5be3-41e7-a80f-405ff7eaca16"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "614166bb-aacc-46da-930c-2bb5ea4e5a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11021.14 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:49:45 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 783,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:49:45.652Z",
+        "time": 398,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 398
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f19aea7a-7149-4db6-ab31-fc36cb0817be"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1676,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8ed78bac-1c60-4c68-8988-049efeef5388"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "8ed78bac-1c60-4c68-8988-049efeef5388"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200909T234947Z:8ed78bac-1c60-4c68-8988-049efeef5388"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:49:47 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:49:46.079Z",
+        "time": 1345,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1345
+        }
+      },
+      {
+        "_id": "3c8facecec869b975ba799366056ecd9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "954e38bd-98b8-4321-b3b8-22831e594be5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1828,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.ContainerRegistry/registries?api-version=2019-12-01-preview"
+        },
+        "response": {
+          "bodySize": 1655,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1655,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"type\":\"Microsoft.ContainerRegistry/registries\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/manualj1dev\",\"name\":\"manualj1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"ndowmon@gmail.com\",\"createdByType\":\"User\",\"createdAt\":\"2020-09-09T23:31:34.0800684+00:00\",\"lastModifiedBy\":\"ndowmon@gmail.com\",\"lastModifiedByType\":\"User\",\"lastModifiedAt\":\"2020-09-09T23:39:23.8672488+00:00\"},\"properties\":{\"loginServer\":\"manualj1dev.azurecr.io\",\"creationDate\":\"2020-09-09T23:31:34.0800684Z\",\"provisioningState\":\"Succeeded\",\"adminUserEnabled\":false,\"policies\":{\"quarantinePolicy\":{\"status\":\"disabled\"},\"trustPolicy\":{\"type\":\"Notary\",\"status\":\"disabled\"},\"retentionPolicy\":{\"days\":7,\"lastUpdatedTime\":\"2020-09-09T23:31:35.1137149+00:00\",\"status\":\"disabled\"}},\"encryption\":{\"status\":\"disabled\"},\"dataEndpointEnabled\":false,\"dataEndpointHostNames\":[],\"privateEndpointConnections\":[],\"publicNetworkAccess\":\"Enabled\"}},{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"type\":\"Microsoft.ContainerRegistry/registries\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"createdByType\":\"Application\",\"createdAt\":\"2020-09-09T23:49:02.73313+00:00\",\"lastModifiedBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2020-09-09T23:49:02.73313+00:00\"},\"properties\":{\"loginServer\":\"ndowmon1j1dev.azurecr.io\",\"creationDate\":\"2020-09-09T23:49:02.73313Z\",\"provisioningState\":\"Succeeded\",\"adminUserEnabled\":false,\"policies\":{\"quarantinePolicy\":{\"status\":\"disabled\"},\"trustPolicy\":{\"type\":\"Notary\",\"status\":\"disabled\"},\"retentionPolicy\":{\"days\":7,\"lastUpdatedTime\":\"2020-09-09T23:49:04.0604185+00:00\",\"status\":\"disabled\"}},\"encryption\":{\"status\":\"disabled\"},\"dataEndpointEnabled\":false,\"dataEndpointHostNames\":[],\"privateEndpointConnections\":[],\"publicNetworkAccess\":\"Enabled\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a203943c-309d-4430-b759-dc73ea0320f5"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "a203943c-309d-4430-b759-dc73ea0320f5"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200909T234947Z:a203943c-309d-4430-b759-dc73ea0320f5"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:49:47 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:49:47.439Z",
+        "time": 512,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 512
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/container-registry/__recordings__/iterateRegistryWebhooks_874434892/recording.har
+++ b/src/steps/resource-manager/container-registry/__recordings__/iterateRegistryWebhooks_874434892/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "iterateRegistryWebhooks",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "23023fd6-678e-4cb4-9c25-d7d2b346375c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1444,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1444,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1599699127\",\"not_before\":\"1599695227\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-10-09T23:52:07.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1444"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "23023fd6-678e-4cb4-9c25-d7d2b346375c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3993b384-fc9e-4fe7-bea9-0da35ea74100"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11021.14 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:52:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 783,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:52:07.306Z",
+        "time": 346,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 346
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e747131e-1be8-4b54-95ab-6ad4a410c4df"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1670,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "dcd88548-bfba-4640-961b-41871583e25b"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "dcd88548-bfba-4640-961b-41871583e25b"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200909T235207Z:dcd88548-bfba-4640-961b-41871583e25b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:52:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:52:07.656Z",
+        "time": 296,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 296
+        }
+      },
+      {
+        "_id": "1275d7ebcfd13e5d5efcc517102f3651",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "b19fc0a6-a226-4c9e-8f97-053046ed66b4"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1866,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks?api-version=2019-12-01-preview"
+        },
+        "response": {
+          "bodySize": 1013,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1013,
+            "text": "{\"value\":[{\"type\":\"Microsoft.ContainerRegistry/registries/webhooks\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev\",\"name\":\"j1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"createdByType\":\"Application\",\"createdAt\":\"2020-09-09T23:49:06.7238034+00:00\",\"lastModifiedBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2020-09-09T23:49:06.7238034+00:00\"},\"properties\":{\"status\":\"enabled\",\"scope\":\"\",\"actions\":[\"push\"],\"provisioningState\":\"Succeeded\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "70ef10d4-0104-4637-8564-0a7b433718da"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "70ef10d4-0104-4637-8564-0a7b433718da"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200909T235209Z:70ef10d4-0104-4637-8564-0a7b433718da"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Sep 2020 23:52:09 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-09T23:52:07.959Z",
+        "time": 1511,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1511
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registries_2250806650/recording.har
+++ b/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registries_2250806650/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "resource-manager-step-container-registries",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "8b76ef9c-fdf2-4a40-b6e0-55b6b3bb18bb"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1599754361\",\"not_before\":\"1599750461\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-10-10T15:12:41.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "8b76ef9c-fdf2-4a40-b6e0-55b6b3bb18bb"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cda96b49-e47d-4b54-912b-358e24811d00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11021.14 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:40 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 783,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:40.769Z",
+        "time": 681,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 681
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5fa628ed-eaf1-40b0-a5d5-eca17d5443b5"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1676,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "631d7220-9621-4cbc-9c68-0b20f6febdb5"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "631d7220-9621-4cbc-9c68-0b20f6febdb5"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200910T151241Z:631d7220-9621-4cbc-9c68-0b20f6febdb5"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:41.481Z",
+        "time": 300,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 300
+        }
+      },
+      {
+        "_id": "3c8facecec869b975ba799366056ecd9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "bd4d71fc-4ec3-4286-aacb-ab27569dfc46"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1828,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.ContainerRegistry/registries?api-version=2019-12-01-preview"
+        },
+        "response": {
+          "bodySize": 1403,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1403,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"type\":\"Microsoft.ContainerRegistry/registries\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"createdByType\":\"Application\",\"createdAt\":\"2020-09-10T14:52:11.2991507+00:00\",\"lastModifiedBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2020-09-10T14:52:11.2991507+00:00\"},\"properties\":{\"loginServer\":\"ndowmon1j1dev.azurecr.io\",\"creationDate\":\"2020-09-10T14:52:11.2991507Z\",\"provisioningState\":\"Succeeded\",\"adminUserEnabled\":false,\"policies\":{\"quarantinePolicy\":{\"status\":\"disabled\"},\"trustPolicy\":{\"type\":\"Notary\",\"status\":\"disabled\"},\"retentionPolicy\":{\"days\":7,\"lastUpdatedTime\":\"2020-09-10T14:52:12.3914099+00:00\",\"status\":\"disabled\"}},\"encryption\":{\"status\":\"disabled\"},\"dataEndpointEnabled\":false,\"dataEndpointHostNames\":[],\"privateEndpointConnections\":[],\"publicNetworkAccess\":\"Enabled\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "436f7092-6bbd-4201-86dd-021ff7e4ce22"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "436f7092-6bbd-4201-86dd-021ff7e4ce22"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200910T151242Z:436f7092-6bbd-4201-86dd-021ff7e4ce22"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:41.794Z",
+        "time": 497,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 497
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registry-webhooks_891010703/recording.har
+++ b/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registry-webhooks_891010703/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "resource-manager-step-container-registry-webhooks",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "401e99e4-fb32-48e3-ae9e-1abc2714e145"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1599754362\",\"not_before\":\"1599750462\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-10-10T15:12:42.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "401e99e4-fb32-48e3-ae9e-1abc2714e145"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "47a0ae0e-dd85-44eb-8605-703409715e00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11021.14 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 783,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:42.329Z",
+        "time": 264,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 264
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "aa260a17-ec58-444f-8da2-fa5d7887a4ac"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1676,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 355,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 355,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "60c0bde6-94eb-4cd7-96b4-604ae01d4dfe"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "60c0bde6-94eb-4cd7-96b4-604ae01d4dfe"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200910T151242Z:60c0bde6-94eb-4cd7-96b4-604ae01d4dfe"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "355"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:42.596Z",
+        "time": 255,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 255
+        }
+      },
+      {
+        "_id": "1275d7ebcfd13e5d5efcc517102f3651",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "6801b0af-8203-44d2-8a62-21605d019e45"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1872,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks?api-version=2019-12-01-preview"
+        },
+        "response": {
+          "bodySize": 1017,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1017,
+            "text": "{\"value\":[{\"type\":\"Microsoft.ContainerRegistry/registries/webhooks\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev\",\"name\":\"j1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"createdByType\":\"Application\",\"createdAt\":\"2020-09-10T14:52:16.113464+00:00\",\"lastModifiedBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2020-09-10T14:52:16.113464+00:00\"},\"properties\":{\"status\":\"enabled\",\"scope\":\"\",\"actions\":[\"push\"],\"provisioningState\":\"Succeeded\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "5d4bda6d-2c1c-495c-9b21-f17633a8dc2e"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5d4bda6d-2c1c-495c-9b21-f17633a8dc2e"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20200910T151243Z:5d4bda6d-2c1c-495c-9b21-f17633a8dc2e"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Sep 2020 15:12:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-09-10T15:12:42.856Z",
+        "time": 533,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 533
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/container-registry/__snapshots__/converters.test.ts.snap
+++ b/src/steps/resource-manager/container-registry/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createContainerRegistryEntity properties transferred 1`] = `
+Object {
+  "_class": Array [
+    "DataStore",
+  ],
+  "_key": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "adminUserEnabled": false,
+        "creationDate": 2020-09-09T23:49:02.733Z,
+        "dataEndpointEnabled": false,
+        "dataEndpointHostNames": Array [],
+        "encryption": Object {
+          "status": "disabled",
+        },
+        "id": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev",
+        "location": "eastus",
+        "loginServer": "ndowmon1j1dev.azurecr.io",
+        "name": "ndowmon1j1dev",
+        "policies": Object {
+          "quarantinePolicy": Object {
+            "status": "disabled",
+          },
+          "retentionPolicy": Object {
+            "days": 7,
+            "lastUpdatedTime": 2020-09-09T23:49:04.060Z,
+            "status": "disabled",
+          },
+          "trustPolicy": Object {
+            "status": "disabled",
+            "type": "Notary",
+          },
+        },
+        "privateEndpointConnections": Array [],
+        "provisioningState": "Succeeded",
+        "publicNetworkAccess": "Enabled",
+        "sku": Object {
+          "name": "Basic",
+          "tier": "Basic",
+        },
+        "systemData": Object {
+          "createdAt": "2020-09-09T23:49:02.73313+00:00",
+          "createdBy": "d2c4cc5a-4ace-480c-aeff-2c97326511ba",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-09-09T23:49:02.73313+00:00",
+          "lastModifiedBy": "d2c4cc5a-4ace-480c-aeff-2c97326511ba",
+          "lastModifiedByType": "Application",
+        },
+        "tags": Object {},
+        "type": "Microsoft.ContainerRegistry/registries",
+      },
+    },
+  ],
+  "_type": "azure_container_registry",
+  "adminUserEnabled": false,
+  "classification": null,
+  "createdOn": 1599695342733,
+  "dataEndpointEnabled": false,
+  "displayName": "ndowmon1j1dev",
+  "encrypted": false,
+  "id": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev",
+  "location": "eastus",
+  "loginServer": "ndowmon1j1dev.azurecr.io",
+  "name": "ndowmon1j1dev",
+  "provisioningState": "Succeeded",
+  "publicNetworkAccess": "Enabled",
+  "type": "Microsoft.ContainerRegistry/registries",
+  "webLink": "https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev",
+}
+`;
+
+exports[`createContainerRegistryWebhookEntity properties transferred 1`] = `
+Object {
+  "_class": Array [
+    "ApplicationEndpoint",
+  ],
+  "_key": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "actions": Array [
+          "push",
+        ],
+        "id": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev",
+        "location": "eastus",
+        "name": "j1dev",
+        "provisioningState": "Succeeded",
+        "scope": "",
+        "status": "enabled",
+        "systemData": Object {
+          "createdAt": "2020-09-09T23:49:06.7238034+00:00",
+          "createdBy": "d2c4cc5a-4ace-480c-aeff-2c97326511ba",
+          "createdByType": "Application",
+          "lastModifiedAt": "2020-09-09T23:49:06.7238034+00:00",
+          "lastModifiedBy": "d2c4cc5a-4ace-480c-aeff-2c97326511ba",
+          "lastModifiedByType": "Application",
+        },
+        "tags": Object {},
+        "type": "Microsoft.ContainerRegistry/registries/webhooks",
+      },
+    },
+  ],
+  "_type": "azure_container_registry_webhook",
+  "actions": Array [
+    "push",
+  ],
+  "active": false,
+  "address": "NOT_RETURNED_FROM_AZURE_API",
+  "createdOn": undefined,
+  "displayName": "j1dev",
+  "id": "/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev",
+  "location": "eastus",
+  "name": "j1dev",
+  "provisioningState": "Succeeded",
+  "scope": "",
+  "status": "enabled",
+  "type": "Microsoft.ContainerRegistry/registries/webhooks",
+  "webLink": "https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev",
+}
+`;

--- a/src/steps/resource-manager/container-registry/client.test.ts
+++ b/src/steps/resource-manager/container-registry/client.test.ts
@@ -1,0 +1,84 @@
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+
+import {
+  Recording,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { J1ContainerRegistryManagementClient } from './client';
+import { IntegrationConfig } from '../../../types';
+import { Registry, Webhook } from '@azure/arm-containerregistry/esm/models';
+
+// developer used different creds than ~/test/integrationInstanceConfig
+const config: IntegrationConfig = {
+  clientId: process.env.CLIENT_ID || 'clientId',
+  clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+  directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
+  subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
+};
+
+let recording: Recording;
+
+afterEach(async () => {
+  await recording.stop();
+});
+
+describe('iterate container registries', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iterateRegistries',
+    });
+
+    const client = new J1ContainerRegistryManagementClient(
+      config,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const resources: Registry[] = [];
+    await client.iterateRegistries((e) => {
+      resources.push(e);
+    });
+
+    expect(resources).toContainEqual(
+      expect.objectContaining({
+        name: expect.stringContaining('j1dev'),
+      }),
+    );
+  });
+});
+
+describe('iterate container registry webhooks', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iterateRegistryWebhooks',
+      options: {
+        recordFailedRequests: true,
+      },
+    });
+
+    const client = new J1ContainerRegistryManagementClient(
+      config,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const registry = {
+      id:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+      name: 'ndowmon1j1dev',
+    };
+
+    const resources: Webhook[] = [];
+    await client.iterateRegistryWebhooks(registry, (e) => {
+      resources.push(e);
+    });
+
+    expect(resources).toContainEqual(
+      expect.objectContaining({
+        name: 'j1dev',
+      }),
+    );
+  });
+});

--- a/src/steps/resource-manager/container-registry/client.ts
+++ b/src/steps/resource-manager/container-registry/client.ts
@@ -1,0 +1,54 @@
+import { ContainerRegistryManagementClient } from '@azure/arm-containerregistry';
+import { Registry, Webhook } from '@azure/arm-containerregistry/esm/models';
+import {
+  Client,
+  iterateAllResources,
+  ListResourcesEndpoint,
+} from '../../../azure/resource-manager/client';
+import { resourceGroupName } from '../../../azure/utils';
+
+export class J1ContainerRegistryManagementClient extends Client {
+  public async iterateRegistries(
+    callback: (s: Registry) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      ContainerRegistryManagementClient,
+    );
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      resourceEndpoint: serviceClient.registries,
+      resourceDescription: 'containerRegistry.registry',
+      callback,
+    });
+  }
+
+  public async iterateRegistryWebhooks(
+    containerRegistry: { name: string; id: string },
+    callback: (s: Webhook) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      ContainerRegistryManagementClient,
+    );
+    const resourceGroup = resourceGroupName(containerRegistry.id, true)!;
+    const registryName = containerRegistry.name;
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      resourceEndpoint: {
+        list: async () => {
+          return serviceClient.webhooks.list(resourceGroup, registryName);
+        },
+        listNext: /* istanbul ignore next: testing iteration might be difficult */ async (
+          nextLink: string,
+        ) => {
+          return serviceClient.webhooks.listNext(nextLink);
+        },
+      } as ListResourcesEndpoint,
+      resourceDescription: 'containerRegistry.webhook',
+      callback,
+    });
+  }
+}

--- a/src/steps/resource-manager/container-registry/constants.ts
+++ b/src/steps/resource-manager/container-registry/constants.ts
@@ -1,0 +1,38 @@
+import {
+  generateRelationshipType,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
+
+export const STEP_RM_CONTAINER_REGISTRIES = 'rm-container-registries';
+export const STEP_RM_CONTAINER_REGISTRY_WEBHOOKS =
+  'rm-container-registry-webhooks';
+
+export const ContainerRegistryEntities = {
+  REGISTRY: {
+    _type: 'azure_container_registry',
+    _class: ['DataStore'],
+    resourceName: '[RM] Container Registry',
+  },
+  WEBHOOK: {
+    _type: 'azure_container_registry_webhook',
+    _class: ['ApplicationEndpoint'],
+    resourceName: '[RM] Container Registry Webhook',
+  },
+};
+
+export const ContainerRegistryRelationships = {
+  RESOURCE_GROUP_HAS_ZONE: createResourceGroupResourceRelationshipMetadata(
+    ContainerRegistryEntities.REGISTRY._type,
+  ),
+  REGISTRY_HAS_WEBHOOK: {
+    _type: generateRelationshipType(
+      RelationshipClass.HAS,
+      ContainerRegistryEntities.REGISTRY,
+      ContainerRegistryEntities.WEBHOOK,
+    ),
+    sourceType: ContainerRegistryEntities.REGISTRY._type,
+    _class: RelationshipClass.HAS,
+    targetType: ContainerRegistryEntities.WEBHOOK._type,
+  },
+};

--- a/src/steps/resource-manager/container-registry/converters.test.ts
+++ b/src/steps/resource-manager/container-registry/converters.test.ts
@@ -1,0 +1,92 @@
+import { createAzureWebLinker } from '../../../azure';
+import {
+  createContainerRegistryEntity,
+  createContainerRegistryWebhookEntity,
+} from './converters';
+import { Registry, Webhook } from '@azure/arm-containerregistry/esm/models';
+
+const webLinker = createAzureWebLinker('something.onmicrosoft.com');
+
+describe('createContainerRegistryEntity', () => {
+  test('properties transferred', () => {
+    const data: Registry & { systemData: any } = {
+      id:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+      name: 'ndowmon1j1dev',
+      type: 'Microsoft.ContainerRegistry/registries',
+      location: 'eastus',
+      tags: {},
+      sku: { name: 'Basic', tier: 'Basic' },
+      loginServer: 'ndowmon1j1dev.azurecr.io',
+      creationDate: new Date('2020-09-09T23:49:02.733Z'),
+      provisioningState: 'Succeeded',
+      adminUserEnabled: false,
+      policies: {
+        quarantinePolicy: { status: 'disabled' },
+        trustPolicy: { type: 'Notary', status: 'disabled' },
+        retentionPolicy: {
+          days: 7,
+          lastUpdatedTime: new Date('2020-09-09T23:49:04.060Z'),
+          status: 'disabled',
+        },
+      },
+      encryption: { status: 'disabled' },
+      dataEndpointEnabled: false,
+      dataEndpointHostNames: [],
+      privateEndpointConnections: [],
+      publicNetworkAccess: 'Enabled',
+      systemData: {
+        createdBy: 'd2c4cc5a-4ace-480c-aeff-2c97326511ba',
+        createdByType: 'Application',
+        createdAt: '2020-09-09T23:49:02.73313+00:00',
+        lastModifiedBy: 'd2c4cc5a-4ace-480c-aeff-2c97326511ba',
+        lastModifiedByType: 'Application',
+        lastModifiedAt: '2020-09-09T23:49:02.73313+00:00',
+      },
+    };
+
+    expect(createContainerRegistryEntity(webLinker, data)).toMatchSnapshot();
+    expect(
+      createContainerRegistryEntity(webLinker, data),
+    ).toMatchGraphObjectSchema({
+      _class: ['DataStore'],
+      schema: {},
+    });
+  });
+});
+
+describe('createContainerRegistryWebhookEntity', () => {
+  test('properties transferred', () => {
+    // the following is returned from the API, but current SDK version doesn't recognize `systemData` as a property on `Webhook`
+    const data: Webhook & { systemData: any } = {
+      id:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev',
+      name: 'j1dev',
+      type: 'Microsoft.ContainerRegistry/registries/webhooks',
+      location: 'eastus',
+      tags: {},
+      status: 'enabled',
+      scope: '',
+      actions: ['push'],
+      provisioningState: 'Succeeded',
+      systemData: {
+        createdBy: 'd2c4cc5a-4ace-480c-aeff-2c97326511ba',
+        createdByType: 'Application',
+        createdAt: '2020-09-09T23:49:06.7238034+00:00',
+        lastModifiedBy: 'd2c4cc5a-4ace-480c-aeff-2c97326511ba',
+        lastModifiedByType: 'Application',
+        lastModifiedAt: '2020-09-09T23:49:06.7238034+00:00',
+      },
+    };
+
+    expect(
+      createContainerRegistryWebhookEntity(webLinker, data),
+    ).toMatchSnapshot();
+    expect(
+      createContainerRegistryWebhookEntity(webLinker, data),
+    ).toMatchGraphObjectSchema({
+      _class: ['ApplicationEndpoint'],
+      schema: {},
+    });
+  });
+});

--- a/src/steps/resource-manager/container-registry/converters.ts
+++ b/src/steps/resource-manager/container-registry/converters.ts
@@ -1,0 +1,52 @@
+import {
+  Entity,
+  createIntegrationEntity,
+  convertProperties,
+} from '@jupiterone/integration-sdk-core';
+
+import { AzureWebLinker } from '../../../azure';
+import { ContainerRegistryEntities } from './constants';
+import { Registry, Webhook } from '@azure/arm-containerregistry/esm/models';
+
+export function createContainerRegistryEntity(
+  webLinker: AzureWebLinker,
+  data: Registry,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        ...convertProperties(data),
+        _key: data.id as string,
+        _type: ContainerRegistryEntities.REGISTRY._type,
+        _class: ContainerRegistryEntities.REGISTRY._class,
+        id: data.id,
+        name: data.name,
+        classification: null,
+        encrypted: data.encryption?.status === 'enabled',
+        webLink: webLinker.portalResourceUrl(data.id),
+      },
+    },
+  });
+}
+
+export function createContainerRegistryWebhookEntity(
+  webLinker: AzureWebLinker,
+  data: Webhook,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        ...convertProperties(data),
+        _key: data.id as string,
+        _type: ContainerRegistryEntities.WEBHOOK._type,
+        _class: ContainerRegistryEntities.WEBHOOK._class,
+        id: data.id,
+        name: data.name,
+        address: 'NOT_RETURNED_FROM_AZURE_API',
+        webLink: webLinker.portalResourceUrl(data.id),
+      },
+    },
+  });
+}

--- a/src/steps/resource-manager/container-registry/index.test.ts
+++ b/src/steps/resource-manager/container-registry/index.test.ts
@@ -1,0 +1,121 @@
+import { fetchContainerRegistries, fetchContainerRegistryWebhooks } from '.';
+import {
+  createMockStepExecutionContext,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '../../../types';
+import { setupAzureRecording } from '../../../../test/helpers/recording';
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) {
+    await recording.stop();
+  }
+});
+
+test('step - container registries', async () => {
+  const instanceConfig: IntegrationConfig = {
+    clientId: process.env.CLIENT_ID || 'clientId',
+    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+    directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
+    subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
+  };
+
+  recording = setupAzureRecording({
+    directory: __dirname,
+    name: 'resource-manager-step-container-registries',
+  });
+
+  const context = createMockStepExecutionContext<IntegrationConfig>({
+    instanceConfig,
+    entities: [
+      {
+        _key:
+          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev',
+        _type: 'azure_resource_group',
+        _class: ['Group'],
+      },
+    ],
+  });
+
+  context.jobState.getData = jest.fn().mockResolvedValue({
+    defaultDomain: 'www.fake-domain.com',
+  });
+
+  await fetchContainerRegistries(context);
+
+  expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
+  expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
+    _class: 'DataStore',
+    schema: {},
+  });
+
+  expect(context.jobState.collectedRelationships).toEqual([
+    {
+      _key:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev|has|/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+      _type: 'azure_resource_group_has_container_registry',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev',
+      _toEntityKey:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+      displayName: 'HAS',
+    },
+  ]);
+});
+
+test('step - container registry webhooks', async () => {
+  const instanceConfig: IntegrationConfig = {
+    clientId: process.env.CLIENT_ID || 'clientId',
+    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+    directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
+    subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
+  };
+
+  recording = setupAzureRecording({
+    directory: __dirname,
+    name: 'resource-manager-step-container-registry-webhooks',
+  });
+
+  const context = createMockStepExecutionContext<IntegrationConfig>({
+    instanceConfig,
+    entities: [
+      {
+        _key:
+          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+        _type: 'azure_container_registry',
+        _class: ['DataStore'],
+        id:
+          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+        name: 'ndowmon1j1dev',
+      },
+    ],
+  });
+
+  context.jobState.getData = jest.fn().mockResolvedValue({
+    defaultDomain: 'www.fake-domain.com',
+  });
+
+  await fetchContainerRegistryWebhooks(context);
+
+  expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
+  expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
+    _class: 'ApplicationEndpoint',
+    schema: {},
+  });
+
+  expect(context.jobState.collectedRelationships).toEqual([
+    {
+      _key:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev|has|/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev',
+      _type: 'azure_container_registry_has_webhook',
+      _class: 'HAS',
+      _fromEntityKey:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
+      _toEntityKey:
+        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev',
+      displayName: 'HAS',
+    },
+  ]);
+});

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -1,0 +1,108 @@
+import {
+  Entity,
+  Step,
+  IntegrationStepExecutionContext,
+  createDirectRelationship,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+
+import { createAzureWebLinker } from '../../../azure';
+import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { ACCOUNT_ENTITY_TYPE, STEP_AD_ACCOUNT } from '../../active-directory';
+import { J1ContainerRegistryManagementClient } from './client';
+import {
+  ContainerRegistryEntities,
+  ContainerRegistryRelationships,
+  STEP_RM_CONTAINER_REGISTRIES,
+  STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
+} from './constants';
+import {
+  createContainerRegistryEntity,
+  createContainerRegistryWebhookEntity,
+} from './converters';
+import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
+export * from './constants';
+
+export async function fetchContainerRegistries(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await jobState.getData<Entity>(ACCOUNT_ENTITY_TYPE);
+
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new J1ContainerRegistryManagementClient(
+    instance.config,
+    logger,
+  );
+
+  await client.iterateRegistries(async (registry) => {
+    const registryEntity = createContainerRegistryEntity(webLinker, registry);
+    await jobState.addEntity(registryEntity);
+
+    await jobState.addRelationship(
+      await createResourceGroupResourceRelationship(
+        executionContext,
+        registryEntity,
+      ),
+    );
+  });
+}
+
+export async function fetchContainerRegistryWebhooks(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await jobState.getData<Entity>(ACCOUNT_ENTITY_TYPE);
+
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new J1ContainerRegistryManagementClient(
+    instance.config,
+    logger,
+  );
+
+  await jobState.iterateEntities(
+    { _type: ContainerRegistryEntities.REGISTRY._type },
+    async (registryEntity) => {
+      await client.iterateRegistryWebhooks(
+        (registryEntity as unknown) as { name: string; id: string },
+        async (registryWebhook) => {
+          const registryWebhookEntity = createContainerRegistryWebhookEntity(
+            webLinker,
+            registryWebhook,
+          );
+          await jobState.addEntity(registryWebhookEntity);
+
+          await jobState.addRelationship(
+            createDirectRelationship({
+              _class: RelationshipClass.HAS,
+              from: registryEntity,
+              to: registryWebhookEntity,
+            }),
+          );
+        },
+      );
+    },
+  );
+}
+
+export const containerRegistrySteps: Step<
+  IntegrationStepExecutionContext<IntegrationConfig>
+>[] = [
+  {
+    id: STEP_RM_CONTAINER_REGISTRIES,
+    name: 'Container Registries',
+    entities: [ContainerRegistryEntities.REGISTRY],
+    relationships: [ContainerRegistryRelationships.RESOURCE_GROUP_HAS_ZONE],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    executionHandler: fetchContainerRegistries,
+  },
+  {
+    id: STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
+    name: 'Container Registry Webhooks',
+    entities: [ContainerRegistryEntities.WEBHOOK],
+    relationships: [ContainerRegistryRelationships.REGISTRY_HAS_WEBHOOK],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CONTAINER_REGISTRIES],
+    executionHandler: fetchContainerRegistryWebhooks,
+  },
+];

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.ts
@@ -29,6 +29,10 @@ import {
 } from '../api-management';
 import { DnsEntities, STEP_RM_DNS_ZONES } from '../dns';
 import { PrivateDnsEntities, STEP_RM_PRIVATE_DNS_ZONES } from '../private-dns';
+import {
+  ContainerRegistryEntities,
+  STEP_RM_CONTAINER_REGISTRIES,
+} from '../container-registry';
 
 export interface ResourceIdMap {
   resourceIdMatcher: RegExp;
@@ -128,6 +132,15 @@ export const RESOURCE_ID_TYPES_MAP: ResourceIdMap[] = [
     ),
     _type: PrivateDnsEntities.ZONE._type,
     dependsOn: [STEP_RM_PRIVATE_DNS_ZONES],
+  },
+  {
+    resourceIdMatcher: new RegExp(
+      RESOURCE_GROUP_MATCHER +
+        '/providers/Microsoft.ContainerRegistry/registries/[^/]+' +
+        EOL_MATCHER,
+    ),
+    _type: ContainerRegistryEntities.REGISTRY._type,
+    dependsOn: [STEP_RM_CONTAINER_REGISTRIES],
   },
 ];
 

--- a/terraform/container-registry.tf
+++ b/terraform/container-registry.tf
@@ -1,0 +1,32 @@
+variable "create_container_registry_resources" {
+  type    = number
+  default = 0
+}
+
+locals {
+  container_registry_resource_count = var.create_container_registry_resources == 1 ? 1 : 0
+}
+
+variable "azurerm_container_registry_webhook" {
+  type    = number
+  default = 0
+}
+
+resource "azurerm_container_registry" "j1dev" {
+  count               = local.container_registry_resource_count
+  name                = "${var.developer_id}j1dev"
+  resource_group_name = azurerm_resource_group.j1dev.name
+  location            = azurerm_resource_group.j1dev.location
+  sku                 = "Basic"
+}
+
+resource "azurerm_container_registry_webhook" "j1dev" {
+  count               = local.container_registry_resource_count
+  name                = "j1dev"
+  resource_group_name = azurerm_resource_group.j1dev.name
+  registry_name       = azurerm_container_registry.j1dev[0].name
+  location            = azurerm_resource_group.j1dev.location
+
+  service_uri         = "https://mywebhookreceiver.example/mytag"
+  actions             = ["push"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,15 @@
     "@azure/ms-rest-js" "^2.0.4"
     tslib "^1.10.0"
 
+"@azure/arm-containerregistry@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/arm-containerregistry/-/arm-containerregistry-8.0.0.tgz#7d1da67e9d45e540bc75dc12b7a0b55b894b461b"
+  integrity sha512-8v+3YtATbaFv5qMGvhFVR+qx1QPc1+NBy2MWWoJ69SmEE1X91ySvXDbEa0Pr7znm/bqbBYWOLJN5L3Aa7Q0fpg==
+  dependencies:
+    "@azure/ms-rest-azure-js" "^2.0.1"
+    "@azure/ms-rest-js" "^2.0.4"
+    tslib "^1.10.0"
+
 "@azure/arm-cosmosdb@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@azure/arm-cosmosdb/-/arm-cosmosdb-7.0.0.tgz#fe81b23254b233e7244c03981e55da0e11495b73"


### PR DESCRIPTION
The Azure **Container Registry** service is equivalent to the Azure ECR service. 

The Container Registry client for Node.js does _not_ currently expose Repository.list or image/tag.list APIs, so I have ingested only `Registry` and `Webhook` entities (both of which are exposed in the SDK client _and_ as [terraform resources](https://www.terraform.io/docs/providers/azurerm/r/container_registry_webhook.html)).

<img width="588" alt="Screen Shot 2020-09-10 at 11 22 04 AM" src="https://user-images.githubusercontent.com/15333061/92754144-9030a480-f358-11ea-81d2-8761efd7853d.png">
