### PR TITLE
Add key lookup transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Added the ability to execute specific steps in an integration last.
+- Added a transformer so that `findEntity` uses case-insensitive matching.
 - Added `azure_advisor_recommendation` entities
 - Added `ANY_SCOPE|has|azure_advisor_recommendation` relationships. These can
   target any scoped entity within Azure.

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "@azure/ms-rest-js": "^2.0.0"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^3.5.1"
+    "@jupiterone/integration-sdk-core": "^3.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^3.5.1",
-    "@jupiterone/integration-sdk-dev-tools": "^3.5.1",
-    "@jupiterone/integration-sdk-testing": "^3.5.1",
+    "@jupiterone/integration-sdk-core": "^3.6.0",
+    "@jupiterone/integration-sdk-dev-tools": "^3.6.0",
+    "@jupiterone/integration-sdk-testing": "^3.6.0",
     "@microsoft/microsoft-graph-types": "^1.10.0",
     "@types/fs-extra": "^5.0.5",
     "@types/jest": "^25.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,4 +81,8 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...advisorSteps,
     ...securitySteps,
   ],
+
+  invocationConfigOptions: {
+    keyNormalizationFunction: (_key) => _key.toLowerCase(),
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,5 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...securitySteps,
   ],
 
-  invocationConfigOptions: {
-    keyNormalizationFunction: (_key) => _key.toLowerCase(),
-  },
+  normalizeGraphObjectKey: (_key) => _key.toLowerCase(),
 };

--- a/src/steps/active-directory/index.test.ts
+++ b/src/steps/active-directory/index.test.ts
@@ -1,7 +1,4 @@
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 
 import { setupAzureRecording } from '../../../test/helpers/recording';
 import instanceConfig from '../../../test/integrationInstanceConfig';
@@ -13,6 +10,7 @@ import {
   fetchUsers,
   fetchServicePrincipals,
 } from './index';
+import { createMockAzureStepExecutionContext } from '../../../test/createMockAzureStepExecutionContext';
 
 let recording: Recording;
 
@@ -26,7 +24,7 @@ test('active directory steps', async () => {
     name: 'active-directory-steps',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
   });
 
@@ -301,7 +299,7 @@ test('active directory step - service principals', async () => {
     name: 'active-directory-step-service-principals',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
   });
 

--- a/src/steps/resource-manager/advisor/index.test.ts
+++ b/src/steps/resource-manager/advisor/index.test.ts
@@ -1,8 +1,5 @@
 import { fetchRecommendations } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { AdvisorEntities, AdvisorRelationships } from './constants';
@@ -15,6 +12,7 @@ import { SUBSCRIPTION_ENTITY_METADATA } from '../subscriptions';
 import { STORAGE_ACCOUNT_ENTITY_METADATA } from '../storage';
 import { SecurityEntities } from '../security';
 import { ResourceRecommendationBase } from '@azure/arm-advisor/esm/models';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 let recording: Recording;
 
@@ -37,7 +35,7 @@ test('step - recommendations', async () => {
     name: 'resource-manager-step-recommendations',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       // ASSESSMENT ENTITIES

--- a/src/steps/resource-manager/advisor/index.ts
+++ b/src/steps/resource-manager/advisor/index.ts
@@ -33,36 +33,40 @@ export async function fetchRecommendations(
       createRecommendationEntity(webLinker, recommendation),
     );
 
-    const assessmentEntity = await jobState.findEntity(
-      recommendation.resourceMetadata?.source!,
-    );
-    if (assessmentEntity) {
-      await jobState.addRelationship(
-        createDirectRelationship({
-          _class: AdvisorRelationships.ASSESSMENT_IDENTIFIED_FINDING._class,
-          from: assessmentEntity,
-          to: recommendationEntity,
-          properties: {
-            _type: AdvisorRelationships.ASSESSMENT_IDENTIFIED_FINDING._type,
-          },
-        }),
+    if (recommendation.resourceMetadata?.source) {
+      const assessmentEntity = await jobState.findEntity(
+        recommendation.resourceMetadata.source,
       );
+      if (assessmentEntity) {
+        await jobState.addRelationship(
+          createDirectRelationship({
+            _class: AdvisorRelationships.ASSESSMENT_IDENTIFIED_FINDING._class,
+            from: assessmentEntity,
+            to: recommendationEntity,
+            properties: {
+              _type: AdvisorRelationships.ASSESSMENT_IDENTIFIED_FINDING._type,
+            },
+          }),
+        );
+      }
     }
 
-    const resourceEntity = await jobState.findEntity(
-      recommendation.resourceMetadata?.resourceId!,
-    );
-    if (resourceEntity) {
-      await jobState.addRelationship(
-        createDirectRelationship({
-          _class: AdvisorRelationships.ANY_RESOURCE_HAS_FINDING._class,
-          from: resourceEntity,
-          to: recommendationEntity,
-          properties: {
-            _type: AdvisorRelationships.ANY_RESOURCE_HAS_FINDING._type,
-          },
-        }),
+    if (recommendation.resourceMetadata?.resourceId) {
+      const resourceEntity = await jobState.findEntity(
+        recommendation.resourceMetadata.resourceId,
       );
+      if (resourceEntity) {
+        await jobState.addRelationship(
+          createDirectRelationship({
+            _class: AdvisorRelationships.ANY_RESOURCE_HAS_FINDING._class,
+            from: resourceEntity,
+            to: recommendationEntity,
+            properties: {
+              _type: AdvisorRelationships.ANY_RESOURCE_HAS_FINDING._type,
+            },
+          }),
+        );
+      }
     }
   });
 }

--- a/src/steps/resource-manager/api-management/index.test.ts
+++ b/src/steps/resource-manager/api-management/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchApiManagementServices, fetchApiManagementApis } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - api management services', async () => {
     name: 'resource-manager-step-api-management-services',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -122,7 +120,7 @@ test('step - api management apis', async () => {
     },
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/authorization/index.test.ts
+++ b/src/steps/resource-manager/authorization/index.test.ts
@@ -8,10 +8,7 @@ import {
   buildRoleAssignmentScopeRelationships,
 } from '.';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { AuthorizationClient } from './client';
 import { Entity } from '@jupiterone/integration-sdk-core';
@@ -30,6 +27,7 @@ import { generateEntityKey } from '../../../utils/generateKeys';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { USER_ENTITY_TYPE, USER_ENTITY_CLASS } from '../../active-directory';
 import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 let recording: Recording;
 
@@ -76,7 +74,7 @@ describe('#findOrCreateRoleDefinitionEntity', () => {
       _class: ROLE_DEFINITION_ENTITY_CLASS,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [roleDefinitionEntity],
     });
@@ -135,7 +133,7 @@ describe('#findOrCreateRoleDefinitionEntity', () => {
       _class: ROLE_DEFINITION_ENTITY_CLASS,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -164,7 +162,7 @@ describe('#findOrCreateRoleDefinitionEntity', () => {
       roleDefinitionId: fullyQualifiedRoleDefinitionId,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -219,7 +217,7 @@ describe('#findOrBuildTargetEntityForRoleDefinition', () => {
       principalType,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [targetEntity],
     });
@@ -252,7 +250,7 @@ describe('#findOrBuildTargetEntityForRoleDefinition', () => {
       principalType,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -285,7 +283,7 @@ test('step - role assignments', async () => {
     name: 'active-directory-step-role-assignments',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
   });
 
@@ -356,7 +354,7 @@ test('step - role assignment principal relationships', async () => {
     principalType: 'User' as PrincipalType,
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       userEntity,
@@ -437,7 +435,7 @@ test('step - role assignment scope relationships', async () => {
     scope: keyVaultPrefix + 'some-non-keyvault',
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       keyVaultEntity,
@@ -498,7 +496,7 @@ test('step - role definitions', async () => {
     roleDefinitionId:
       '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c',
   };
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [roleAssignmentEntity, roleAssignmentEntityTwo],
   });
@@ -575,7 +573,7 @@ test('step - classic administrators', async () => {
     name: 'active-directory-step-classic-administrators',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
   });
 

--- a/src/steps/resource-manager/batch/index.test.ts
+++ b/src/steps/resource-manager/batch/index.test.ts
@@ -4,12 +4,10 @@ import {
   fetchBatchCertificates,
   fetchBatchPools,
 } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 let recording: Recording;
 
@@ -41,7 +39,7 @@ test('step - batch accounts', async () => {
     location: 'eastus',
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [resourceGroup],
   });
@@ -82,7 +80,7 @@ test('step - batch pools', async () => {
     name: 'j1devbatchaccount',
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [batchAccount],
   });
@@ -123,7 +121,7 @@ test('step - batch applications', async () => {
     name: 'j1devbatchaccount',
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [batchAccount],
   });
@@ -164,7 +162,7 @@ test('step - batch certificates', async () => {
     name: 'j1devbatchaccount',
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [batchAccount],
   });

--- a/src/steps/resource-manager/cdn/index.test.ts
+++ b/src/steps/resource-manager/cdn/index.test.ts
@@ -1,11 +1,9 @@
 import { fetchProfiles, fetchEndpoints } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { CdnEntities } from './constants';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -27,7 +25,7 @@ test('step - cdn profiles', async () => {
     name: 'resource-manager-step-cdn-profiles',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -81,7 +79,7 @@ test('step - cdn endpoints', async () => {
 
   const parentId =
     '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/Microsoft.Cdn/profiles/j1dev';
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/container-instance/index.test.ts
+++ b/src/steps/resource-manager/container-instance/index.test.ts
@@ -1,11 +1,11 @@
 import {
-  createMockStepExecutionContext,
   Recording,
   MockIntegrationStepExecutionContext,
 } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { fetchContainerGroups } from '.';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 const instanceConfig: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',
@@ -45,7 +45,7 @@ describe('step = container instance container groups', () => {
       },
     };
 
-    context = createMockStepExecutionContext<IntegrationConfig>({
+    context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: Object.values(entities),
     });

--- a/src/steps/resource-manager/container-registry/index.test.ts
+++ b/src/steps/resource-manager/container-registry/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchContainerRegistries, fetchContainerRegistryWebhooks } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - container registries', async () => {
     name: 'resource-manager-step-container-registries',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -78,7 +76,7 @@ test('step - container registry webhooks', async () => {
     name: 'resource-manager-step-container-registry-webhooks',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/dns/index.test.ts
+++ b/src/steps/resource-manager/dns/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchZones, fetchRecordSets } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - dns zones', async () => {
     name: 'resource-manager-step-dns-zones',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -103,7 +101,7 @@ test('step - dns record sets', async () => {
     },
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/event-grid/index.test.ts
+++ b/src/steps/resource-manager/event-grid/index.test.ts
@@ -6,13 +6,11 @@ import {
   fetchEventGridTopicSubscriptions,
 } from '.';
 
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 const instanceConfig: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',
@@ -35,7 +33,7 @@ test('step = event grid domains', async () => {
     name: 'resource-manager-step-event-grid-domains',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -83,7 +81,7 @@ test('step = event grid domain topics', async () => {
     name: 'resource-manager-step-event-grid-domain-topics',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -141,7 +139,7 @@ test('step = event grid domain topic subscriptions', async () => {
     name: 'resource-manager-step-event-grid-domain-topic-subscriptions',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -200,7 +198,7 @@ test('step = event grid topics', async () => {
     name: 'resource-manager-step-event-grid-topics',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -248,7 +246,7 @@ test('step = event grid topic subscriptions', async () => {
     name: 'resource-manager-step-event-grid-topic-subscriptions',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -3,14 +3,10 @@ import {
   Relationship,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
-import { IntegrationConfig } from '../../../types';
 import { fetchAccount } from '../../active-directory';
 import {
   buildSecurityGroupRuleRelationships,
@@ -20,6 +16,7 @@ import {
   fetchPublicIPAddresses,
   fetchVirtualNetworks,
 } from './';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 expect.extend({
   toContainGraphObject<T extends Entity | Relationship>(
@@ -108,7 +105,7 @@ test('network steps', async () => {
     _class: ['Group'],
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [resouceGroupEntity],
   });

--- a/src/steps/resource-manager/private-dns/index.test.ts
+++ b/src/steps/resource-manager/private-dns/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchPrivateZones, fetchPrivateRecordSets } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - private dns zones', async () => {
     name: 'resource-manager-step-private-dns-zones',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -92,7 +90,7 @@ test('step - private dns record sets', async () => {
     },
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/redis-cache/index.test.ts
+++ b/src/steps/resource-manager/redis-cache/index.test.ts
@@ -3,12 +3,10 @@ import {
   fetchRedisFirewallRules,
   fetchRedisLinkedServers,
 } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 const instanceConfig: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',
@@ -31,7 +29,7 @@ test('step = redis caches', async () => {
     name: 'resource-manager-step-redis-caches',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -79,7 +77,7 @@ test('step = redis firewall rules', async () => {
     name: 'resource-manager-step-redis-firewall-rules',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -184,7 +182,7 @@ test('step = redis linked servers', async () => {
     },
   };
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: Object.values(entities),
   });

--- a/src/steps/resource-manager/resources/index.test.ts
+++ b/src/steps/resource-manager/resources/index.test.ts
@@ -2,14 +2,12 @@ import {
   fetchResourceGroups,
   createSubscriptionResourceGroupRelationship,
 } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import globalInstanceConfig from '../../../../test/integrationInstanceConfig';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { Entity } from '@jupiterone/integration-sdk-core';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -27,7 +25,7 @@ describe('#createSubscriptionResourceGroupRelationship', () => {
       _key: subscriptionId,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig: globalInstanceConfig,
       entities: [subscriptionEntity],
     });
@@ -58,7 +56,7 @@ describe('#createSubscriptionResourceGroupRelationship', () => {
   test('should throw when subscription does not exist in jobState', async () => {
     const subscriptionId = '/subscriptions/subscription-id';
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig: globalInstanceConfig,
       entities: [],
     });
@@ -81,7 +79,7 @@ describe('#createSubscriptionResourceGroupRelationship', () => {
   });
 
   test('should throw when subscription ID cannot be extracted from entity _key', async () => {
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig: globalInstanceConfig,
       entities: [],
     });
@@ -117,7 +115,7 @@ test('step - resource groups', async () => {
     name: 'resource-manager-step-resource-groups',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/security/index.test.ts
+++ b/src/steps/resource-manager/security/index.test.ts
@@ -1,13 +1,11 @@
 import { fetchAssessments } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { SUBSCRIPTION_ENTITY_METADATA } from '../subscriptions';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
 import { SecurityEntities } from './constants';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -29,7 +27,7 @@ test('step - security assessments', async () => {
     name: 'resource-manager-step-security-assessments',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/service-bus/index.test.ts
+++ b/src/steps/resource-manager/service-bus/index.test.ts
@@ -4,12 +4,10 @@ import {
   fetchServiceBusTopics,
   fetchServiceBusSubscriptions,
 } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -31,7 +29,7 @@ test('step - service bus namespaces', async () => {
     name: 'resource-manager-step-service-bus-namespaces',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -83,7 +81,7 @@ test('step - service bus queues', async () => {
     name: 'resource-manager-step-service-bus-queues',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -137,7 +135,7 @@ test('step - service bus topics', async () => {
     name: 'resource-manager-step-service-bus-topics',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -192,7 +190,7 @@ test('step - service bus subscriptions', async () => {
     name: 'resource-manager-step-service-bus-subscriptions',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchStorageQueues, fetchStorageTables } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - storage queues', async () => {
     name: 'resource-manager-step-storage-queues',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {
@@ -105,7 +103,7 @@ test('step - storage tables', async () => {
     },
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
       {

--- a/src/steps/resource-manager/subscriptions/index.test.ts
+++ b/src/steps/resource-manager/subscriptions/index.test.ts
@@ -1,10 +1,8 @@
 import { fetchSubscriptions } from '.';
-import {
-  createMockStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 let recording: Recording;
 
 afterEach(async () => {
@@ -26,7 +24,7 @@ test('step - subscriptions', async () => {
     name: 'resource-manager-step-resource-groups',
   });
 
-  const context = createMockStepExecutionContext<IntegrationConfig>({
+  const context = createMockAzureStepExecutionContext({
     instanceConfig,
   });
 

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
@@ -1,8 +1,7 @@
-import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
-import { IntegrationConfig } from '../../../types';
 import { Entity } from '@jupiterone/integration-sdk-core';
 import createResourceGroupResourceRelationship from './createResourceGroupResourceRelationship';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 describe('#createResourceGroupResourceRelationship', () => {
   test('should return direct relationship when resourceGroup exists in jobState', async () => {
@@ -14,7 +13,7 @@ describe('#createResourceGroupResourceRelationship', () => {
       _key: resourceGroupId,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [resourceGroupEntity],
     });
@@ -53,7 +52,7 @@ describe('#createResourceGroupResourceRelationship', () => {
       _key: resourceGroupId,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [resourceGroupEntity],
     });
@@ -88,7 +87,7 @@ describe('#createResourceGroupResourceRelationship', () => {
     const resourceGroupId =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id';
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -115,7 +114,7 @@ describe('#createResourceGroupResourceRelationship', () => {
   });
 
   test('should throw when resourceGroup cannot be extracted from entity _key', async () => {
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -141,7 +140,7 @@ describe('#createResourceGroupResourceRelationship', () => {
       _key: '/subscriptions/subscription-id/resourceGroups/resource-group-id',
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [resourceGroupEntity],
     });

--- a/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
+++ b/src/steps/resource-manager/utils/findOrBuildResourceEntityFromResourceId.test.ts
@@ -1,9 +1,8 @@
 import findOrBuildResourceEntityFromResourceId from './findOrBuildResourceEntityFromResourceId';
 import { Entity } from '@jupiterone/integration-sdk-core';
-import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
 import instanceConfig from '../../../../test/integrationInstanceConfig';
-import { IntegrationConfig } from '../../../types';
 import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 
 describe('#findOrBuildResourceEntityFromResourceId', () => {
   test('should find resource entity that exists in the job state', async () => {
@@ -15,7 +14,7 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
       _key: id,
     };
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [targetEntity],
     });
@@ -31,7 +30,7 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
     const id =
       '/subscriptions/subscription-id/resourceGroups/resource-group-id/providers/Microsoft.KeyVault/vaults/key-vault-id';
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });
@@ -49,7 +48,7 @@ describe('#findOrBuildResourceEntityFromResourceId', () => {
   test('should return undefined if resourceId does not match', async () => {
     const id = 'some-random-id';
 
-    const context = createMockStepExecutionContext<IntegrationConfig>({
+    const context = createMockAzureStepExecutionContext({
       instanceConfig,
       entities: [],
     });

--- a/test/createMockAzureStepExecutionContext.ts
+++ b/test/createMockAzureStepExecutionContext.ts
@@ -10,10 +10,6 @@ export function createMockAzureStepExecutionContext(
 ) {
   return createMockStepExecutionContext<IntegrationConfig>({
     ...options,
-    invocationConfigOptions: {
-      ...options.invocationConfigOptions,
-      keyNormalizationFunction:
-        invocationConfig.invocationConfigOptions?.keyNormalizationFunction,
-    },
+    normalizeGraphObjectKey: invocationConfig.normalizeGraphObjectKey,
   });
 }

--- a/test/createMockAzureStepExecutionContext.ts
+++ b/test/createMockAzureStepExecutionContext.ts
@@ -1,0 +1,19 @@
+import {
+  CreateMockStepExecutionContextOptions,
+  createMockStepExecutionContext,
+} from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '../src/types';
+import { invocationConfig } from '../src';
+
+export function createMockAzureStepExecutionContext(
+  options: CreateMockStepExecutionContextOptions<IntegrationConfig>,
+) {
+  return createMockStepExecutionContext<IntegrationConfig>({
+    ...options,
+    invocationConfigOptions: {
+      ...options.invocationConfigOptions,
+      keyNormalizationFunction:
+        invocationConfig.invocationConfigOptions?.keyNormalizationFunction,
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,12 +1004,12 @@
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk-cli@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-3.5.1.tgz#fb5b7c61a949371d94d75003f4d90f3ce420f12e"
-  integrity sha512-bQ5W0+2mkRZqm9yvSN1S7Kl0IWMAK7kxy4uw9a814ygLVlLAiF/d6ojkNmOCQDI/bW8s63DZGqGyWntHLAHTfA==
+"@jupiterone/integration-sdk-cli@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-3.6.0.tgz#4212a0906eb9a67e9feb3707b5911d4646377c31"
+  integrity sha512-sUUF8YG8uE17CmzdPkyX2OHQ230dUNKOX877JQkMcb/Puv3pfGfX71KWZtpuhjzO0YszqEewi9eIixf9bY+NPg==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^3.5.1"
+    "@jupiterone/integration-sdk-runtime" "^3.6.0"
     commander "^5.0.0"
     globby "^11.0.0"
     lodash "^4.17.19"
@@ -1017,22 +1017,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-3.5.1.tgz#c76f0f367af2ddc1a2d9d177f7c49ceebc243e09"
-  integrity sha512-VyW80iHP1ixduD0ZODgIzl0N/pEM3uV73wkJ7D0YBctz2YhXWM80tIAq1R+l/MPqXXdSIs+kSSztZ6aYRV94bQ==
+"@jupiterone/integration-sdk-core@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-3.6.0.tgz#fa458237c1ff548262d426764891b10fa4d2f5ea"
+  integrity sha512-31zzZAGPhLMHf1BDQJPym3AN98/s4pv35VtIuPMEdIgwLt2Vb1J0ExQsmaQk3w9UANStir30DgLWYwuiyrpdDQ==
   dependencies:
     "@jupiterone/data-model" "^0.14.0"
     lodash "^4.17.15"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-dev-tools@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-3.5.1.tgz#65ad53ab897fb4044dcbfdf210487cb3f1a747fa"
-  integrity sha512-0xXIujqQ4ZVKSeSP+9dA+NUV6/m5dRdrIHR/8GRWBzkNCkRtEufpzsrVXnR6GamvPBd7RJGTCxQGfwtXYeApEQ==
+"@jupiterone/integration-sdk-dev-tools@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-3.6.0.tgz#de103bd3d9f8fe862ed9d452d4f3ddef71bfd5ef"
+  integrity sha512-tD0dLjNY4zPX9VkgVx14Gvju8bM8qFQtOkY9nUDvvLeQN7WVKQEufrVAXY+YFsqM/7hvg/S4cpK9K9B5sbEPhQ==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^3.5.1"
-    "@jupiterone/integration-sdk-testing" "^3.5.1"
+    "@jupiterone/integration-sdk-cli" "^3.6.0"
+    "@jupiterone/integration-sdk-testing" "^3.6.0"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^3.8.0"
@@ -1048,12 +1048,12 @@
     ts-node "^8.10.2"
     typescript "^3.9.3"
 
-"@jupiterone/integration-sdk-runtime@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-3.5.1.tgz#9d780a6aa6767635813360edd09195791acbe29b"
-  integrity sha512-kahZeWri438SfQA6eP0en03d1xN9dgKGif/ue8d6MN6LrN51jkBildgx5FSu1/w6bOBjQ3bgQp1+sGslvYCbCA==
+"@jupiterone/integration-sdk-runtime@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-3.6.0.tgz#e511e1e40e718bbc8fd6b6c32c8e0013477bebb4"
+  integrity sha512-6eDv4S8eO4h66lNwWQ8eOp1To8bqi2bwOlqLzixAC+sErJEtrIKBcKHs+VE+BAMgiYI/FW6ZxFo5MHHhjtyDdw==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^3.5.1"
+    "@jupiterone/integration-sdk-core" "^3.6.0"
     "@lifeomic/alpha" "^1.1.3"
     async-sema "^3.1.0"
     axios "^0.19.2"
@@ -1071,13 +1071,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-3.5.1.tgz#051661f78427c3af2ebdf505c29d48bb5aa9176d"
-  integrity sha512-ZNptJ9/26OPpujiooHeUG0E30+Z5yVH5rulzFi7lFNlUs86JDlzdcInan0rL3TqOPufUem1HmCvyKnnyo9XSPw==
+"@jupiterone/integration-sdk-testing@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-3.6.0.tgz#4a9435223d4ab3079be8fd3500291c963d875d59"
+  integrity sha512-7lmv+kQfS1Y3B/O6r6/gKQscj+fHc5jj3ql58dSY8p7Q6R8sLofH5ukI2kmmxkvHZio1AqvEAftKRYamDy05pw==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^3.5.1"
-    "@jupiterone/integration-sdk-runtime" "^3.5.1"
+    "@jupiterone/integration-sdk-core" "^3.6.0"
+    "@jupiterone/integration-sdk-runtime" "^3.6.0"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"


### PR DESCRIPTION
Implement key normalization introduced in:  https://github.com/JupiterOne/sdk/pull/358

Azure IDs have inconsistent casing when returned from a variety of Azure APIs. Normalize Azure IDs to lowercase in order to ensure that the `DuplicateKeyTracker` and `jobState.findEntity()` functionality work properly for these `_key` values.