### PR TITLE
Revert ingest resource manager flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
-## 5.2.0 - 2020-09-21
+## 5.3.1 - 2020-09-21
+
+### Fixed
+
+- Removed `ingestResourceManager` which caused previously-configured
+  integrations to stop ingesting resource manager steps
+
+## 5.3.0 - 2020-09-21
 
 - Added `azure_service_bus_namespace` entities
 - Added `azure_resource_group|has|azure_service_bus_namespace` relationships

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -197,9 +197,9 @@ describe('getStepStartStates', () => {
     });
   });
 
-  test('ingestResourceManager: true', () => {
+  test("subscriptionId: 'value'", () => {
     const context = createMockExecutionContext({
-      instanceConfig: { ingestResourceManager: true } as IntegrationConfig,
+      instanceConfig: { subscriptionId: '1234' } as IntegrationConfig,
     });
     const states = getStepStartStates(context);
     expect(states).toEqual({

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -73,6 +73,7 @@ import {
   STEP_RM_CDN_PROFILE,
   STEP_RM_CDN_ENDPOINTS,
 } from './steps/resource-manager/cdn';
+import { hasSubscriptionId } from '.';
 
 export default function getStepStartStates(
   executionContext: IntegrationExecutionContext<IntegrationConfig>,
@@ -80,7 +81,7 @@ export default function getStepStartStates(
   const config = executionContext.instance.config || {};
 
   const activeDirectory = { disabled: !config.ingestActiveDirectory };
-  const resourceManager = { disabled: !config.ingestResourceManager };
+  const resourceManager = { disabled: !hasSubscriptionId(config) };
 
   return {
     [STEP_AD_ACCOUNT]: { disabled: false },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ import { containerRegistrySteps } from './steps/resource-manager/container-regis
 import { serviceBusSteps } from './steps/resource-manager/service-bus';
 import { cdnSteps } from './steps/resource-manager/cdn';
 
+export function hasSubscriptionId(config: IntegrationConfig): boolean {
+  const subscriptionId = config.subscriptionId;
+  return subscriptionId !== undefined && subscriptionId.length > 0;
+}
+
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields: {
     clientId: {
@@ -40,10 +45,6 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
       mask: false,
     },
     ingestActiveDirectory: {
-      type: 'boolean',
-      mask: false,
-    },
-    ingestResourceManager: {
       type: 'boolean',
       mask: false,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
 
   /**
    * The Azure Subscription from which to fetch Azure resources. Currently not
-   * guaranteed to be present in all integration instances. This is required if `ingestResourceManager` is set to `true`
+   * guaranteed to be present in all integration instances.
    *
    * A Subscription Administrator must assign the "Reader" RBAC role (least
    * privilege) to the Service Principal used to obtain API access tokens.
@@ -58,13 +58,4 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
    * instances.
    */
   ingestActiveDirectory?: boolean;
-
-  /**
-   * A directive indicating whether or not to ingest Resource Manager resources.
-   * A value of `undefined` will be interpreted as `false`.
-   *
-   * The integration may be configured to enable or disable the ingestion of
-   * Resource Manager resources. This is necessary when an account administrator wants to set up an azure AD integration, but does not have an azure subscription and does not want to set one up.
-   */
-  ingestResourceManager?: boolean;
 }

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -4,8 +4,6 @@ import { createMockExecutionContext } from '@jupiterone/integration-sdk-testing'
 import { IntegrationConfig } from './types';
 import validateInvocation from './validateInvocation';
 
-import * as graphAuthenticate from './azure/graph/authenticate';
-
 it('should reject', async () => {
   const executionContext = createMockExecutionContext<IntegrationConfig>({
     instanceConfig: {} as IntegrationConfig,
@@ -16,25 +14,6 @@ it('should reject', async () => {
   } catch (e) {
     expect(e instanceof IntegrationValidationError).toBe(true);
   }
-});
-
-test('rejects when ingestResourceManager=true and subscriptionId=undefined', async () => {
-  jest
-    .spyOn(graphAuthenticate, 'default')
-    .mockResolvedValueOnce('someAccessToken');
-  const executionContext = createMockExecutionContext<IntegrationConfig>({
-    instanceConfig: {
-      clientId: 'INVALID',
-      clientSecret: 'INVALID',
-      directoryId: 'INVALID',
-      ingestResourceManager: true,
-    } as IntegrationConfig,
-  });
-
-  const exec = async () => validateInvocation(executionContext);
-  await expect(exec).rejects.toThrow(
-    'When integration configuration value ingestResourceManager flag is set to true, subscriptionId is required.',
-  );
 });
 
 it('auth error', async () => {

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -2,12 +2,12 @@ import {
   IntegrationExecutionContext,
   IntegrationValidationError,
   IntegrationError,
-  IntegrationLocalConfigFieldMissingError,
 } from '@jupiterone/integration-sdk-core';
 
 import { default as authenticateGraph } from './azure/graph/authenticate';
 import { default as authenticateResourceManager } from './azure/resource-manager/authenticate';
 import { IntegrationConfig } from './types';
+import { hasSubscriptionId } from '.';
 
 export default async function validateInvocation(
   validationContext: IntegrationExecutionContext<IntegrationConfig>,
@@ -30,13 +30,7 @@ export default async function validateInvocation(
     }
   }
 
-  if (config.ingestResourceManager) {
-    if (!config.subscriptionId) {
-      throw new IntegrationLocalConfigFieldMissingError(
-        'When integration configuration value ingestResourceManager flag is set to true, subscriptionId is required.',
-      );
-    }
-
+  if (hasSubscriptionId(config)) {
     try {
       await authenticateResourceManager(config);
     } catch (err) {


### PR DESCRIPTION
Reverting the change from earlier. This change made previously-configured integrations stop ingesting resource manager resources. I feel that reverting this change is a smarter move than setting up a maintenance job to set `ingestResourceManager` to `true` on existing integrations.