### PR TITLE
Feature/azure monitor log profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to
 - Added `azure_monitor_log_profile` entities
 - Added `azure_subscription|has|azure_monitor_log_profile` relationships
 - Added `azure_monitor_log_profile|uses|azure_storage_account` relationships
+- Added `encyrption.keySource` and `encryption.keyVaultProperties` to the
+  `azure_storage_account` entity
+- Added `allowBlobPublicAccess` to the `azure_storage_account` entity
 
 ## 5.7.0 - 2020-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - Added `encryption.keySource` and `encryption.keyVaultProperties` to the
   `azure_storage_account` entity
 - Added `allowBlobPublicAccess` to the `azure_storage_account` entity
+- Added `azure_storage_account|uses|azure_keyvault_service` relationship
 
 ## 5.7.0 - 2020-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - Added `azure_monitor_log_profile` entities
 - Added `azure_subscription|has|azure_monitor_log_profile` relationships
 - Added `azure_monitor_log_profile|uses|azure_storage_account` relationships
-- Added `encyrption.keySource` and `encryption.keyVaultProperties` to the
+- Added `encryption.keySource` and `encryption.keyVaultProperties` to the
   `azure_storage_account` entity
 - Added `allowBlobPublicAccess` to the `azure_storage_account` entity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `azure_monitor_log_profile` entities
+- Added `azure_subscription|has|azure_monitor_log_profile` relationships
+- Added `azure_monitor_log_profile|uses|azure_storage_account` relationships
+
 ## 5.7.0 - 2020-11-05
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -109,6 +109,7 @@ The following entities are created:
 | [RM] Load Balancer                 | `azure_lb`                            | `Gateway`                          |
 | [RM] MariaDB Database              | `azure_mariadb_database`              | `Database`, `DataStore`            |
 | [RM] MariaDB Server                | `azure_mariadb_server`                | `Database`, `DataStore`, `Host`    |
+| [RM] Monitor Log Profile           | `azure_monitor_log_profile`           | `Configuration`                    |
 | [RM] MySQL Database                | `azure_mysql_database`                | `Database`, `DataStore`            |
 | [RM] MySQL Server                  | `azure_mysql_server`                  | `Database`, `DataStore`, `Host`    |
 | [RM] Network Interface             | `azure_nic`                           | `NetworkInterface`                 |
@@ -173,6 +174,7 @@ The following relationships are created/mapped:
 | `azure_user_group`              | **HAS**               | `azure_user`                          |
 | `azure_lb`                      | **CONNECTS**          | `azure_nic`                           |
 | `azure_mariadb_server`          | **HAS**               | `azure_mariadb_database`              |
+| `azure_monitor_log_profile`     | **USES**              | `azure_storage_account`               |
 | `azure_mysql_server`            | **HAS**               | `azure_mysql_database`                |
 | `azure_postgresql_server`       | **HAS**               | `azure_postgresql_database`           |
 | `azure_private_dns_zone`        | **HAS**               | `azure_private_dns_record_set`        |
@@ -243,6 +245,7 @@ The following relationships are created/mapped:
 | `azure_storage_account`         | **HAS**               | `azure_storage_queue`                 |
 | `azure_storage_account`         | **HAS**               | `azure_storage_table`                 |
 | `azure_subnet`                  | **HAS**               | `azure_vm`                            |
+| `azure_subscription`            | **HAS**               | `azure_monitor_log_profile`           |
 | `azure_subscription`            | **HAS**               | `azure_resource_group`                |
 | `azure_subscription`            | **HAS**               | `azure_security_center_contact`       |
 | `azure_subscription`            | **PERFORMED**         | `azure_security_assessment`           |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -244,6 +244,7 @@ The following relationships are created/mapped:
 | `azure_storage_account`         | **HAS**               | `azure_storage_file_share`            |
 | `azure_storage_account`         | **HAS**               | `azure_storage_queue`                 |
 | `azure_storage_account`         | **HAS**               | `azure_storage_table`                 |
+| `azure_storage_account`         | **USES**              | `azure_keyvault_service`              |
 | `azure_subnet`                  | **HAS**               | `azure_vm`                            |
 | `azure_subscription`            | **HAS**               | `azure_monitor_log_profile`           |
 | `azure_subscription`            | **HAS**               | `azure_resource_group`                |

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@azure/arm-eventgrid": "^9.0.0",
     "@azure/arm-keyvault": "^1.2.1",
     "@azure/arm-mariadb": "^1.4.0",
+    "@azure/arm-monitor": "^6.0.0",
     "@azure/arm-mysql": "^3.3.0",
     "@azure/arm-network": "^20.0.0",
     "@azure/arm-policy": "^3.1.0",

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -96,6 +96,7 @@ import {
 import { AdvisorSteps } from './steps/resource-manager/advisor';
 import { SecuritySteps } from './steps/resource-manager/security';
 import { PolicySteps } from './steps/resource-manager/policy/constants';
+import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {
@@ -175,6 +176,7 @@ describe('getStepStartStates', () => {
       [SecuritySteps.ASSESSMENTS]: { disabled: true },
       [PolicySteps.POLICY_ASSIGNMENTS]: { disabled: true },
       [SecuritySteps.SECURITY_CENTER_CONTACTS]: { disabled: true },
+      [MonitorSteps.MONITOR_LOG_PROFILES]: { disabled: true },
     });
   });
 
@@ -250,6 +252,7 @@ describe('getStepStartStates', () => {
       [SecuritySteps.ASSESSMENTS]: { disabled: true },
       [PolicySteps.POLICY_ASSIGNMENTS]: { disabled: true },
       [SecuritySteps.SECURITY_CENTER_CONTACTS]: { disabled: true },
+      [MonitorSteps.MONITOR_LOG_PROFILES]: { disabled: true },
     });
   });
 
@@ -325,6 +328,7 @@ describe('getStepStartStates', () => {
       [SecuritySteps.ASSESSMENTS]: { disabled: false },
       [PolicySteps.POLICY_ASSIGNMENTS]: { disabled: false },
       [SecuritySteps.SECURITY_CENTER_CONTACTS]: { disabled: false },
+      [MonitorSteps.MONITOR_LOG_PROFILES]: { disabled: false },
     });
   });
 });

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -98,6 +98,7 @@ import {
 import { AdvisorSteps } from './steps/resource-manager/advisor/constants';
 import { SecuritySteps } from './steps/resource-manager/security/constants';
 import { PolicySteps } from './steps/resource-manager/policy/constants';
+import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 
 function makeStepStartStates(
   stepIds: string[],
@@ -185,6 +186,7 @@ export function getResourceManagerSteps(): GetApiSteps {
       STEP_RM_EVENT_GRID_DOMAIN_TOPIC_SUBSCRIPTIONS,
       SecuritySteps.ASSESSMENTS,
       SecuritySteps.SECURITY_CENTER_CONTACTS,
+      MonitorSteps.MONITOR_LOG_PROFILES,
     ],
     executeLastSteps: [
       AdvisorSteps.RECOMMENDATIONS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { eventGridSteps } from './steps/resource-manager/event-grid';
 import { advisorSteps } from './steps/resource-manager/advisor';
 import { securitySteps } from './steps/resource-manager/security';
 import { policySteps } from './steps/resource-manager/policy';
+import { monitorSteps } from './steps/resource-manager/monitor';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields: {
@@ -82,6 +83,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...advisorSteps,
     ...securitySteps,
     ...policySteps,
+    ...monitorSteps,
   ],
 
   normalizeGraphObjectKey: (_key) => _key.toLowerCase(),

--- a/src/steps/resource-manager/monitor/__recordings__/iteratePolicyAssignments_3854727663/recording.har
+++ b/src/steps/resource-manager/monitor/__recordings__/iteratePolicyAssignments_3854727663/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "iteratePolicyAssignments",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "5c19a56f-a587-4e5d-8cf0-ba1e7ae0936a"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1604701031\",\"not_before\":\"1604697131\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-12-06T21:17:11.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "5c19a56f-a587-4e5d-8cf0-ba1e7ae0936a"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "afccba7d-4739-4b60-850e-9c16f9090c01"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11198.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:17:11 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:17:11.379Z",
+        "time": 377,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 377
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "558fb460-d454-42eb-9eeb-b50261d0c1d2"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cc759158-199d-4069-a0ae-baa71c11eb36"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "cc759158-199d-4069-a0ae-baa71c11eb36"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201106T211712Z:cc759158-199d-4069-a0ae-baa71c11eb36"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:17:11 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 581,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:17:11.789Z",
+        "time": 288,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 288
+        }
+      },
+      {
+        "_id": "099f32aa0a8a9cd66a55b6f68bdc5a2a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "98488465-57c4-441d-9358-249e3e8f6b9a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1803,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-03-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/microsoft.insights/logprofiles?api-version=2016-03-01"
+        },
+        "response": {
+          "bodySize": 1071,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1071,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/microsoft.insights/logprofiles/default\",\"type\":null,\"name\":\"default\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct\",\"serviceBusRuleId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.EventHub/namespaces/j1dev-log-profile-eventhub/authorizationrules/RootManageSharedAccessKey\",\"locations\":[\"westus\",\"global\"],\"categories\":[\"Delete\",\"Action\",\"Write\"],\"retentionPolicy\":{\"enabled\":true,\"days\":365}},\"identity\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "86376438-1e7d-4aef-8fa8-082ec9740d42"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "fdd233df-9bd0-4d98-a22f-fa6aa0242c7c"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201106T211712Z:fdd233df-9bd0-4d98-a22f-fa6aa0242c7c"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:17:12 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 622,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:17:12.093Z",
+        "time": 414,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 414
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/monitor/__recordings__/resource-manager-step-monitor-log-profiles_3087885473/recording.har
+++ b/src/steps/resource-manager/monitor/__recordings__/resource-manager-step-monitor-log-profiles_3087885473/recording.har
@@ -1,0 +1,508 @@
+{
+  "log": {
+    "_recordingName": "resource-manager-step-monitor-log-profiles",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "cbfd3156-2b05-42bc-8b50-caad9ec86a7a"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1604702045\",\"not_before\":\"1604698145\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-12-06T21:34:05.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "cbfd3156-2b05-42bc-8b50-caad9ec86a7a"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "442ba0df-849e-412d-8447-0f69edea1801"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11198.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:34:04 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:34:04.796Z",
+        "time": 339,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 339
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "918143ea-d397-4f3c-9607-937f763deb6b"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f2b06f46-6e53-4889-ae50-747da74b6175"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f2b06f46-6e53-4889-ae50-747da74b6175"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201106T213405Z:f2b06f46-6e53-4889-ae50-747da74b6175"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:34:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 581,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:34:05.167Z",
+        "time": 285,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 285
+        }
+      },
+      {
+        "_id": "099f32aa0a8a9cd66a55b6f68bdc5a2a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c9127848-e211-44b2-ade2-343e23af101c"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1803,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-03-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/microsoft.insights/logprofiles?api-version=2016-03-01"
+        },
+        "response": {
+          "bodySize": 1071,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1071,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/microsoft.insights/logprofiles/default\",\"type\":null,\"name\":\"default\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct\",\"serviceBusRuleId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.EventHub/namespaces/j1dev-log-profile-eventhub/authorizationrules/RootManageSharedAccessKey\",\"locations\":[\"westus\",\"global\"],\"categories\":[\"Delete\",\"Action\",\"Write\"],\"retentionPolicy\":{\"enabled\":true,\"days\":365}},\"identity\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "c78e2a30-2c5c-40ba-bb5d-9ae0fb423481"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "621798e4-e128-4b21-92c2-9a1c6296f45a"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201106T213406Z:621798e4-e128-4b21-92c2-9a1c6296f45a"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 06 Nov 2020 21:34:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 622,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-06T21:34:05.468Z",
+        "time": 613,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 613
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/monitor/__snapshots__/converters.test.ts.snap
+++ b/src/steps/resource-manager/monitor/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createMonitorLogProfileEntity properties transferred 1`] = `
+Object {
+  "_class": Array [
+    "Configuration",
+  ],
+  "_key": "/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/providers/microsoft.insights/logprofiles/default",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "categories": Array [
+          "Delete",
+          "Write",
+          "Action",
+        ],
+        "id": "/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/providers/microsoft.insights/logprofiles/default",
+        "location": "",
+        "locations": Array [
+          "global",
+        ],
+        "name": "default",
+        "retentionPolicy": Object {
+          "days": 3,
+          "enabled": true,
+        },
+        "serviceBusRuleId": "",
+        "storageAccountId": "/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/resourceGroups/JohnKemTest/providers/Microsoft.Storage/storageAccounts/johnkemtest8162",
+        "type": "",
+      },
+    },
+  ],
+  "_type": "azure_monitor_log_profile",
+  "categories": Array [
+    "Delete",
+    "Write",
+    "Action",
+  ],
+  "createdOn": undefined,
+  "displayName": "default",
+  "id": "/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/providers/microsoft.insights/logprofiles/default",
+  "locations": Array [
+    "global",
+  ],
+  "name": "default",
+  "retentionPolicy.days": 3,
+  "retentionPolicy.enabled": true,
+  "serviceBusRuleId": "",
+  "storageAccountId": "/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/resourceGroups/JohnKemTest/providers/Microsoft.Storage/storageAccounts/johnkemtest8162",
+  "webLink": "https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/providers/microsoft.insights/logprofiles/default",
+}
+`;

--- a/src/steps/resource-manager/monitor/client.test.ts
+++ b/src/steps/resource-manager/monitor/client.test.ts
@@ -1,0 +1,61 @@
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+import {
+  Recording,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { IntegrationConfig } from '../../../types';
+import { MonitorClient } from './client';
+import { LogProfileResource } from '@azure/arm-monitor/esm/models';
+
+let recording: Recording;
+
+afterEach(async () => {
+  await recording.stop();
+});
+
+describe('iterateLogProfiles', () => {
+  test('all', async () => {
+    // developer used different creds than ~/test/integrationInstanceConfig
+    const config: IntegrationConfig = {
+      clientId: process.env.CLIENT_ID || 'clientId',
+      clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+      directoryId: 'bcd90474-9b62-4040-9d7b-8af257b1427d',
+      subscriptionId: '40474ebe-55a2-4071-8fa8-b610acdd8e56',
+    };
+
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iteratePolicyAssignments',
+    });
+
+    const client = new MonitorClient(
+      config,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const resources: LogProfileResource[] = [];
+
+    await client.iterateLogProfiles((e) => {
+      resources.push(e);
+    });
+
+    expect(resources).toContainEqual({
+      id: `/subscriptions/${config.subscriptionId}/providers/microsoft.insights/logprofiles/default`,
+      tags: null,
+      type: null,
+      identity: null,
+      kind: null,
+      name: 'default',
+      location: null,
+      storageAccountId: `/subscriptions/${config.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+      serviceBusRuleId: `/subscriptions/${config.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.EventHub/namespaces/j1dev-log-profile-eventhub/authorizationrules/RootManageSharedAccessKey`,
+      locations: ['westus', 'global'],
+      categories: ['Delete', 'Action', 'Write'],
+      retentionPolicy: {
+        enabled: true,
+        days: 365,
+      },
+    });
+  });
+});

--- a/src/steps/resource-manager/monitor/client.ts
+++ b/src/steps/resource-manager/monitor/client.ts
@@ -1,0 +1,35 @@
+import {
+  Client,
+  iterateAllResources,
+} from '../../../azure/resource-manager/client';
+import { MonitorManagementClient } from '@azure/arm-monitor';
+import { LogProfileResource } from '@azure/arm-monitor/esm/models';
+
+export class MonitorClient extends Client {
+  /**
+   * Returns the Log Profile for an Azure Subscription
+   * Log Profiles are the legacy method for sending the Activity Log to Azure Storage or Azure Event Hubs.
+   * The Activity Log captures all management activities performed on a subscription.
+   * By default, Activity Logs are only retained for 90 days.
+   * Historically, Log Profiles were used to make sure that all subscription related logs were retained for a longer duration.
+   * @param callback A callback function to be called after retrieving the Log Profile for an Azure Subscription
+   */
+  public async iterateLogProfiles(
+    callback: (s: LogProfileResource) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      MonitorManagementClient,
+    );
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      /**
+       * The @azure/arm-monitor client does not have a listNext() function for Log Profiles, because there is only one Log Profile allowed per Azure Subscription.
+       */
+      resourceEndpoint: serviceClient.logProfiles,
+      resourceDescription: 'monitor.logProfile',
+      callback,
+    });
+  }
+}

--- a/src/steps/resource-manager/monitor/constants.ts
+++ b/src/steps/resource-manager/monitor/constants.ts
@@ -16,7 +16,7 @@ export const MonitorEntities = {
 
 export const MonitorRelationships = {
   SUBSCRIPTION_HAS_MONITOR_LOG_PROFILE: {
-    _type: 'azure_subscription_has_monitor_policy_assignment',
+    _type: 'azure_subscription_has_monitor_log_profile',
     sourceType: SUBSCRIPTION_ENTITY_METADATA._type,
     _class: RelationshipClass.HAS,
     targetType: MonitorEntities.MONITOR_LOG_PROFILE._type,

--- a/src/steps/resource-manager/monitor/constants.ts
+++ b/src/steps/resource-manager/monitor/constants.ts
@@ -1,0 +1,31 @@
+import { RelationshipClass } from '@jupiterone/integration-sdk-core';
+import { STORAGE_ACCOUNT_ENTITY_METADATA } from '../storage';
+import { SUBSCRIPTION_ENTITY_METADATA } from '../subscriptions';
+
+export const MonitorSteps = {
+  MONITOR_LOG_PROFILES: 'rm-monitor-log-profiles',
+};
+
+export const MonitorEntities = {
+  MONITOR_LOG_PROFILE: {
+    _type: 'azure_monitor_log_profile',
+    _class: ['Configuration'],
+    resourceName: '[RM] Monitor Log Profile',
+  },
+};
+
+export const MonitorRelationships = {
+  SUBSCRIPTION_HAS_MONITOR_LOG_PROFILE: {
+    _type: 'azure_subscription_has_monitor_policy_assignment',
+    sourceType: SUBSCRIPTION_ENTITY_METADATA._type,
+    _class: RelationshipClass.HAS,
+    targetType: MonitorEntities.MONITOR_LOG_PROFILE._type,
+  },
+
+  MONITOR_LOG_PROFILE_USES_STORAGE_ACCOUNT: {
+    _type: 'azure_monitor_log_profile_uses_storage_account',
+    sourceType: MonitorEntities.MONITOR_LOG_PROFILE._type,
+    _class: RelationshipClass.USES,
+    targetType: STORAGE_ACCOUNT_ENTITY_METADATA._type,
+  },
+};

--- a/src/steps/resource-manager/monitor/converters.test.ts
+++ b/src/steps/resource-manager/monitor/converters.test.ts
@@ -1,0 +1,44 @@
+import { createAzureWebLinker } from '../../../azure';
+import { createMonitorLogProfileEntity } from './converters';
+import { LogProfileResource } from '@azure/arm-monitor/esm/models';
+
+const webLinker = createAzureWebLinker('something.onmicrosoft.com');
+
+describe('createMonitorLogProfileEntity', () => {
+  test('properties transferred', () => {
+    const data: LogProfileResource = {
+      id:
+        '/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/providers/microsoft.insights/logprofiles/default',
+      type: '',
+      name: 'default',
+      location: '',
+      storageAccountId:
+        '/subscriptions/df602c9c-7aa0-407d-a6fb-eb20c8bd1192/resourceGroups/JohnKemTest/providers/Microsoft.Storage/storageAccounts/johnkemtest8162',
+      serviceBusRuleId: '',
+      locations: ['global'],
+      categories: ['Delete', 'Write', 'Action'],
+      retentionPolicy: {
+        enabled: true,
+        days: 3,
+      },
+    };
+
+    const logProfileEntity = createMonitorLogProfileEntity(webLinker, data);
+
+    expect(logProfileEntity).toMatchSnapshot();
+    expect(logProfileEntity).toMatchGraphObjectSchema({
+      _class: ['Configuration'],
+      schema: {
+        additionalProperties: true,
+        properties: {
+          storageAccountId: { type: 'string' },
+          serviceBusRuleId: { type: 'string' },
+          locations: { type: 'array', items: { type: 'string' } },
+          categories: { type: 'array', items: { type: 'string' } },
+          'retentionPolicy.enabled': { type: 'boolean' },
+          'retentionPolicy.days': { type: 'number' },
+        },
+      },
+    });
+  });
+});

--- a/src/steps/resource-manager/monitor/converters.ts
+++ b/src/steps/resource-manager/monitor/converters.ts
@@ -1,0 +1,33 @@
+import { AzureWebLinker } from '../../../azure';
+import {
+  createIntegrationEntity,
+  Entity,
+} from '@jupiterone/integration-sdk-core';
+import { MonitorEntities } from './constants';
+import { LogProfileResource } from '@azure/arm-monitor/esm/models';
+
+export function createMonitorLogProfileEntity(
+  webLinker: AzureWebLinker,
+  data: LogProfileResource,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: data.id,
+        _type: MonitorEntities.MONITOR_LOG_PROFILE._type,
+        _class: MonitorEntities.MONITOR_LOG_PROFILE._class,
+        id: data.id,
+        webLink: webLinker.portalResourceUrl(data.id),
+        name: data.name,
+        displayName: data.name,
+        storageAccountId: data.storageAccountId,
+        serviceBusRuleId: data.serviceBusRuleId,
+        locations: data.locations,
+        categories: data.categories,
+        'retentionPolicy.enabled': data.retentionPolicy.enabled,
+        'retentionPolicy.days': data.retentionPolicy.days,
+      },
+    },
+  });
+}

--- a/src/steps/resource-manager/monitor/index.test.ts
+++ b/src/steps/resource-manager/monitor/index.test.ts
@@ -1,0 +1,78 @@
+import { Recording } from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '../../../types';
+import { setupAzureRecording } from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { fetchLogProfiles } from '.';
+
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) {
+    await recording.stop();
+  }
+});
+
+test('step = monitor log profiles', async () => {
+  const instanceConfig: IntegrationConfig = {
+    clientId: process.env.CLIENT_ID || 'clientId',
+    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+    directoryId: 'bcd90474-9b62-4040-9d7b-8af257b1427d',
+    subscriptionId: '40474ebe-55a2-4071-8fa8-b610acdd8e56',
+  };
+
+  recording = setupAzureRecording({
+    directory: __dirname,
+    name: 'resource-manager-step-monitor-log-profiles',
+  });
+
+  const context = createMockAzureStepExecutionContext({
+    instanceConfig,
+    entities: [
+      {
+        _key: `/subscriptions/${instanceConfig.subscriptionId}`,
+        _class: ['Group'],
+        _type: 'azure_subscription',
+        id: `/subscriptions/${instanceConfig.subscriptionId}`,
+      },
+      {
+        _class: ['Service'],
+        _type: 'azure_storage_account',
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+        id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+        name: `j1devlogprofilestrgacct`,
+      },
+    ],
+    setData: {
+      [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
+    },
+  });
+
+  await fetchLogProfiles(context);
+
+  const { collectedEntities, collectedRelationships } = context.jobState;
+
+  expect(collectedEntities.length).toBeGreaterThan(0);
+
+  expect(collectedRelationships).toMatchDirectRelationshipSchema({});
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}|has|/subscriptions/${instanceConfig.subscriptionId}/providers/microsoft.insights/logprofiles/default`,
+      _type: 'azure_subscription_has_monitor_log_profile',
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/providers/microsoft.insights/logprofiles/default`,
+      displayName: 'HAS',
+    }),
+  );
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/providers/microsoft.insights/logprofiles/default|uses|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+      _type: 'azure_monitor_log_profile_uses_storage_account',
+      _class: 'USES',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/providers/microsoft.insights/logprofiles/default`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+      displayName: 'USES',
+    }),
+  );
+});

--- a/src/steps/resource-manager/monitor/index.ts
+++ b/src/steps/resource-manager/monitor/index.ts
@@ -1,0 +1,81 @@
+import {
+  Entity,
+  Step,
+  IntegrationStepExecutionContext,
+  createDirectRelationship,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+import { createAzureWebLinker } from '../../../azure';
+import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { STEP_RM_STORAGE_RESOURCES } from '../storage/constants';
+import { STEP_RM_SUBSCRIPTIONS } from '../subscriptions/constants';
+import { MonitorClient } from './client';
+import {
+  MonitorSteps,
+  MonitorEntities,
+  MonitorRelationships,
+} from './constants';
+import { createMonitorLogProfileEntity } from './converters';
+export * from './constants';
+
+export async function fetchLogProfiles(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await jobState.getData<Entity>(ACCOUNT_ENTITY_TYPE);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new MonitorClient(instance.config, logger);
+
+  await client.iterateLogProfiles(async (logProfile) => {
+    if (!logProfile) return;
+
+    const logProfileEntity = await jobState.addEntity(
+      createMonitorLogProfileEntity(webLinker, logProfile),
+    );
+
+    const subscriptionId = `/subscriptions/${instance.config.subscriptionId}`;
+    const subscriptionEntity = await jobState.findEntity(subscriptionId);
+
+    if (subscriptionEntity) {
+      await jobState.addRelationship(
+        createDirectRelationship({
+          _class:
+            MonitorRelationships.SUBSCRIPTION_HAS_MONITOR_LOG_PROFILE._class,
+          from: subscriptionEntity,
+          to: logProfileEntity,
+        }),
+      );
+    }
+
+    const { storageAccountId } = logProfile;
+    if (!storageAccountId) return;
+
+    const storageAccountEntity = await jobState.findEntity(storageAccountId);
+    if (!storageAccountEntity) return;
+
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.USES,
+        from: logProfileEntity,
+        to: storageAccountEntity,
+      }),
+    );
+  });
+}
+
+export const monitorSteps: Step<
+  IntegrationStepExecutionContext<IntegrationConfig>
+>[] = [
+  {
+    id: MonitorSteps.MONITOR_LOG_PROFILES,
+    name: 'Monitor Log Profiles',
+    entities: [MonitorEntities.MONITOR_LOG_PROFILE],
+    relationships: [
+      MonitorRelationships.SUBSCRIPTION_HAS_MONITOR_LOG_PROFILE,
+      MonitorRelationships.MONITOR_LOG_PROFILE_USES_STORAGE_ACCOUNT,
+    ],
+    dependsOn: [STEP_RM_SUBSCRIPTIONS, STEP_RM_STORAGE_RESOURCES],
+    executionHandler: fetchLogProfiles,
+  },
+];

--- a/src/steps/resource-manager/policy/converters.ts
+++ b/src/steps/resource-manager/policy/converters.ts
@@ -4,7 +4,7 @@ import {
   Entity,
 } from '@jupiterone/integration-sdk-core';
 import { parseTimePropertyValue } from '@jupiterone/integration-sdk-core/dist/src/data/converters';
-import { flatten } from './helpers';
+import flatten from '../utils/flatten';
 import { PolicyEntities } from './constants';
 import { PolicyAssignment } from '@azure/arm-policy/esm/models';
 

--- a/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-accounts_690738595/recording.har
+++ b/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-accounts_690738595/recording.har
@@ -1,0 +1,1273 @@
+{
+  "log": {
+    "_recordingName": "resource-manager-step-storage-accounts",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "db6fe42d-8a8e-454a-8d17-7ccb2661e7d4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1605117529\",\"not_before\":\"1605113629\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2020-12-11T16:58:49.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "db6fe42d-8a8e-454a-8d17-7ccb2661e7d4"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8af96c11-e138-4d16-bc04-8b841f14d701"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11198.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:49 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:49.615Z",
+        "time": 413,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 413
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c2b3899b-06b6-475c-b539-fc1cd89255a2"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "b2d69a08-86b6-4a94-b730-cd80109f0592"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "b2d69a08-86b6-4a94-b730-cd80109f0592"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165850Z:b2d69a08-86b6-4a94-b730-cd80109f0592"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:49 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 581,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:50.060Z",
+        "time": 270,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 270
+        }
+      },
+      {
+        "_id": "dd03d578db1de3c650911164ef89d311",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "12ca9aec-4dbf-4095-b50e-35c8f46c9857"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1807,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 2769,
+          "content": {
+            "mimeType": "application/json",
+            "size": 2769,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Standard_GRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct\",\"name\":\"j1devlogprofilestrgacct\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_0\",\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:11.6613959Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:11.6613959Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-11-11T16:24:11.5676273Z\",\"primaryEndpoints\":{\"dfs\":\"https://j1devlogprofilestrgacct.dfs.core.windows.net/\",\"web\":\"https://j1devlogprofilestrgacct.z13.web.core.windows.net/\",\"blob\":\"https://j1devlogprofilestrgacct.blob.core.windows.net/\",\"queue\":\"https://j1devlogprofilestrgacct.queue.core.windows.net/\",\"table\":\"https://j1devlogprofilestrgacct.table.core.windows.net/\",\"file\":\"https://j1devlogprofilestrgacct.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\"}},{\"identity\":{\"principalId\":\"cac62dde-9ae8-4b1b-b15f-0084087bd771\",\"tenantId\":\"bcd90474-9b62-4040-9d7b-8af257b1427d\",\"type\":\"systemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev\",\"name\":\"keionnedj1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_0\",\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://keionned-j1dev.vault.azure.net/keys/myKey/ab3966e511ef43c18e188bc0b41cc9f4\",\"lastKeyRotationTimestamp\":\"2020-11-11T16:33:32.9694493Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://keionned-j1dev.vault.azure.net\",\"keyname\":\"myKey\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:11.7863490Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:11.7863490Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-11-11T16:24:11.6770041Z\",\"primaryEndpoints\":{\"dfs\":\"https://keionnedj1dev.dfs.core.windows.net/\",\"web\":\"https://keionnedj1dev.z13.web.core.windows.net/\",\"blob\":\"https://keionnedj1dev.blob.core.windows.net/\",\"queue\":\"https://keionnedj1dev.queue.core.windows.net/\",\"table\":\"https://keionnedj1dev.table.core.windows.net/\",\"file\":\"https://keionnedj1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1devblobstorage\",\"name\":\"keionnedj1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_0\",\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:17.9901847Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-11-11T16:24:17.9901847Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-11-11T16:24:17.8812464Z\",\"primaryEndpoints\":{\"dfs\":\"https://keionnedj1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://keionnedj1devblobstorage.blob.core.windows.net/\",\"table\":\"https://keionnedj1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a0a944fe-3a78-41ee-9e4f-691492903efa"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "3647691d-1f17-44be-a072-7d10e288ef6d"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165850Z:3647691d-1f17-44be-a072-7d10e288ef6d"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:49 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:50.346Z",
+        "time": 334,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 334
+        }
+      },
+      {
+        "_id": "0201a7c8761888c93f7bc7462b5d3034",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "1aa94f87-3c7e-49db-a348-c54cb2c96531"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1911,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct/blobServices/default/containers?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 1159,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1159,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct/blobServices/default/containers/insights-operational-logs\",\"name\":\"insights-operational-logs\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D8865E7E4FD551\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2020-11-11T16:26:07.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0de9902f-5a8b-4036-a685-c05208688df9"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "4b3d3156-2a79-4fd5-b285-0027b3200149"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165851Z:4b3d3156-2a79-4fd5-b285-0027b3200149"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:50 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:50.710Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
+        }
+      },
+      {
+        "_id": "87e8fb32fd6833200486761f14ca2c1d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3d523f89-eb32-4d71-a4ac-0fafd43ede04"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1907,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct/fileServices/default/shares?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json",
+            "size": 273,
+            "text": "{\"value\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "20e0a9f8-aa3a-42bb-adf2-87f1202810b6"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "dffe0612-7fae-4765-bb50-c591988745d8"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165851Z:dffe0612-7fae-4765-bb50-c591988745d8"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:50 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:51.026Z",
+        "time": 357,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 357
+        }
+      },
+      {
+        "_id": "ce82fdf13fb6f68544aed74767d252df",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c64ef0ed-9857-4201-830b-365304cea062"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1874,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/blobServices/default/containers?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 1077,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1077,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/blobServices/default/containers/j1dev\",\"name\":\"j1dev\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D8865E46EC9382\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2020-11-11T16:24:34.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "df66260f-1dc3-424e-b08a-d49b49d28a12"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "67274831-ebd5-4496-93a4-746450371b3f"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165852Z:67274831-ebd5-4496-93a4-746450371b3f"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:51 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:51.390Z",
+        "time": 671,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 671
+        }
+      },
+      {
+        "_id": "3036868063b947cf6659ef4b7a77752a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f4059219-c324-4c07-ab86-32385878cd5a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1870,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/fileServices/default/shares?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 885,
+          "content": {
+            "mimeType": "application/json",
+            "size": 885,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/fileServices/default/shares/j1dev\",\"name\":\"j1dev\",\"type\":\"Microsoft.Storage/storageAccounts/fileServices/shares\",\"etag\":\"\\\"0x8D8865E464A72A7\\\"\",\"properties\":{\"accessTier\":\"TransactionOptimized\",\"lastModifiedTime\":\"2020-11-11T16:24:33.0000000Z\",\"shareQuota\":1,\"enabledProtocols\":\"SMB\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8b953c12-6e99-4e9c-80a3-0ea89ac2afe1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "6944e9e1-fe6d-4436-abf6-1d8658c00c7d"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165852Z:6944e9e1-fe6d-4436-abf6-1d8658c00c7d"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:51 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:52.067Z",
+        "time": 535,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 535
+        }
+      },
+      {
+        "_id": "699473a1cb52eaa87fa9e07600d261b4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d61d5e93-60de-4d44-b26e-a1aa3a036278"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-19.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1885,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1devblobstorage/blobServices/default/containers?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json",
+            "size": 273,
+            "text": "{\"value\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f61e153d-6749-459a-880e-9ec326c0dd89"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "103cff3a-3c18-4fb2-b955-c5c65e022ce4"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTUS:20201111T165852Z:103cff3a-3c18-4fb2-b955-c5c65e022ce4"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Nov 2020 16:58:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-11-11T16:58:52.610Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/storage/constants.ts
+++ b/src/steps/resource-manager/storage/constants.ts
@@ -2,6 +2,7 @@ import {
   generateRelationshipType,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
+import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
 
 // Step IDs
 export const STEP_RM_STORAGE_RESOURCES = 'rm-storage-resources';
@@ -35,6 +36,15 @@ export const STORAGE_ACCOUNT_CONTAINER_RELATIONSHIP_METADATA = {
   sourceType: STORAGE_ACCOUNT_ENTITY_METADATA._type,
   _class: STORAGE_ACCOUNT_RELATIONSHIP_CLASS,
   targetType: STORAGE_CONTAINER_ENTITY_METADATA._type,
+};
+
+export const StorageRelationships = {
+  STORAGE_ACCOUNT_USES_KEY_VAULT: {
+    _type: 'azure_storage_account_uses_keyvault_service',
+    sourceType: STORAGE_ACCOUNT_ENTITY_METADATA._type,
+    _class: RelationshipClass.USES,
+    targetType: KEY_VAULT_SERVICE_ENTITY_TYPE,
+  },
 };
 
 export const STORAGE_FILE_SHARE_ENTITY_METADATA = {

--- a/src/steps/resource-manager/storage/converters.test.ts
+++ b/src/steps/resource-manager/storage/converters.test.ts
@@ -112,9 +112,9 @@ describe('createStorageAccountEntity Storage (Classic)', () => {
       'tag.environment': 'j1dev',
       allowBlobPublicAccess: false,
       'encryption.keySource': 'Microsoft.Keyvault',
-      'encryption.keyValueProperties.keyName': 'test',
-      'encryption.keyValueProperties.keyVaultUri': 'testUri',
-      'encryption.keyValueProperties.keyVersion': 'version',
+      'encryption.keyVaultProperties.keyName': 'test',
+      'encryption.keyVaultProperties.keyVaultUri': 'testUri',
+      'encryption.keyVaultProperties.keyVersion': 'version',
     };
 
     const storageAccountEntity = createStorageAccountEntity(webLinker, data);

--- a/src/steps/resource-manager/storage/converters.test.ts
+++ b/src/steps/resource-manager/storage/converters.test.ts
@@ -50,7 +50,12 @@ describe('createStorageAccountEntity Storage (Classic)', () => {
           lastEnabledTime: new Date('2019-10-09T18:53:02.2416314Z'),
         },
       },
-      keySource: 'Microsoft.Storage',
+      keySource: 'Microsoft.Keyvault',
+      keyVaultProperties: {
+        keyName: 'test',
+        keyVersion: 'version',
+        keyVaultUri: 'testUri',
+      },
     },
     provisioningState: 'Succeeded',
     creationTime: new Date('2020-04-10T15:43:34.2993802Z'),
@@ -68,6 +73,7 @@ describe('createStorageAccountEntity Storage (Classic)', () => {
     },
     primaryLocation: 'eastus',
     statusOfPrimary: 'available',
+    allowBlobPublicAccess: false,
   };
 
   test('properties transferred', () => {
@@ -104,11 +110,26 @@ describe('createStorageAccountEntity Storage (Classic)', () => {
       ],
       createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
       'tag.environment': 'j1dev',
+      allowBlobPublicAccess: false,
+      'encryption.keySource': 'Microsoft.Keyvault',
+      'encryption.keyValueProperties.keyName': 'test',
+      'encryption.keyValueProperties.keyVaultUri': 'testUri',
+      'encryption.keyValueProperties.keyVersion': 'version',
     };
 
     const storageAccountEntity = createStorageAccountEntity(webLinker, data);
     expect(storageAccountEntity).toMatchGraphObjectSchema({
       _class: STORAGE_ACCOUNT_ENTITY_METADATA._class,
+      schema: {
+        additionalProperties: true,
+        properties: {
+          allowBlobPublicAccess: { type: 'boolean' },
+          'encryption.keySource': { type: 'string' },
+          'encryption.keyVaultProperties.keyName': { type: 'string' },
+          'encryption.keyVaultProperties.keyVersion': { type: 'string' },
+          'encryption.keyVaultProperties.keyVaultUri': { type: 'string' },
+        },
+      },
     });
     expect(storageAccountEntity).toEqual(entity);
   });
@@ -214,6 +235,7 @@ describe('createStorageAccountEntity StorageV2', () => {
       ],
       createdOn: new Date('2020-04-10T15:43:34.2993802Z').getTime(),
       'tag.environment': 'j1dev',
+      'encryption.keySource': 'Microsoft.Storage',
     };
 
     const storageAccountEntity = createStorageAccountEntity(webLinker, data);
@@ -315,6 +337,7 @@ describe('createStorageAccountEntity BlobStorage', () => {
       createdOn: new Date('2020-04-17T13:22:05.030Z').getTime(),
       enableHttpsTrafficOnly: true,
       'tag.environment': 'j1dev',
+      'encryption.keySource': 'Microsoft.Storage',
     };
 
     const storageAccountEntity = createStorageAccountEntity(webLinker, data);

--- a/src/steps/resource-manager/storage/converters.ts
+++ b/src/steps/resource-manager/storage/converters.ts
@@ -95,7 +95,7 @@ export function createStorageAccountEntity(
         ...flatten({
           encryption: {
             keySource: data.encryption?.keySource,
-            keyValueProperties: data.encryption?.keyVaultProperties,
+            keyVaultProperties: data.encryption?.keyVaultProperties,
           },
         }),
       },

--- a/src/steps/resource-manager/storage/converters.ts
+++ b/src/steps/resource-manager/storage/converters.ts
@@ -13,6 +13,7 @@ import {
 
 import { AzureWebLinker } from '../../../azure';
 import { resourceGroupName } from '../../../azure/utils';
+import flatten from '../utils/flatten';
 import {
   STORAGE_ACCOUNT_ENTITY_METADATA,
   STORAGE_CONTAINER_ENTITY_METADATA,
@@ -90,6 +91,13 @@ export function createStorageAccountEntity(
           encryptedServices?.queue?.enabled !== undefined
             ? encryptedServices.queue?.enabled
             : undefined,
+        allowBlobPublicAccess: data.allowBlobPublicAccess,
+        ...flatten({
+          encryption: {
+            keySource: data.encryption?.keySource,
+            keyValueProperties: data.encryption?.keyVaultProperties,
+          },
+        }),
       },
       tagProperties: ['environment'],
     },

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -1,4 +1,8 @@
-import { fetchStorageQueues, fetchStorageTables } from '.';
+import {
+  fetchStorageResources,
+  fetchStorageQueues,
+  fetchStorageTables,
+} from '.';
 import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
@@ -10,6 +14,183 @@ afterEach(async () => {
   if (recording) {
     await recording.stop();
   }
+});
+
+test('step - storage accounts', async () => {
+  const instanceConfig: IntegrationConfig = {
+    clientId: process.env.CLIENT_ID || 'clientId',
+    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+    directoryId: 'bcd90474-9b62-4040-9d7b-8af257b1427d',
+    subscriptionId: '40474ebe-55a2-4071-8fa8-b610acdd8e56',
+  };
+
+  const devName = 'keionned';
+
+  recording = setupAzureRecording({
+    directory: __dirname,
+    name: 'resource-manager-step-storage-accounts',
+  });
+
+  const context = createMockAzureStepExecutionContext({
+    instanceConfig,
+    entities: [
+      {
+        _class: ['Service'],
+        _type: 'azure_keyvault_service',
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${devName}-j1dev`,
+        id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${devName}-j1dev`,
+        name: `${devName}-j1dev`,
+        _rawData: [
+          {
+            name: `${devName}-j1dev`,
+            rawData: {
+              vaultUri: `https://${devName}-j1dev.vault.azure.net`,
+            },
+          },
+        ],
+      },
+    ],
+    setData: {
+      [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
+    },
+  });
+
+  await fetchStorageResources(context);
+
+  const { collectedEntities, collectedRelationships } = context.jobState;
+  const storageAccounts = collectedEntities.filter(
+    (e) => e._type === 'azure_storage_account',
+  );
+  const storageContainers = collectedEntities.filter(
+    (e) => e._type === 'azure_storage_container',
+  );
+  const fileShares = collectedEntities.filter(
+    (e) => e._type === 'azure_storage_file_share',
+  );
+
+  expect(collectedEntities.length).toBeGreaterThan(0);
+  expect(storageAccounts).toMatchGraphObjectSchema({
+    _class: ['Service'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        resourceGroup: { type: 'string' },
+        region: { type: 'string' },
+        kind: {
+          type: 'string',
+          enum: [
+            'Storage',
+            'StorageV2',
+            'BlobStorage',
+            'FileStorage',
+            'BlockBlobStorage',
+          ],
+        },
+        sku: {
+          type: 'string',
+          enum: [
+            'Standard_LRS',
+            'Standard_GRS',
+            'Standard_RAGRS',
+            'Standard_ZRS',
+            'Premium_LRS',
+            'Premium_ZRS',
+            'Standard_GZRS',
+            'Standard_RAGZRS',
+          ],
+        },
+        encryptedFileShare: { type: 'boolean' },
+        encryptedBlob: { type: 'boolean' },
+        encryptedTable: { type: 'boolean' },
+        encryptedQueue: { type: 'boolean' },
+        enableHttpsTrafficOnly: { type: 'boolean' },
+        endpoints: { type: 'array', items: { type: 'string' } },
+        allowBlobPublicAccess: { type: 'boolean' },
+        'encryption.keySource': { type: 'string' },
+        'encryption.keyVaultProperties.keyName': { type: 'string' },
+        'encryption.keyVaultProperties.keyVersion': { type: 'string' },
+        'encryption.keyVaultProperties.keyVaultUri': { type: 'string' },
+      },
+    },
+  });
+  expect(storageContainers).toMatchGraphObjectSchema({
+    _class: ['DataStore'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        public: { type: 'boolean' },
+        resourceGroup: { type: 'string' },
+        publicAccess: { type: 'string', enum: ['Container', 'Blob', 'None'] },
+        encrypted: { type: 'boolean' },
+      },
+    },
+  });
+  expect(fileShares).toMatchGraphObjectSchema({
+    _class: ['DataStore'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        resourceGroup: { type: 'string' },
+        encrypted: { type: 'boolean' },
+      },
+    },
+  });
+
+  /**
+   * NOTE: This relationship will not exist if you do not run the terraform to produce a Log Profile (monitor.tf)
+   * To ensure this test passes, do not delete the recording, or enable the flag to create a Log Profile in monitor.tf
+   */
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct/blobServices/default/containers/insights-operational-logs`,
+      _type: 'azure_storage_account_has_container',
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev_log_profile_resource_group/providers/Microsoft.Storage/storageAccounts/j1devlogprofilestrgacct/blobServices/default/containers/insights-operational-logs`,
+      displayName: 'HAS',
+    }),
+  );
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/blobServices/default/containers/j1dev`,
+      _type: 'azure_storage_account_has_container',
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/blobServices/default/containers/j1dev`,
+      displayName: 'HAS',
+    }),
+  );
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/fileServices/default/shares/j1dev`,
+      _type: 'azure_storage_account_has_file_share',
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev/fileServices/default/shares/j1dev`,
+      displayName: 'HAS',
+    }),
+  );
+
+  /**
+   * NOTE: This test will fail unless it is run against the original recording or you manually setup custom encryption on a Storage Account in the Azure Portal.
+   * This is because it is currently not possible to setup custom encryption properties on a Storage Account using terraform.
+   * This was done to test CIS Benchmark 5.16 ( Ensure the storage account containing the container with activity logs is encrypted with BYOK (Use Your Own Key))
+   * To manually setup custom encryption in the Azure Portal on a Storage Account, Go to Monitor -> {Your Storage Account} -> Encryption -> Customer Managed Keys -> { Select a Key Vault and Key } -> Save
+   * Be sure your user has the correct access to Get, List, and Create keys in the Key Vault you select. If your Azure user does not, manage the Access Policies of the Key Vault you want to use.
+   */
+  expect(collectedRelationships).toContainEqual(
+    expect.objectContaining({
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${devName}j1dev|uses|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${devName}-j1dev`,
+      _type: 'azure_storage_account_uses_keyvault_service',
+      _class: 'USES',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${devName}j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${devName}-j1dev`,
+      displayName: 'USES',
+      keyName: 'myKey',
+      keyVaultUri: `https://${devName}-j1dev.vault.azure.net`,
+      keyVersion: '',
+    }),
+  );
 });
 
 test('step - storage queues', async () => {

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -44,7 +44,9 @@ test('step - storage accounts', async () => {
           {
             name: `${devName}-j1dev`,
             rawData: {
-              vaultUri: `https://${devName}-j1dev.vault.azure.net`,
+              properties: {
+                vaultUri: `https://${devName}-j1dev.vault.azure.net`,
+              },
             },
           },
         ],

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -8,6 +8,8 @@ import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { Vault } from '@azure/arm-keyvault/esm/models';
+
 let recording: Recording;
 
 afterEach(async () => {
@@ -31,6 +33,17 @@ test('step - storage accounts', async () => {
     name: 'resource-manager-step-storage-accounts',
   });
 
+  const vault: Vault = {
+    location: 'eastus',
+    properties: {
+      tenantId: instanceConfig.directoryId,
+      sku: {
+        name: 'standard',
+      },
+      vaultUri: `https://${devName}-j1dev.vault.azure.net`,
+    },
+  };
+
   const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [
@@ -43,11 +56,7 @@ test('step - storage accounts', async () => {
         _rawData: [
           {
             name: `${devName}-j1dev`,
-            rawData: {
-              properties: {
-                vaultUri: `https://${devName}-j1dev.vault.azure.net`,
-              },
-            },
+            rawData: vault,
           },
         ],
       },

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -92,11 +92,14 @@ async function buildKeyVaultEntityMap(
   await jobState.iterateEntities(
     { _type: KEY_VAULT_SERVICE_ENTITY_TYPE },
     (keyVaultEntity) => {
+      const keyVaultRawData = keyVaultEntity?._rawData?.[0]?.rawData;
+      if (!keyVaultRawData) return;
+
+      const rawVaultUri: string = keyVaultRawData.properties?.vaultUri;
+      if (!rawVaultUri) return;
+
       // NOTE: sometimes the URI is returned with a trailing slash. We must remove it to make sure it matches the URI on the Storage Account
-      const vaultUri: string = keyVaultEntity?._rawData?.[0]?.rawData?.vaultUri.replace(
-        /\/$/,
-        '',
-      );
+      const vaultUri = rawVaultUri.replace(/\/$/, '');
 
       if (!vaultUri) return;
 

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -91,7 +91,7 @@ async function buildKeyVaultEntityMap(
 
   await jobState.iterateEntities(
     { _type: KEY_VAULT_SERVICE_ENTITY_TYPE },
-    async (keyVaultEntity) => {
+    (keyVaultEntity) => {
       // NOTE: sometimes the URI is returned with a trailing slash. We must remove it to make sure it matches the URI on the Storage Account
       const vaultUri: string = keyVaultEntity?._rawData?.[0]?.rawData?.vaultUri.replace(
         /\/$/,

--- a/src/steps/resource-manager/utils/flatten.test.ts
+++ b/src/steps/resource-manager/utils/flatten.test.ts
@@ -1,4 +1,4 @@
-import { flatten } from './helpers';
+import flatten from './flatten';
 
 describe('flatten', () => {
   describe('when flattening an object with a boolean prop', () => {

--- a/src/steps/resource-manager/utils/flatten.ts
+++ b/src/steps/resource-manager/utils/flatten.ts
@@ -107,7 +107,7 @@ function getConversionStrategy(
   return conversionStrategies.find((cs) => cs.canConvert(key, value, options));
 }
 
-export function flatten(
+export default function flatten(
   obj: any, // If this is used at runtime against a returned property from a client, it maybe used against something someone expects to be an object, but is not
   options: FlattenObjectOptions = {},
   currentKey: string = '',

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -1,0 +1,58 @@
+variable "create_monitor_log_profile" {
+  type    = number
+  default = 0
+}
+
+locals {
+  monitor_log_profile_count = var.create_monitor_log_profile == 1 ? 1 : 0
+}
+
+resource "azurerm_resource_group" "j1dev_log_profile_resource_group" {
+  count    = local.monitor_log_profile_count
+  name     = "j1dev_log_profile_resource_group"
+  location = "eastus"
+}
+
+resource "azurerm_storage_account" "j1dev_log_profile_storage_account" {
+  count = local.monitor_log_profile_count
+  # The name can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long.
+  name                     = "j1devlogprofilestrgacct"
+  resource_group_name      = azurerm_resource_group.j1dev_log_profile_resource_group[0].name
+  location                 = azurerm_resource_group.j1dev_log_profile_resource_group[0].location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_eventhub_namespace" "j1dev_log_profile_eventhub" {
+  count = local.monitor_log_profile_count
+  # The eventhub namespace name can contain only letters, numbers and hyphens. The namespace must start with a letter, and it must end with a letter or number and be between 6 and 50 characters long.
+  name                = "j1dev-log-profile-eventhub"
+  location            = azurerm_resource_group.j1dev_log_profile_resource_group[0].location
+  resource_group_name = azurerm_resource_group.j1dev_log_profile_resource_group[0].name
+  sku                 = "Standard"
+  capacity            = 2
+}
+
+resource "azurerm_monitor_log_profile" "j1dev_log_profile" {
+  name = "default"
+
+  categories = [
+    "Action",
+    "Delete",
+    "Write",
+  ]
+
+  locations = [
+    "westus",
+    "global",
+  ]
+
+  # RootManageSharedAccessKey is created by default with listen, send, manage permissions
+  servicebus_rule_id = "${azurerm_eventhub_namespace.j1dev_log_profile_eventhub[0].id}/authorizationrules/RootManageSharedAccessKey"
+  storage_account_id = azurerm_storage_account.j1dev_log_profile_storage_account[0].id
+
+  retention_policy {
+    enabled = true
+    days    = 365
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,6 +126,15 @@
     "@azure/ms-rest-js" "^1.8.1"
     tslib "^1.9.3"
 
+"@azure/arm-monitor@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/arm-monitor/-/arm-monitor-6.0.0.tgz#ed2d8b8e38ceb85757bf81d74aa9058bd73a5760"
+  integrity sha512-KcX9Hdejc71OdKH+GsLoJ4mQ8rpXCXgMRa0ivb/SH3NLjH0Qc0bvjthNFY74NXVKy5qwjBNYuUb/GrNLtwQQ/g==
+  dependencies:
+    "@azure/ms-rest-azure-js" "^2.0.1"
+    "@azure/ms-rest-js" "^2.0.4"
+    tslib "^1.10.0"
+
 "@azure/arm-mysql@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@azure/arm-mysql/-/arm-mysql-3.3.0.tgz#e47f3523dcdb4be3542b1e77179ecdf2e8ca4ea6"


### PR DESCRIPTION
# Acceptance Criteria
- Ingest [Azure Monitor Log Profile](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log#legacy-collection-methods)
    - Log Profiles are the legacy method for sending the Activity Log to Azure Storage or Azure Event Hubs. The Activity Log captures all management activities performed on a subscription. By default, Activity Logs are only retained for 90 days. Historically, Log Profiles were used to make sure that all subscription related logs were retained for a longer duration. You can only have one Log Profile per Azure Subscription.

- 5.1.1 Ensure that a Log Profile exists (Scored)
    - The CIS requirements say to ensure that at least one Log Profile exists for a subscription.

- 5.1.2 Ensure that Activity Log Retention is set 365 days or greater (Scored)
    - This CIS requirement is to ensure that logs are retained for at least a year if not forever. The Log Profile seems to have a `retentionPolicy` property which is an object containing whether or not retention is enabled and if so, how many days it is enabled. We flattened this object using dot notation and put it on the **Log Profile** entity.

- 5.1.3 Ensure audit profile captures all the activities (Scored)
    - This CIS requirement is to ensure that Activity Logs are captured when any ‘write’, ‘delete’, or ‘action’ activities are performed on the Azure Subscription. This data is returned via a categories property, which is an array of strings. We put the `categories` property on the **Log Profile** entity.

- 5.1.4 Ensure the log profile captures activity logs for all regions including global (Scored)
    - This CIS requirement is to ensure that any activities that happen in any Azure supported region are logged. This data is returned via a locations string array on the Log Profile. The `locations` array was put on the **Log Profile** entity.

- 5.1.5 Ensure the storage container storing the activity logs is not publicly accessible (Scored)
    - This information is not on the **Log Profile** and thus won’t come from the @azure/arm-monitor client, but is instead stored on the **Storage Account**. We added the `allowBlobPublicAccess` to the **Storage Account** entity.

- 5.1.6 Ensure the storage account containing the container with activity logs is encrypted with BYOK (Use Your Own Key) (Scored)
    -  This CIS requirement aims to ensure that the logs stored in the Storage Account are encrypted with your own encryption key. By default, they are not. This information is not on the Log Profile and thus won’t come from the @azure/arm-monitor client, but is instead stored on the Storage Account. We added the `encyrption.keySource` and `encryption.keyVaultProperties` to the **Storage Account** entity. `keySource` should be set to `Microsoft.Keyvault` and `keyVaultProperties` should not be null. 

# What Changed?
- Added the **Azure Monitor Log Profile** entity
- Added the **Azure Subscription** has **Monitor Log Profile** relationship
- Added the **Azure Monitor Log Profile** uses **Azure Storage Account** relationship
- Added the **allowBlobPublicAccess** property to the **Azure Storage Account** entity
- Added certain properties on the **encryption** object to the **Azure Storage Account** entity 
    - `encryption.keySource`
    - `encryption.keyVaultProperties.keyName`
    -  `encryption.keyVaultProperties.keyVaultUri`
    - `encryption.keyVaultProperties.keyVersion`
- Added the **Azure Storage Account** uses **Azure Key Vault Service** relationship

# Decisions Made
- Any objects we needed to capture on the entities would be flattened with dot notation

- If an **Azure Monitor Log Profile** had a defined `storageAccountId`, we would associate it, if possible, with any known ingested **Azure Storage Accounts** by creating a `uses` relationship. (i.e. **Azure Monitor Log Profile** `uses` **Azure Storage Account**)

- Although **Azure Monitor Log Profiles** are not the preferred way to retain **Azure Activity Logs**, we decided to ingest this data for now and later ingest **Azure Diagnostic Settings**

# Out of Scope
- If an **Azure Monitor Log Profile** had a defined `serviceBusRuleId`, we would not associate it with any **Azure EventHubs**. This is because we are not currently ingesting **Azure Eventhub** and creating any such relationships does not help to answer any CIS benchmark questions at this time.

# Graph
<img width="1218" alt="Screen Shot 2020-11-11 at 1 35 19 PM" src="https://user-images.githubusercontent.com/6044786/98861850-306f7c00-2423-11eb-9094-764e67b8b86b.png">

---

<img width="1028" alt="Screen Shot 2020-11-11 at 1 33 10 PM" src="https://user-images.githubusercontent.com/6044786/98861866-36fdf380-2423-11eb-9fac-c362bde65742.png">