### PR TITLE
Stop casting ListResourcesEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop casting client `resourceEndpoint` arg to `ListResourcesEndpoint`
+
 ## 5.4.0 - 2020-10-07
 
 ### Added

--- a/src/azure/resource-manager/client.ts
+++ b/src/azure/resource-manager/client.ts
@@ -21,18 +21,16 @@ import { AzureManagementClientCredentials } from './types';
  * An Azure resource manager endpoint that has `listAll` and `listAllNext` functions.
  */
 export interface ListAllResourcesEndpoint {
-  listAll: <ListResponseType>() => Promise<ListResponseType>;
-  listAllNext: <ListResponseType>(
-    nextLink: string,
-  ) => Promise<ListResponseType>;
+  listAll: () => Promise<ResourceListResponse<any>>;
+  listAllNext: (nextLink: string) => Promise<ResourceListResponse<any>>;
 }
 
 /**
  * An Azure resource manager endpoint that has `list` and `listNext` functions.
  */
 export interface ListResourcesEndpoint {
-  list<ListResponseType>(...args: any): Promise<ListResponseType>;
-  listNext?<ListResponseType>(nextLink: string): Promise<ListResponseType>;
+  list(...args: any): Promise<ResourceListResponse<any>>;
+  listNext?(nextLink: string): Promise<ResourceListResponse<any>>;
 }
 
 export interface ResourceListResponse<T> extends Array<T> {
@@ -260,19 +258,13 @@ export async function iterateAllResources<ServiceClientType, ResourceType>({
         if ('listAllNext' in resourceEndpoint) {
           return nextLink
             ? /* istanbul ignore next: testing iteration might be difficult */
-              await resourceEndpoint.listAllNext<
-                ResourceListResponse<ResourceType>
-              >(nextLink)
-            : await resourceEndpoint.listAll<
-                ResourceListResponse<ResourceType>
-              >();
+              await resourceEndpoint.listAllNext(nextLink)
+            : await resourceEndpoint.listAll();
         } else {
           return resourceEndpoint.listNext && nextLink
             ? /* istanbul ignore next: testing iteration might be difficult */
-              await resourceEndpoint.listNext<
-                ResourceListResponse<ResourceType>
-              >(nextLink)
-            : await resourceEndpoint.list<ResourceListResponse<ResourceType>>();
+              await resourceEndpoint.listNext(nextLink)
+            : await resourceEndpoint.list();
         }
       }, endpointRatePeriod);
     } catch (err) {

--- a/src/steps/resource-manager/api-management/client.ts
+++ b/src/steps/resource-manager/api-management/client.ts
@@ -6,7 +6,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -49,7 +48,7 @@ export class J1ApiManagementClient extends Client {
         ) => {
           return serviceClient.api.listByServiceNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'apiManagement.api',
       callback,
     });

--- a/src/steps/resource-manager/batch/client.ts
+++ b/src/steps/resource-manager/batch/client.ts
@@ -8,7 +8,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 
 export class BatchClient extends Client {
@@ -33,7 +32,7 @@ export class BatchClient extends Client {
         list: async () =>
           serviceClient.batchAccount.listByResourceGroup(resourceGroupName),
         listNext: serviceClient.batchAccount.listByResourceGroupNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'batch.account',
       callback,
     });
@@ -64,7 +63,7 @@ export class BatchClient extends Client {
             batchAccountName,
           ),
         listNext: serviceClient.pool.listByBatchAccountNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'batch.pool',
       callback,
     });
@@ -92,7 +91,7 @@ export class BatchClient extends Client {
         list: async () =>
           serviceClient.application.list(resourceGroupName, batchAccountName),
         listNext: serviceClient.application.listNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'batch.application',
       callback,
     });
@@ -123,7 +122,7 @@ export class BatchClient extends Client {
             batchAccountName,
           ),
         listNext: serviceClient.certificate.listByBatchAccountNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'batch.certificate',
       callback,
     });

--- a/src/steps/resource-manager/cdn/client.ts
+++ b/src/steps/resource-manager/cdn/client.ts
@@ -3,7 +3,6 @@ import { Profile, Endpoint } from '@azure/arm-cdn/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -49,7 +48,7 @@ export class CdnClient extends Client {
         ) => {
           return serviceClient.endpoints.listByProfileNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'cdn.endpoint',
       callback,
     });

--- a/src/steps/resource-manager/container-instance/client.ts
+++ b/src/steps/resource-manager/container-instance/client.ts
@@ -3,7 +3,6 @@ import { ContainerGroup } from '@azure/arm-containerinstance/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 
 export class ContainerInstanceClient extends Client {
@@ -28,7 +27,7 @@ export class ContainerInstanceClient extends Client {
         list: async () =>
           serviceClient.containerGroups.listByResourceGroup(resourceGroupName),
         listNext: serviceClient.containerGroups.listByResourceGroupNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'containerInstance.containerGroups',
       callback,
     });

--- a/src/steps/resource-manager/container-registry/client.ts
+++ b/src/steps/resource-manager/container-registry/client.ts
@@ -3,7 +3,6 @@ import { Registry, Webhook } from '@azure/arm-containerregistry/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -46,7 +45,7 @@ export class J1ContainerRegistryManagementClient extends Client {
         ) => {
           return serviceClient.webhooks.listNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'containerRegistry.webhook',
       callback,
     });

--- a/src/steps/resource-manager/cosmosdb/client.ts
+++ b/src/steps/resource-manager/cosmosdb/client.ts
@@ -7,7 +7,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -56,7 +55,7 @@ export class CosmosDBClient extends Client {
             accountName,
           );
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'cosmosdb.listSqlDatabases',
       callback,
     });

--- a/src/steps/resource-manager/databases/mariadb/client.ts
+++ b/src/steps/resource-manager/databases/mariadb/client.ts
@@ -4,7 +4,6 @@ import { Database, Server } from '@azure/arm-mariadb/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../../azure/utils';
 
@@ -47,7 +46,7 @@ export class MariaDBClient extends Client {
             serverName,
           );
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'maria.databases',
       callback,
     });

--- a/src/steps/resource-manager/databases/mysql/client.ts
+++ b/src/steps/resource-manager/databases/mysql/client.ts
@@ -4,7 +4,6 @@ import { Database, Server } from '@azure/arm-mysql/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../../azure/utils';
 
@@ -47,7 +46,7 @@ export class MySQLClient extends Client {
             serverName,
           );
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'mysql.databases',
       callback,
     });

--- a/src/steps/resource-manager/databases/postgresql/client.ts
+++ b/src/steps/resource-manager/databases/postgresql/client.ts
@@ -4,7 +4,6 @@ import { Database, Server } from '@azure/arm-postgresql/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../../azure/utils';
 
@@ -47,7 +46,7 @@ export class PostgreSQLClient extends Client {
             serverName,
           );
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'postgresql.databases',
       callback,
     });

--- a/src/steps/resource-manager/databases/sql/client.ts
+++ b/src/steps/resource-manager/databases/sql/client.ts
@@ -12,7 +12,6 @@ import { IntegrationProviderAPIError } from '@jupiterone/integration-sdk-core';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../../azure/utils';
 
@@ -58,7 +57,7 @@ export class SQLClient extends Client {
             serverName,
           );
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'sql.databases',
       callback,
     });

--- a/src/steps/resource-manager/dns/client.ts
+++ b/src/steps/resource-manager/dns/client.ts
@@ -3,7 +3,6 @@ import { Zone, RecordSet } from '@azure/arm-dns/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -49,7 +48,7 @@ export class J1DnsManagementClient extends Client {
         ) => {
           return serviceClient.recordSets.listByDnsZoneNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'dns.recordSet',
       callback,
     });

--- a/src/steps/resource-manager/event-grid/client.ts
+++ b/src/steps/resource-manager/event-grid/client.ts
@@ -8,7 +8,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 
 export class EventGridClient extends Client {
@@ -34,7 +33,7 @@ export class EventGridClient extends Client {
         list: async () =>
           serviceClient.domains.listByResourceGroup(resourceGroupName),
         listNext: serviceClient.domains.listByResourceGroupNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'eventGrid.domain',
       callback,
     });
@@ -65,7 +64,7 @@ export class EventGridClient extends Client {
             domainName,
           ),
         listNext: serviceClient.domainTopics.listByDomainNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'eventGrid.domainTopic',
       callback,
     });
@@ -101,7 +100,7 @@ export class EventGridClient extends Client {
             domainTopicName,
           ),
         listNext: serviceClient.eventSubscriptions.listByDomainTopicNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'eventGrid.domainTopicSubscription',
       callback,
     });
@@ -129,7 +128,7 @@ export class EventGridClient extends Client {
         list: async () =>
           serviceClient.topics.listByResourceGroup(resourceGroupName),
         listNext: serviceClient.topics.listByResourceGroupNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'eventGrid.topic',
       callback,
     });
@@ -172,7 +171,7 @@ export class EventGridClient extends Client {
             topicName,
           ),
         listNext: serviceClient.eventSubscriptions.listByResourceNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'eventGrid.topicSubscription',
       callback,
     });

--- a/src/steps/resource-manager/private-dns/client.ts
+++ b/src/steps/resource-manager/private-dns/client.ts
@@ -3,7 +3,6 @@ import { PrivateZone, RecordSet } from '@azure/arm-privatedns/esm/models';
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -46,7 +45,7 @@ export class J1PrivateDnsManagementClient extends Client {
         ) => {
           return serviceClient.recordSets.listNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'privatedns.recordSet',
       callback,
     });

--- a/src/steps/resource-manager/redis-cache/client.ts
+++ b/src/steps/resource-manager/redis-cache/client.ts
@@ -7,7 +7,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 
 export class RedisCacheClient extends Client {
@@ -31,7 +30,7 @@ export class RedisCacheClient extends Client {
         list: async () =>
           serviceClient.redis.listByResourceGroup(resourceGroupName),
         listNext: serviceClient.redis.listByResourceGroupNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'redisCache.cache',
       callback,
     });
@@ -62,7 +61,7 @@ export class RedisCacheClient extends Client {
             redisCacheName,
           ),
         listNext: serviceClient.firewallRules.listByRedisResourceNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'redisCache.firewallRule',
       callback,
     });
@@ -90,7 +89,7 @@ export class RedisCacheClient extends Client {
         list: async () =>
           serviceClient.linkedServer.list(resourceGroupName, redisCacheName),
         listNext: serviceClient.linkedServer.listNext,
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'redisCache.linkedServer',
       callback,
     });

--- a/src/steps/resource-manager/service-bus/client.ts
+++ b/src/steps/resource-manager/service-bus/client.ts
@@ -8,7 +8,6 @@ import {
 import {
   Client,
   iterateAllResources,
-  ListResourcesEndpoint,
 } from '../../../azure/resource-manager/client';
 import { resourceGroupName } from '../../../azure/utils';
 
@@ -53,7 +52,7 @@ export class ServiceBusClient extends Client {
         ) => {
           return serviceClient.queues.listByNamespaceNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'serviceBus.queue',
       callback,
     });
@@ -83,7 +82,7 @@ export class ServiceBusClient extends Client {
         ) => {
           return serviceClient.topics.listByNamespaceNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'serviceBus.topic',
       callback,
     });
@@ -115,7 +114,7 @@ export class ServiceBusClient extends Client {
         ) => {
           return serviceClient.topics.listByNamespaceNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'serviceBus.topic.subscription',
       callback,
     });

--- a/src/steps/resource-manager/storage/client.ts
+++ b/src/steps/resource-manager/storage/client.ts
@@ -8,6 +8,14 @@ import {
   Kind,
 } from '@azure/arm-storage/esm/models';
 
+import {
+  Client,
+  iterateAllResources,
+  IterateAllResourcesOptions,
+  ListResourcesEndpoint,
+} from '../../../azure/resource-manager/client';
+import { resourceGroupName } from '../../../azure/utils';
+
 interface ListStorageAccountResourcesEndpoint extends ListResourcesEndpoint {
   list<ListResponseType>(
     resourceGroupName: string,
@@ -45,19 +53,11 @@ async function iterateAllStorageAccountResources<ResourceType>({
       ) => {
         return resourceEndpoint.listNext(nextLink);
       },
-    } as ListResourcesEndpoint,
+    },
     resourceDescription,
     callback,
   });
 }
-
-import {
-  Client,
-  iterateAllResources,
-  ListResourcesEndpoint,
-  IterateAllResourcesOptions,
-} from '../../../azure/resource-manager/client';
-import { resourceGroupName } from '../../../azure/utils';
 
 export class StorageClient extends Client {
   public async iterateStorageAccounts(
@@ -98,7 +98,7 @@ export class StorageClient extends Client {
         ) => {
           return serviceClient.blobContainers.listNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'storage.blobContainers',
       callback,
     });
@@ -174,7 +174,7 @@ export class StorageClient extends Client {
         ) => {
           return serviceClient.fileShares.listNext(nextLink);
         },
-      } as ListResourcesEndpoint,
+      },
       resourceDescription: 'storage.fileShares',
       callback,
     });


### PR DESCRIPTION
The typings on `ListResourcesEndpoint` and `ListAllResourcesEndpoint` have caused issues in the past when synthetic `resourceEndpoint` arguments are used in Azure service clients. Because of the imperfect typings, developers used a common pattern of type asserting on these endpoints. However, type asserting actually took away any real surety that proper types were used, and bugs such as creating a `linkNext` property where it should have been `listNext`.

Fixes #168 