### PR TITLE
Collecting Diagnostic Settings Entities and Relationships for Network Security Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Diagnostic Settings entities and relationships for Network Security Groups
+
 ## 5.9.0 - 2020-12-17
 
 ### Added

--- a/src/steps/resource-manager/network/__recordings__/network-steps_2570137323/recording.har
+++ b/src/steps/resource-manager/network/__recordings__/network-steps_2570137323/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "2531614bff07ad1a156094ab128f650a",
+        "_id": "b4fc804d70a68fba7c90dae0e6d8a5dc",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 180,
+          "bodySize": 176,
           "cookies": [],
           "headers": [
             {
@@ -28,7 +28,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "180"
+              "value": "176"
             },
             {
               "_fromType": "array",
@@ -59,18 +59,18 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/v2.0/token"
         },
         "response": {
-          "bodySize": 1456,
+          "bodySize": 1557,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1456,
+            "size": 1557,
             "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2020-08-13T21:41:15.000Z",
+              "expires": "2021-01-21T18:32:41.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -82,7 +82,7 @@
               "httpOnly": true,
               "name": "x-ms-gateway-slice",
               "path": "/",
-              "sameSite": "None",
+              "sameSite": "none",
               "secure": true,
               "value": "[REDACTED]"
             },
@@ -90,7 +90,7 @@
               "httpOnly": true,
               "name": "stsservicecookie",
               "path": "/",
-              "sameSite": "None",
+              "sameSite": "none",
               "secure": true,
               "value": "[REDACTED]"
             }
@@ -98,11 +98,15 @@
           "headers": [
             {
               "name": "cache-control",
-              "value": "no-cache, no-store"
+              "value": "no-store, no-cache"
             },
             {
               "name": "pragma",
               "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1557"
             },
             {
               "name": "content-type",
@@ -121,16 +125,16 @@
               "value": "nosniff"
             },
             {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
               "name": "x-ms-request-id",
-              "value": "eaab86f2-98e7-4871-8272-2d70eb609e00"
+              "value": "4a73407c-5e4f-4d1b-ba30-13cfae7a0d00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+              "value": "2.1.11328.13 - CHI ProdSlices"
             },
             {
               "_fromType": "array",
@@ -149,15 +153,11 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:15 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:40 GMT"
             },
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1456"
             }
           ],
           "headersSize": 731,
@@ -166,8 +166,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:15.519Z",
-        "time": 360,
+        "startedDateTime": "2020-12-22T18:32:40.533Z",
+        "time": 432,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -175,7 +175,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 360
+          "wait": 432
         }
       },
       {
@@ -194,7 +194,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "59ba7f24-7cf2-d3f5-10df-e75def979e7b"
+              "value": "a4bdf055-f7af-adcf-7ec1-2dd842a1199a"
             },
             {
               "_fromType": "array",
@@ -226,18 +226,18 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1721,
+          "headersSize": 1822,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://graph.microsoft.com/v1.0/organization"
         },
         "response": {
-          "bodySize": 767,
+          "bodySize": 813,
           "content": {
             "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
-            "size": 767,
-            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"id\":\"a76fc728-0cba-45f0-a9eb-d45207e14513\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2019-09-04T16:59:36Z\",\"directorySizeQuota\":{\"used\":199,\"total\":50000},\"displayName\":\"Default Directory\",\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"privacyProfile\":null,\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"adam.jupiterone@hotmail.com\"],\"assignedPlans\":[{\"assignedDateTime\":\"2019-09-04T17:04:05Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"adamjupiteronehotmailcom.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
+            "size": 813,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"id\":\"bcd90474-9b62-4040-9d7b-8af257b1427d\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2020-09-22T16:37:39Z\",\"directorySizeQuota\":{\"used\":160,\"total\":50000},\"displayName\":\"Default Directory\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"privacyProfile\":null,\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"kanddventurepartners@gmail.com\"],\"tenantType\":\"AAD\",\"assignedPlans\":[{\"assignedDateTime\":\"2020-10-23T20:02:04Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"kanddventurepartnersgmail.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
           },
           "cookies": [],
           "headers": [
@@ -255,15 +255,19 @@
             },
             {
               "name": "request-id",
-              "value": "d231275a-f40d-43a8-b28e-aa7422c8293b"
+              "value": "6019258d-7b8e-4c85-af1c-408249edd89b"
             },
             {
               "name": "client-request-id",
-              "value": "59ba7f24-7cf2-d3f5-10df-e75def979e7b"
+              "value": "a4bdf055-f7af-adcf-7ec1-2dd842a1199a"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"East US\",\"Slice\":\"SliceC\",\"Ring\":\"5\",\"ScaleUnit\":\"005\",\"RoleInstance\":\"AGSFE_IN_12\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"SliceC\",\"Ring\":\"2\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"AGSFE_IN_13\"}}"
+            },
+            {
+              "name": "x-ms-resource-unit",
+              "value": "1"
             },
             {
               "name": "odata-version",
@@ -275,7 +279,7 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:15 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:41 GMT"
             },
             {
               "name": "connection",
@@ -283,17 +287,17 @@
             },
             {
               "name": "content-length",
-              "value": "767"
+              "value": "813"
             }
           ],
-          "headersSize": 573,
+          "headersSize": 599,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:15.886Z",
-        "time": 221,
+        "startedDateTime": "2020-12-22T18:32:40.970Z",
+        "time": 357,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,15 +305,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 221
+          "wait": 357
         }
       },
       {
-        "_id": "bed7e5afa8f6ae66e57f6f91467ef759",
+        "_id": "3440be136d06dd892a0cafcdd940df38",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 176,
+          "bodySize": 172,
           "cookies": [],
           "headers": [
             {
@@ -322,7 +326,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "64c853d2-3c13-4988-8d19-8ba2857d5d90"
+              "value": "471e8b7a-6022-4c6d-81b0-a082b34061d5"
             },
             {
               "name": "return-client-request-id",
@@ -350,7 +354,7 @@
             },
             {
               "name": "content-length",
-              "value": 176
+              "value": 172
             }
           ],
           "headersSize": 414,
@@ -367,18 +371,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
         },
         "response": {
-          "bodySize": 1338,
+          "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1338,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1594766476\",\"not_before\":\"1594762576\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665561\",\"not_before\":\"1608661661\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2020-08-13T21:41:16.000Z",
+              "expires": "2021-01-21T18:32:41.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -404,7 +408,7 @@
           "headers": [
             {
               "name": "cache-control",
-              "value": "no-cache, no-store"
+              "value": "no-store, no-cache"
             },
             {
               "name": "pragma",
@@ -427,24 +431,24 @@
               "value": "nosniff"
             },
             {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
               "name": "client-request-id",
-              "value": "64c853d2-3c13-4988-8d19-8ba2857d5d90"
+              "value": "471e8b7a-6022-4c6d-81b0-a082b34061d5"
             },
             {
               "name": "x-ms-request-id",
-              "value": "15fe7126-301b-4c90-8c8c-d74ba4889900"
+              "value": "37b7296f-3745-4dab-9603-2dcb046e0e00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
+              "value": "2.1.11328.13 - CHI ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
               "value": "1,0,0,,"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
             },
             {
               "_fromType": "array",
@@ -463,7 +467,7 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:15 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:40 GMT"
             },
             {
               "name": "connection",
@@ -471,7 +475,7 @@
             },
             {
               "name": "content-length",
-              "value": "1338"
+              "value": "1450"
             }
           ],
           "headersSize": 782,
@@ -480,7 +484,2148 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:16.130Z",
+        "startedDateTime": "2020-12-22T18:32:41.349Z",
+        "time": 332,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 332
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "1ff6ba4d-70a3-4013-b12f-a0856e6656c2"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "9be04a1c-c123-4f21-ba79-01b08b3a2b49"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9be04a1c-c123-4f21-ba79-01b08b3a2b49"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183242Z:9be04a1c-c123-4f21-ba79-01b08b3a2b49"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:41.713Z",
+        "time": 259,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 259
+        }
+      },
+      {
+        "_id": "681a2c7c5449c445d7d59fbb0f5633d0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "30647a46-993c-4094-9f7f-978f5e6ac41c"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1809,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Network/publicIPAddresses?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 1161,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1161,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev\",\r\n      \"etag\": \"W/\\\"1294d29f-fdde-4ec2-a897-d4e2749d7f43\\\"\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"3fea9d3d-6594-415b-aeb8-10e0daa4afd5\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipTags\": [],\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\"\r\n        }\r\n      },\r\n      \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n      \"sku\": {\r\n        \"name\": \"Basic\"\r\n      }\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cc7450e9-303e-4bca-95f0-c9da461cbae8"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5396b7c5-be2c-4d4f-9584-755fd5a49ef1"
+            },
+            {
+              "name": "x-ms-arm-service-request-id",
+              "value": "1d435ce7-6a2d-46e4-acc8-286b10e0a330"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183242Z:5396b7c5-be2c-4d4f-9584-755fd5a49ef1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 699,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:41.986Z",
+        "time": 325,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 325
+        }
+      },
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "a97c443f-0853-4b5d-a392-da4f06ad2e5c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665562\",\"not_before\":\"1608661662\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-01-21T18:32:42.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "a97c443f-0853-4b5d-a392-da4f06ad2e5c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "37125a18-36a1-4a7e-b043-f59909953c00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11328.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:42.318Z",
+        "time": 362,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 362
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f170e69d-aed6-4180-a60d-58bb5859d2c4"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "5c37aff6-442b-4b4c-bd67-003b7f9ca7dc"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5c37aff6-442b-4b4c-bd67-003b7f9ca7dc"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183243Z:5c37aff6-442b-4b4c-bd67-003b7f9ca7dc"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:43 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:42.684Z",
+        "time": 185,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 185
+        }
+      },
+      {
+        "_id": "3fd34834b77ff26e584a562a03f32ba5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "55210ae0-df07-4282-ad4a-98463ae298f7"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1809,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Network/networkInterfaces?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 1685,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1685,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev\",\r\n      \"etag\": \"W/\\\"32fe3544-3bb1-413a-bde1-d36490f49fef\\\"\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"b5a18c78-08e8-4a4e-ae49-b19bc73dd61b\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"j1devConfiguration\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\",\r\n            \"etag\": \"W/\\\"32fe3544-3bb1-413a-bde1-d36490f49fef\\\"\",\r\n            \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.2.4\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev\"\r\n              },\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"2mcszjejlfzuzeua4okj25djpa.bx.internal.cloudapp.net\"\r\n        },\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\"\r\n        },\r\n        \"hostedWorkloads\": [],\r\n        \"tapConfigurations\": [],\r\n        \"nicType\": \"Standard\"\r\n      },\r\n      \"type\": \"Microsoft.Network/networkInterfaces\"\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2c5ce889-6c77-4758-837e-346596224196"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "ed549df5-7d48-4fc2-a2bd-d0f565166920"
+            },
+            {
+              "name": "x-ms-arm-service-request-id",
+              "value": "29d59d43-33a2-41d6-8389-4e09e67170a7"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183243Z:ed549df5-7d48-4fc2-a2bd-d0f565166920"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:42 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 699,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:42.874Z",
+        "time": 455,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 455
+        }
+      },
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "bdbab26d-8cbf-42b9-8c59-e5a9f4756a01"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665563\",\"not_before\":\"1608661663\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-01-21T18:32:43.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "bdbab26d-8cbf-42b9-8c59-e5a9f4756a01"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "227c6b3e-dbb3-4508-a83b-b0f90d610f00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11328.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:43 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:43.336Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "0e2485b4-31ba-440c-aa90-eaf3eb1caf3d"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "00960ea4-5402-42e5-9f6f-9e25ec7c5aab"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "00960ea4-5402-42e5-9f6f-9e25ec7c5aab"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183244Z:00960ea4-5402-42e5-9f6f-9e25ec7c5aab"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:43 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:43.643Z",
+        "time": 222,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 222
+        }
+      },
+      {
+        "_id": "d9e2431d61b7898630d4b8c059c82395",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "35f85185-9849-4aae-bb5d-70163528dcab"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1813,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Network/networkSecurityGroups?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 2503,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2503,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\",\r\n      \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"65d18f29-30ff-47e2-859d-5d5d8172b5fe\",\r\n        \"securityRules\": [\r\n          {\r\n            \"name\": \"SSH\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"priv_one\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"10.0.3.0/24\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1002,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\": [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound\",\r\n            \"etag\": \"W/\\\"479fab8a-999c-41e6-8ba2-1533f33a0ad7\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev\"\r\n          }\r\n        ],\r\n        \"subnets\": [\r\n          {\r\n            \"id\": \"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "ee13f2e9-073f-4da3-8d91-dfe0fd31eac0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9903f273-0a9b-43b4-98ea-6ee12881a7ac"
+            },
+            {
+              "name": "x-ms-arm-service-request-id",
+              "value": "a5d7297f-c039-493d-a016-f8bdaa20bfff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183244Z:9903f273-0a9b-43b4-98ea-6ee12881a7ac"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:44 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 699,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:43.873Z",
+        "time": 289,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 289
+        }
+      },
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "b9354de4-0007-452c-8736-c867fb6b95ee"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665564\",\"not_before\":\"1608661664\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-01-21T18:32:44.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "b9354de4-0007-452c-8736-c867fb6b95ee"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "37125a18-36a1-4a7e-b043-f5993f953c00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11328.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:44 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:44.167Z",
+        "time": 379,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 379
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "0f2a3c1a-6846-4cd0-bb06-da3ad2e7619f"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "78803d9b-53e4-4ce2-ab34-996f9b286037"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "78803d9b-53e4-4ce2-ab34-996f9b286037"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183244Z:78803d9b-53e4-4ce2-ab34-996f9b286037"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:44 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:44.549Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "2fea29abfa58ab982fca15050579dae3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e8335051-327b-4353-90b6-5cd925933998"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1896,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2017-05-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com//subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+        },
+        "response": {
+          "bodySize": 1085,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1085,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set\",\"type\":\"Microsoft.Insights/diagnosticSettings\",\"name\":\"j1dev_net_sec_grp_set\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev\",\"serviceBusRuleId\":null,\"workspaceId\":null,\"eventHubAuthorizationRuleId\":null,\"eventHubName\":null,\"metrics\":[],\"logs\":[{\"category\":\"NetworkSecurityGroupEvent\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}},{\"category\":\"NetworkSecurityGroupRuleCounter\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logAnalyticsDestinationType\":null},\"identity\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "712d15bf-b1e0-4456-a8e1-45e41ce5ef44"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "a55b094f-2d1b-4040-af5d-1a5e3657d473"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183246Z:a55b094f-2d1b-4040-af5d-1a5e3657d473"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:45 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:44.766Z",
+        "time": 1243,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1243
+        }
+      },
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "4f0d31e4-197d-45fb-8469-82410b833dd9"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665566\",\"not_before\":\"1608661666\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-01-21T18:32:46.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "4f0d31e4-197d-45fb-8469-82410b833dd9"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a3fa0a10-c335-4c55-8cc1-cf3c28d20c00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11328.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:46 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:46.015Z",
+        "time": 378,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 378
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "0f1304b6-bd6b-43a6-90b3-e0a43fc669f1"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "5ba1e905-c89a-4234-9626-57b9826bad1d"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5ba1e905-c89a-4234-9626-57b9826bad1d"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20201222T183246Z:5ba1e905-c89a-4234-9626-57b9826bad1d"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 22 Dec 2020 18:32:46 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-12-22T18:32:46.397Z",
         "time": 202,
         "timings": {
           "blocked": -1,
@@ -493,7 +2638,7 @@
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "cb18a91d720c69b91b7542a7b028565a",
         "_order": 0,
         "cache": {},
         "request": {
@@ -502,18 +2647,18 @@
           "headers": [
             {
               "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
               "name": "accept-language",
               "value": "en-US"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "686309f3-cbc1-42f5-b4c6-e1afa069b9ba"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
+              "value": "cdc392b7-45da-4f34-8b14-264f1b20c737"
             },
             {
               "_fromType": "array",
@@ -523,7 +2668,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
             },
             {
               "_fromType": "array",
@@ -550,160 +2695,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1565,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 347,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 347,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"displayName\":\"Microsoft Azure Standard\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "4380c4e7-5fab-4405-afd9-76d8dc821bc7"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "4380c4e7-5fab-4405-afd9-76d8dc821bc7"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214116Z:4380c4e7-5fab-4405-afd9-76d8dc821bc7"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:15 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "347"
-            }
-          ],
-          "headersSize": 581,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:16.367Z",
-        "time": 354,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 354
-        }
-      },
-      {
-        "_id": "bca408c8d33156f07ddd02ba356400e0",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "e7f5e6a6-a12d-4910-ae4b-a0f9abed86cc"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1697,
+          "headersSize": 1807,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -712,1508 +2704,14 @@
               "value": "2019-12-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/providers/Microsoft.Network/publicIPAddresses?api-version=2019-12-01"
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Network/virtualNetworks?api-version=2019-12-01"
         },
         "response": {
-          "bodySize": 1157,
+          "bodySize": 861,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1157,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev\",\r\n      \"etag\": \"W/\\\"7056b753-521e-4f59-a1f9-c7200b2cba8b\\\"\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"e91e06bc-4c1a-42e1-bf2e-87c2a36ebdd2\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipTags\": [],\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\"\r\n        }\r\n      },\r\n      \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n      \"sku\": {\r\n        \"name\": \"Basic\"\r\n      }\r\n    }\r\n  ]\r\n}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "2ae9a98b-d929-4a79-89dd-b33b5b516e9d"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "162b2a8a-3cc5-4656-8b7b-8f6d196d2a00"
-            },
-            {
-              "name": "x-ms-arm-service-request-id",
-              "value": "77175f63-4830-40b6-9dd9-1bb022a3b302"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214117Z:162b2a8a-3cc5-4656-8b7b-8f6d196d2a00"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:16 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 692,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:16.738Z",
-        "time": 619,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 619
-        }
-      },
-      {
-        "_id": "bed7e5afa8f6ae66e57f6f91467ef759",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 176,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "db4b2a98-92b0-4a38-aaef-bf9b7e6d2dda"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 176
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1338,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1338,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1594766477\",\"not_before\":\"1594762577\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2020-08-13T21:41:17.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache, no-store"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "client-request-id",
-              "value": "db4b2a98-92b0-4a38-aaef-bf9b7e6d2dda"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "0a066f0b-f0b3-4a66-9498-7c7da879b300"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:16 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1338"
-            }
-          ],
-          "headersSize": 782,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:17.367Z",
-        "time": 171,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 171
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "0923e702-cf9f-444d-8ae9-95d2629ab49d"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1565,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 347,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 347,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"displayName\":\"Microsoft Azure Standard\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "283a08ac-27ee-4f70-9208-5afdaff48288"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "283a08ac-27ee-4f70-9208-5afdaff48288"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214117Z:283a08ac-27ee-4f70-9208-5afdaff48288"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:17 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "347"
-            }
-          ],
-          "headersSize": 581,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:17.543Z",
-        "time": 291,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 291
-        }
-      },
-      {
-        "_id": "fa55b473b6ab50ec02a7a339c60521be",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "15386bf0-5fc6-4608-9a24-e2bbeeefa867"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1697,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-12-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/providers/Microsoft.Network/networkInterfaces?api-version=2019-12-01"
-        },
-        "response": {
-          "bodySize": 1609,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1609,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev\",\r\n      \"etag\": \"W/\\\"cb788ae3-38fe-4891-b46d-871d785e68e3\\\"\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"9a2f2357-0821-48b7-89dc-7a6af8d31a95\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"j1devConfiguration\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\",\r\n            \"etag\": \"W/\\\"cb788ae3-38fe-4891-b46d-871d785e68e3\\\"\",\r\n            \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.2.4\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev\"\r\n              },\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n        },\r\n        \"macAddress\": \"00-0D-3A-98-B8-2E\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\"\r\n        },\r\n        \"hostedWorkloads\": [],\r\n        \"tapConfigurations\": [],\r\n        \"nicType\": \"Standard\"\r\n      },\r\n      \"type\": \"Microsoft.Network/networkInterfaces\"\r\n    }\r\n  ]\r\n}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "5e07e686-02ed-4a93-81a6-eb25c130e149"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "a6900cd1-9070-4ef2-ba70-f05e4820c678"
-            },
-            {
-              "name": "x-ms-arm-service-request-id",
-              "value": "a0db0e39-d9a2-4d15-9ff9-6b81893bfd0b"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214118Z:a6900cd1-9070-4ef2-ba70-f05e4820c678"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:17 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 692,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:17.840Z",
-        "time": 417,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 417
-        }
-      },
-      {
-        "_id": "bed7e5afa8f6ae66e57f6f91467ef759",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 176,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "f0bcd7bc-9ce2-4830-84ba-850ad35606e1"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 176
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1338,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1338,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1594766478\",\"not_before\":\"1594762578\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2020-08-13T21:41:18.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache, no-store"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "client-request-id",
-              "value": "f0bcd7bc-9ce2-4830-84ba-850ad35606e1"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "45a58854-53bb-499d-bbc2-20fb29b7a100"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:18 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1338"
-            }
-          ],
-          "headersSize": 782,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:18.263Z",
-        "time": 181,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 181
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "764c0129-3f29-4a96-b4be-08cf7ec74a78"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1565,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 347,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 347,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"displayName\":\"Microsoft Azure Standard\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "bba81ba8-73d7-4672-ae07-47f655b676ab"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "bba81ba8-73d7-4672-ae07-47f655b676ab"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214118Z:bba81ba8-73d7-4672-ae07-47f655b676ab"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:18 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "347"
-            }
-          ],
-          "headersSize": 581,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:18.448Z",
-        "time": 313,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 313
-        }
-      },
-      {
-        "_id": "ffde0bb01a0f75e7864dfc3d3f98ad78",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "39ae8fdb-3231-4bc8-8048-f206a0c828f6"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1701,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-12-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/providers/Microsoft.Network/networkSecurityGroups?api-version=2019-12-01"
-        },
-        "response": {
-          "bodySize": 2499,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 2499,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\",\r\n      \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"bf612654-8947-43c7-86da-f48740022419\",\r\n        \"securityRules\": [\r\n          {\r\n            \"name\": \"SSH\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"priv_one\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"10.0.3.0/24\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1002,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\": [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound\",\r\n            \"etag\": \"W/\\\"8ccad6fa-bf5c-473a-844a-8b1407de952b\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev\"\r\n          }\r\n        ],\r\n        \"subnets\": [\r\n          {\r\n            \"id\": \"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "9db6243b-28f8-40ca-98ea-b40900a43173"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "6e30a114-435f-4712-88b3-5d9518ef51ad"
-            },
-            {
-              "name": "x-ms-arm-service-request-id",
-              "value": "e296ec5f-72db-4a04-bd84-8442f8d14b33"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214119Z:6e30a114-435f-4712-88b3-5d9518ef51ad"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:18 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 692,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:18.767Z",
-        "time": 388,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 388
-        }
-      },
-      {
-        "_id": "bed7e5afa8f6ae66e57f6f91467ef759",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 176,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "c0e18ca3-ec58-44e5-b42b-ea92fc091ffa"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 176
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1332,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1332,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1594766479\",\"not_before\":\"1594762579\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2020-08-13T21:41:19.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache, no-store"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "client-request-id",
-              "value": "c0e18ca3-ec58-44e5-b42b-ea92fc091ffa"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "6d0dc317-72e4-499d-ba1e-c5ad52b21f00"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:19 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1332"
-            }
-          ],
-          "headersSize": 782,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:19.163Z",
-        "time": 179,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 179
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "eaf90686-3c3e-44d5-ae59-a9d6d09d29b4"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1559,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 347,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 347,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"displayName\":\"Microsoft Azure Standard\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11998"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "4e111da0-f6ee-46e1-aa1d-133071e5c7fe"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "4e111da0-f6ee-46e1-aa1d-133071e5c7fe"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214119Z:4e111da0-f6ee-46e1-aa1d-133071e5c7fe"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:18 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "347"
-            }
-          ],
-          "headersSize": 581,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-07-14T21:41:19.348Z",
-        "time": 288,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 288
-        }
-      },
-      {
-        "_id": "3fc5ac3194824ee6a73f9936cd2bfcf1",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "98cdf9ed-3b8f-4682-a7ea-c944586d73ef"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1689,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-12-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/providers/Microsoft.Network/virtualNetworks?api-version=2019-12-01"
-        },
-        "response": {
-          "bodySize": 867,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 867,
-            "text": "{\"value\":[{\"name\":\"j1dev_two\",\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two\",\"etag\":\"W/\\\"756510cc-8c35-4ea1-92e8-2d032c45a26e\\\"\",\"type\":\"Microsoft.Network/virtualNetworks\",\"location\":\"westus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"770f2029-a3b9-4376-ab32-b3409f43ccae\",\"addressSpace\":{\"addressPrefixes\":[\"10.0.0.0/16\"]},\"dhcpOptions\":{\"dnsServers\":[]},\"subnets\":[{\"name\":\"j1dev_priv_two\",\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two\",\"etag\":\"W/\\\"756510cc-8c35-4ea1-92e8-2d032c45a26e\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.3.0/24\",\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"}],\"virtualNetworkPeerings\":[],\"enableDdosProtection\":false,\"enableVmProtection\":false}},{\"name\":\"j1dev\",\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev\",\"etag\":\"W/\\\"1e363267-3af2-4c45-8809-470723494d44\\\"\",\"type\":\"Microsoft.Network/virtualNetworks\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"59b26ef4-07de-4d65-bae1-5f76f935788b\",\"addressSpace\":{\"addressPrefixes\":[\"10.0.0.0/16\"]},\"dhcpOptions\":{\"dnsServers\":[]},\"subnets\":[{\"name\":\"j1dev\",\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\",\"etag\":\"W/\\\"1e363267-3af2-4c45-8809-470723494d44\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.2.0/24\",\"networkSecurityGroup\":{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\"},\"ipConfigurations\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\"}],\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"},{\"name\":\"j1dev_priv_one\",\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one\",\"etag\":\"W/\\\"1e363267-3af2-4c45-8809-470723494d44\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.3.0/24\",\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"}],\"virtualNetworkPeerings\":[],\"enableDdosProtection\":false,\"enableVmProtection\":false}}]}"
+            "size": 861,
+            "text": "{\"value\":[{\"name\":\"j1dev_two\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two\",\"etag\":\"W/\\\"00431784-67c4-4348-8c44-af5633faa955\\\"\",\"type\":\"Microsoft.Network/virtualNetworks\",\"location\":\"westus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"7383f944-3603-46fa-94e4-1cb5de40928c\",\"addressSpace\":{\"addressPrefixes\":[\"10.0.0.0/16\"]},\"dhcpOptions\":{\"dnsServers\":[]},\"subnets\":[{\"name\":\"j1dev_priv_two\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two\",\"etag\":\"W/\\\"00431784-67c4-4348-8c44-af5633faa955\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.3.0/24\",\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"}],\"virtualNetworkPeerings\":[],\"enableDdosProtection\":false,\"enableVmProtection\":false}},{\"name\":\"j1dev\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev\",\"etag\":\"W/\\\"050a1375-e7c1-4b1c-bb9f-f7fc6a59f5b2\\\"\",\"type\":\"Microsoft.Network/virtualNetworks\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"a42c05e3-5989-4c73-9280-f3949e7c6978\",\"addressSpace\":{\"addressPrefixes\":[\"10.0.0.0/16\"]},\"dhcpOptions\":{\"dnsServers\":[]},\"subnets\":[{\"name\":\"j1dev_priv_one\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one\",\"etag\":\"W/\\\"050a1375-e7c1-4b1c-bb9f-f7fc6a59f5b2\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.3.0/24\",\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"},{\"name\":\"j1dev\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\",\"etag\":\"W/\\\"050a1375-e7c1-4b1c-bb9f-f7fc6a59f5b2\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"addressPrefix\":\"10.0.2.0/24\",\"networkSecurityGroup\":{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\"},\"ipConfigurations\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev/ipConfigurations/j1devConfiguration\"}],\"serviceEndpoints\":[],\"delegations\":[],\"privateEndpointNetworkPolicies\":\"Enabled\",\"privateLinkServiceNetworkPolicies\":\"Enabled\"},\"type\":\"Microsoft.Network/virtualNetworks/subnets\"}],\"virtualNetworkPeerings\":[],\"enableDdosProtection\":false,\"enableVmProtection\":false}}]}"
           },
           "cookies": [],
           "headers": [
@@ -2239,23 +2737,23 @@
             },
             {
               "name": "x-ms-original-request-ids",
-              "value": "4ff42b0b-0a19-4fbd-8b17-e917a5e2ac72, 6f4afe13-20d9-4ebf-9bbb-54d610798c82"
+              "value": "94c2d425-266d-4e34-9c64-d475e88f2843, 41a40663-96fc-4fa3-bf1a-f6299b62c0d3"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "x-ms-request-id",
-              "value": "83e3396c-aa50-49ec-86aa-afed012d1232"
+              "value": "6f7b326b-7a23-417b-a7c7-5270a678d6ba"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "83e3396c-aa50-49ec-86aa-afed012d1232"
+              "value": "6f7b326b-7a23-417b-a7c7-5270a678d6ba"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214120Z:83e3396c-aa50-49ec-86aa-afed012d1232"
+              "value": "WESTCENTRALUS:20201222T183247Z:6f7b326b-7a23-417b-a7c7-5270a678d6ba"
             },
             {
               "name": "strict-transport-security",
@@ -2267,7 +2765,7 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:19 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:46 GMT"
             },
             {
               "name": "connection",
@@ -2275,17 +2773,17 @@
             },
             {
               "name": "content-length",
-              "value": "867"
+              "value": "861"
             }
           ],
-          "headersSize": 690,
+          "headersSize": 697,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:19.641Z",
-        "time": 443,
+        "startedDateTime": "2020-12-22T18:32:46.605Z",
+        "time": 514,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2293,15 +2791,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 443
+          "wait": 514
         }
       },
       {
-        "_id": "bed7e5afa8f6ae66e57f6f91467ef759",
-        "_order": 4,
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 5,
         "cache": {},
         "request": {
-          "bodySize": 176,
+          "bodySize": 172,
           "cookies": [],
           "headers": [
             {
@@ -2314,7 +2812,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "54e34808-eee7-42e8-a827-be5b3fb252ac"
+              "value": "2a2e2c02-a886-44db-8a2b-39dbd3502d16"
             },
             {
               "name": "return-client-request-id",
@@ -2342,7 +2840,7 @@
             },
             {
               "name": "content-length",
-              "value": 176
+              "value": 172
             }
           ],
           "headersSize": 414,
@@ -2359,18 +2857,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/a76fc728-0cba-45f0-a9eb-d45207e14513/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
         },
         "response": {
-          "bodySize": 1338,
+          "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1338,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1594766480\",\"not_before\":\"1594762580\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1608665567\",\"not_before\":\"1608661667\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2020-08-13T21:41:20.000Z",
+              "expires": "2021-01-21T18:32:47.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -2396,11 +2894,15 @@
           "headers": [
             {
               "name": "cache-control",
-              "value": "no-cache, no-store"
+              "value": "no-store, no-cache"
             },
             {
               "name": "pragma",
               "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             },
             {
               "name": "content-type",
@@ -2419,24 +2921,24 @@
               "value": "nosniff"
             },
             {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
               "name": "client-request-id",
-              "value": "54e34808-eee7-42e8-a827-be5b3fb252ac"
+              "value": "2a2e2c02-a886-44db-8a2b-39dbd3502d16"
             },
             {
               "name": "x-ms-request-id",
-              "value": "aa1dc1a5-1420-4c12-9766-0ceb2767ad00"
+              "value": "f0886c95-07da-4087-a41a-9532203e0e00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.10821.14 - EST ProdSlices"
+              "value": "2.1.11328.13 - CHI ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
               "value": "1,0,0,,"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
             },
             {
               "_fromType": "array",
@@ -2455,15 +2957,11 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:19 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:47 GMT"
             },
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1338"
             }
           ],
           "headersSize": 782,
@@ -2472,8 +2970,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:20.091Z",
-        "time": 174,
+        "startedDateTime": "2020-12-22T18:32:47.127Z",
+        "time": 305,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2481,12 +2979,12 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 174
+          "wait": 305
         }
       },
       {
         "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 4,
+        "_order": 5,
         "cache": {},
         "request": {
           "bodySize": 0,
@@ -2500,7 +2998,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "4a06ed45-fd2c-41a1-b9ea-3afda52ab5b2"
+              "value": "ac99d079-09ac-49ff-af2a-552e9e72b518"
             },
             {
               "_fromType": "array",
@@ -2515,7 +3013,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
             },
             {
               "_fromType": "array",
@@ -2542,7 +3040,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1565,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2554,11 +3052,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 347,
+          "bodySize": 336,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 347,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"dccea45f-7035-4a17-8731-1fd46aaa74a0\",\"displayName\":\"Microsoft Azure Standard\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -2584,19 +3082,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "x-ms-request-id",
-              "value": "c8d25762-dd0f-4bc3-8d5d-0c28d7d81dfe"
+              "value": "8c169eb3-534d-40dd-bf59-b5d5f1436618"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "c8d25762-dd0f-4bc3-8d5d-0c28d7d81dfe"
+              "value": "8c169eb3-534d-40dd-bf59-b5d5f1436618"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214120Z:c8d25762-dd0f-4bc3-8d5d-0c28d7d81dfe"
+              "value": "WESTCENTRALUS:20201222T183247Z:8c169eb3-534d-40dd-bf59-b5d5f1436618"
             },
             {
               "name": "strict-transport-security",
@@ -2608,7 +3106,7 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:19 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:47 GMT"
             },
             {
               "name": "connection",
@@ -2616,17 +3114,17 @@
             },
             {
               "name": "content-length",
-              "value": "347"
+              "value": "336"
             }
           ],
-          "headersSize": 581,
+          "headersSize": 588,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:20.269Z",
-        "time": 288,
+        "startedDateTime": "2020-12-22T18:32:47.436Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2634,11 +3132,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 288
+          "wait": 216
         }
       },
       {
-        "_id": "c65e4c9573d4ebd2958d5e8c03c04e53",
+        "_id": "b283b9529578f71cc181d23ee701ce7c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2658,7 +3156,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "d2cfb624-8d6e-4ea3-9637-c952c3d673ee"
+              "value": "0034747e-e6a7-46a7-9647-c44104278f09"
             },
             {
               "_fromType": "array",
@@ -2668,7 +3166,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.13.1 OS/(x64-Darwin-19.5.0)"
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
             },
             {
               "_fromType": "array",
@@ -2695,7 +3193,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1693,
+          "headersSize": 1805,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2704,7 +3202,7 @@
               "value": "2019-12-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/providers/Microsoft.Network/loadBalancers?api-version=2019-12-01"
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.Network/loadBalancers?api-version=2019-12-01"
         },
         "response": {
           "bodySize": 133,
@@ -2737,19 +3235,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "x-ms-request-id",
-              "value": "fa52fe17-8dfd-4249-be3f-63a66a0dc741"
+              "value": "8b1f77d8-e8ee-47f5-8ee3-eab2f7895f96"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "fa52fe17-8dfd-4249-be3f-63a66a0dc741"
+              "value": "8b1f77d8-e8ee-47f5-8ee3-eab2f7895f96"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTUS:20200714T214120Z:fa52fe17-8dfd-4249-be3f-63a66a0dc741"
+              "value": "WESTCENTRALUS:20201222T183248Z:8b1f77d8-e8ee-47f5-8ee3-eab2f7895f96"
             },
             {
               "name": "strict-transport-security",
@@ -2761,7 +3259,7 @@
             },
             {
               "name": "date",
-              "value": "Tue, 14 Jul 2020 21:41:20 GMT"
+              "value": "Tue, 22 Dec 2020 18:32:47 GMT"
             },
             {
               "name": "connection",
@@ -2772,14 +3270,14 @@
               "value": "133"
             }
           ],
-          "headersSize": 587,
+          "headersSize": 594,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-14T21:41:20.562Z",
-        "time": 295,
+        "startedDateTime": "2020-12-22T18:32:47.658Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2787,7 +3285,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 295
+          "wait": 225
         }
       }
     ],

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -6,7 +6,6 @@ import {
 import { Recording } from '@jupiterone/integration-sdk-testing';
 
 import { setupAzureRecording } from '../../../../test/helpers/recording';
-import instanceConfig from '../../../../test/integrationInstanceConfig';
 import { fetchAccount } from '../../active-directory';
 import {
   buildSecurityGroupRuleRelationships,
@@ -17,6 +16,14 @@ import {
   fetchVirtualNetworks,
 } from './';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
+import { MonitorEntities } from '../monitor/constants';
+import { IntegrationConfig } from '../../../types';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+
+const GUID_REGEX = new RegExp(
+  /(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}/,
+  'g',
+);
 
 expect.extend({
   toContainGraphObject<T extends Entity | Relationship>(
@@ -87,20 +94,28 @@ expect.extend({
 });
 
 let recording: Recording;
+let instanceConfig: IntegrationConfig;
 
 afterEach(async () => {
   await recording.stop();
 });
 
 test('network steps', async () => {
+  instanceConfig = {
+    clientId: process.env.CLIENT_ID || 'clientId',
+    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+    directoryId: 'bcd90474-9b62-4040-9d7b-8af257b1427d',
+    subscriptionId: '40474ebe-55a2-4071-8fa8-b610acdd8e56',
+    developerId: 'keionned',
+  };
+
   recording = setupAzureRecording({
     directory: __dirname,
     name: 'network-steps',
   });
 
   const resouceGroupEntity: Entity = {
-    _key:
-      '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
+    _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
     _type: 'azure_resource_group',
     _class: ['Group'],
   };
@@ -108,6 +123,14 @@ test('network steps', async () => {
   const context = createMockAzureStepExecutionContext({
     instanceConfig,
     entities: [resouceGroupEntity],
+    setData: {
+      [ACCOUNT_ENTITY_TYPE]: {
+        defaultDomain: 'www.fake-domain.com',
+        _type: ACCOUNT_ENTITY_TYPE,
+        _key: 'azure_account_id',
+        id: 'azure_account_id',
+      },
+    },
   });
 
   // Simulates dependency order of execution
@@ -128,7 +151,7 @@ test('network steps', async () => {
       createdOn: undefined,
       defaultDomain: expect.any(String),
       displayName: 'Local Integration',
-      id: 'a76fc728-0cba-45f0-a9eb-d45207e14513',
+      id: instanceConfig.directoryId,
       name: 'Default Directory',
       organizationName: 'Default Directory',
       verifiedDomains: expect.any(Array),
@@ -138,176 +161,192 @@ test('network steps', async () => {
     {
       CIDR: '10.0.0.0/16',
       _class: ['Network'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_vnet',
       createdOn: undefined,
       displayName: 'j1dev (10.0.0.0/16)',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
       internal: true,
       name: 'j1dev',
       public: false,
       region: 'eastus',
       resourceGroup: 'j1dev',
       'tag.environment': 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
     },
     {
       CIDR: '10.0.2.0/24',
       _class: ['Network'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_subnet',
       createdOn: undefined,
       displayName: 'j1dev (10.0.2.0/24)',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
       internal: true,
       name: 'j1dev',
       public: false,
       region: 'eastus',
       resourceGroup: 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
     },
     {
       CIDR: '10.0.3.0/24',
       _class: ['Network'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_subnet',
       createdOn: undefined,
       displayName: 'j1dev_priv_one (10.0.3.0/24)',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
       internal: true,
       name: 'j1dev_priv_one',
       public: false,
       region: 'eastus',
       resourceGroup: 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
     },
     {
       _class: 'IpAddress',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_public_ip',
       displayName: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev`,
       public: true,
       // Dynamic address may be undefined when the address is not bound to anything
       // publicIp: '52.188.119.30',
       // publicIpAddress: '52.188.119.30',
       region: 'eastus',
       resourceGroup: 'j1dev',
-      resourceGuid: 'e91e06bc-4c1a-42e1-bf2e-87c2a36ebdd2',
+      resourceGuid: expect.stringMatching(GUID_REGEX),
       sku: 'Basic',
       'tag.environment': 'j1dev',
       type: 'Microsoft.Network/publicIPAddresses',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev`,
     },
     {
       _class: 'NetworkInterface',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_nic',
       displayName: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
       ipForwarding: false,
-      macAddress: '00-0D-3A-98-B8-2E',
+      macAddress: undefined,
       privateIp: ['10.0.2.4'],
       privateIpAddress: ['10.0.2.4'],
       publicIp: expect.any(Array),
       publicIpAddress: expect.any(Array),
       region: 'eastus',
       resourceGroup: 'j1dev',
-      resourceGuid: '9a2f2357-0821-48b7-89dc-7a6af8d31a95',
-      securityGroupId:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      resourceGuid: expect.stringMatching(GUID_REGEX),
+      securityGroupId: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       'tag.environment': 'j1dev',
       type: 'Microsoft.Network/networkInterfaces',
       // Only defined when bound to a VM
       // virtualMachineId:
-      //   '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Compute/virtualMachines/j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      //   `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Compute/virtualMachines/j1dev`,
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
     },
     {
       _class: ['Firewall'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_security_group',
       category: ['network', 'host'],
       createdOn: undefined,
       displayName: 'j1dev',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       isWideOpen: false,
       name: 'j1dev',
       region: 'eastus',
       resourceGroup: 'j1dev',
       'tag.environment': 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
     },
 
     // VPC default, westus
     {
       CIDR: '10.0.0.0/16',
       _class: ['Network'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_vnet',
       createdOn: undefined,
       displayName: 'j1dev_two (10.0.0.0/16)',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
       internal: true,
       name: 'j1dev_two',
       public: false,
       region: 'westus',
       resourceGroup: 'j1dev',
       'tag.environment': 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
     },
     {
       CIDR: '10.0.3.0/24',
       _class: ['Network'],
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
       _rawData: [expect.objectContaining({ name: 'default' })],
       _type: 'azure_subnet',
       createdOn: undefined,
       displayName: 'j1dev_priv_two (10.0.3.0/24)',
       environment: 'j1dev',
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
       internal: true,
       name: 'j1dev_priv_two',
       public: false,
       region: 'westus',
       resourceGroup: 'j1dev',
-      webLink:
-        'https://portal.azure.com/#@adamjupiteronehotmailcom.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
+    },
+    // Diagnostic Settings
+    {
+      _class: MonitorEntities.DIAGNOSTIC_LOG_SETTING._class,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true`,
+      _type: MonitorEntities.DIAGNOSTIC_LOG_SETTING._type,
+      _rawData: [expect.objectContaining({ name: 'default' })],
+      category: 'NetworkSecurityGroupRuleCounter',
+      displayName: 'j1dev_net_sec_grp_set',
+      enabled: true,
+      eventHubAuthorizationRuleId: null,
+      eventHubName: null,
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true`,
+      logAnalyticsDestinationType: null,
+      name: 'j1dev_net_sec_grp_set',
+      'retentionPolicy.days': 1,
+      'retentionPolicy.enabled': true,
+      serviceBusRuleId: null,
+      storageAccountId: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set`,
+      workspaceId: null,
+    },
+    {
+      _class: MonitorEntities.DIAGNOSTIC_LOG_SETTING._class,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true`,
+      _type: MonitorEntities.DIAGNOSTIC_LOG_SETTING._type,
+      _rawData: [expect.objectContaining({ name: 'default' })],
+      category: 'NetworkSecurityGroupEvent',
+      displayName: 'j1dev_net_sec_grp_set',
+      enabled: true,
+      eventHubAuthorizationRuleId: null,
+      eventHubName: null,
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true`,
+      logAnalyticsDestinationType: null,
+      name: 'j1dev_net_sec_grp_set',
+      'retentionPolicy.days': 1,
+      'retentionPolicy.enabled': true,
+      serviceBusRuleId: null,
+      storageAccountId: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      webLink: `https://portal.azure.com/#@kanddventurepartnersgmail.onmicrosoft.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set`,
+      workspaceId: null,
     },
   );
 
@@ -315,56 +354,41 @@ test('network steps', async () => {
     // VPC default, eastus
     {
       _class: 'CONTAINS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev|contains|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev|contains|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
       _type: 'azure_vnet_contains_subnet',
       displayName: 'CONTAINS',
     },
     {
       _class: 'CONTAINS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev|contains|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev|contains|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
       _type: 'azure_vnet_contains_subnet',
       displayName: 'CONTAINS',
     },
     {
       _class: 'PROTECTS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|protects|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|protects|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev`,
       _type: 'azure_security_group_protects_subnet',
       displayName: 'PROTECTS',
     },
     {
       _class: 'PROTECTS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|protects|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|protects|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
       _type: 'azure_security_group_protects_nic',
       displayName: 'PROTECTS',
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one:22:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one:22:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev_priv_one`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       _type: 'azure_security_group_rule',
       access: 'Allow',
       destinationAddressPrefix: '*',
@@ -374,8 +398,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 22,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one`,
       inbound: true,
       ingress: true,
       ipProtocol: 'tcp',
@@ -393,12 +416,9 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one:22:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one:22:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       _type: 'azure_security_group_rule',
       access: 'Allow',
       destinationAddressPrefix: '*',
@@ -408,8 +428,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 22,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one`,
       inbound: true,
       ingress: true,
       ipProtocol: 'tcp',
@@ -427,13 +446,11 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound:*:Service:azure_virtual_network:VirtualNetwork',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound:*:Service:azure_virtual_network:VirtualNetwork`,
       _mapping: {
         relationshipDirection: RelationshipDirection.REVERSE,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           _class: 'Service',
           _type: 'azure_virtual_network',
@@ -451,8 +468,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound`,
       inbound: true,
       ingress: true,
       ipProtocol: '*',
@@ -470,13 +486,11 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound:*:Service:azure_load_balancer:AzureLoadBalancer',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound:*:Service:azure_load_balancer:AzureLoadBalancer`,
       _mapping: {
         relationshipDirection: RelationshipDirection.REVERSE,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           _class: 'Service',
           _type: 'azure_load_balancer',
@@ -494,8 +508,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound`,
       inbound: true,
       ingress: true,
       ipProtocol: '*',
@@ -513,13 +526,11 @@ test('network steps', async () => {
     },
     {
       _class: 'DENIES',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound:*:internet',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound:*:internet`,
       _mapping: {
         relationshipDirection: RelationshipDirection.REVERSE,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           CIDR: '0.0.0.0/0',
           CIDRv6: '::/0',
@@ -541,8 +552,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound`,
       inbound: true,
       ingress: true,
       ipProtocol: '*',
@@ -560,13 +570,11 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound:*:Service:azure_virtual_network:VirtualNetwork',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound:*:Service:azure_virtual_network:VirtualNetwork`,
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           _class: 'Service',
           _type: 'azure_virtual_network',
@@ -584,8 +592,7 @@ test('network steps', async () => {
       egress: true,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound`,
       inbound: false,
       ingress: false,
       ipProtocol: '*',
@@ -603,13 +610,11 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound:*:internet',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound:*:internet`,
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           CIDR: '0.0.0.0/0',
           CIDRv6: '::/0',
@@ -631,8 +636,7 @@ test('network steps', async () => {
       egress: true,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound`,
       inbound: false,
       ingress: false,
       ipProtocol: '*',
@@ -650,13 +654,11 @@ test('network steps', async () => {
     },
     {
       _class: 'DENIES',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound:*:internet',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound:*:internet`,
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           CIDR: '0.0.0.0/0',
           CIDRv6: '::/0',
@@ -678,8 +680,7 @@ test('network steps', async () => {
       egress: true,
       etag: expect.any(String),
       fromPort: 0,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound`,
       inbound: false,
       ingress: false,
       ipProtocol: '*',
@@ -697,13 +698,11 @@ test('network steps', async () => {
     },
     {
       _class: 'ALLOWS',
-      _key:
-        'azure_security_group_rule:/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH:22:internet',
+      _key: `azure_security_group_rule:/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH:22:internet`,
       _mapping: {
         relationshipDirection: RelationshipDirection.REVERSE,
         skipTargetCreation: false,
-        sourceEntityKey:
-          '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+        sourceEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
         targetEntity: {
           CIDR: '0.0.0.0/0',
           CIDRv6: '::/0',
@@ -724,8 +723,7 @@ test('network steps', async () => {
       egress: false,
       etag: expect.any(String),
       fromPort: 22,
-      id:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH',
+      id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH`,
       inbound: true,
       ingress: true,
       ipProtocol: 'tcp',
@@ -745,71 +743,86 @@ test('network steps', async () => {
     // VPC default, westus
     {
       _class: 'CONTAINS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two|contains|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two|contains|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two/subnets/j1dev_priv_two`,
       _type: 'azure_vnet_contains_subnet',
       displayName: 'CONTAINS',
     },
 
     // Resource Group
     {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
       _type: 'azure_resource_group_has_nic',
       _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev`,
       displayName: 'HAS',
     },
     {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev`,
       _type: 'azure_resource_group_has_public_ip',
       _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/publicIPAddresses/j1dev`,
       displayName: 'HAS',
     },
     {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       _type: 'azure_resource_group_has_security_group',
       _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
       displayName: 'HAS',
     },
     {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
       _type: 'azure_resource_group_has_vnet',
       _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev`,
       displayName: 'HAS',
     },
     {
-      _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev|has|/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
       _type: 'azure_resource_group_has_vnet',
       _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev_two`,
       displayName: 'HAS',
+    },
+    // Diagnostic Settings
+    {
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true`,
+      _type: 'azure_resource_has_diagnostic_log_setting',
+      displayName: 'HAS',
+    },
+    {
+      _class: 'HAS',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true`,
+      _type: 'azure_resource_has_diagnostic_log_setting',
+      displayName: 'HAS',
+    },
+    {
+      _class: 'USES',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupRuleCounter/true/1/true|uses|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      _type: 'azure_diagnostic_log_setting_uses_storage_account',
+      displayName: 'USES',
+    },
+    {
+      _class: 'USES',
+      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true`,
+      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set/logs/NetworkSecurityGroupEvent/true/1/true|uses|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+      _type: 'azure_diagnostic_log_setting_uses_storage_account',
+      displayName: 'USES',
     },
   );
 }, 120000);

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -21,8 +21,8 @@ import { IntegrationConfig } from '../../../types';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
 
 const GUID_REGEX = new RegExp(
-  /(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}/,
-  'g',
+  '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+  'i',
 );
 
 expect.extend({

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -66,6 +66,11 @@ import createResourceGroupResourceRelationship, {
   createResourceGroupResourceRelationshipMetadata,
 } from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
+import {
+  createDiagnosticSettingsEntitiesAndRelationshipsForResource,
+  diagnosticSettingsEntitiesForResource,
+  diagnosticSettingsRelationshipsForResource,
+} from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 
 export * from './constants';
 
@@ -239,6 +244,11 @@ export async function fetchNetworkSecurityGroups(
         subnetSecurityGroupMap[s.id as string] = sg;
       }
     }
+
+    await createDiagnosticSettingsEntitiesAndRelationshipsForResource(
+      executionContext,
+      sgEntity,
+    );
   });
 
   await jobState.setData('subnetSecurityGroupMap', subnetSecurityGroupMap);
@@ -442,6 +452,7 @@ export const networkSteps: Step<
         _type: SECURITY_GROUP_ENTITY_TYPE,
         _class: SECURITY_GROUP_ENTITY_CLASS,
       },
+      ...diagnosticSettingsEntitiesForResource,
     ],
     relationships: [
       {
@@ -453,6 +464,7 @@ export const networkSteps: Step<
       createResourceGroupResourceRelationshipMetadata(
         SECURITY_GROUP_ENTITY_TYPE,
       ),
+      ...diagnosticSettingsRelationshipsForResource,
     ],
     // SECURITY_GROUP_RULE_RELATIONSHIP_TYPE doesn't seem to exist here.
     dependsOn: [

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -77,6 +77,32 @@ resource "azurerm_network_security_group" "j1dev" {
   }
 }
 
+resource "azurerm_monitor_diagnostic_setting" "j1dev_net_sec_grp_set" {
+  name               = "j1dev_net_sec_grp_set"
+  target_resource_id = azurerm_network_security_group.j1dev.id
+  storage_account_id = azurerm_storage_account.j1dev.id
+
+  log {
+    category = "NetworkSecurityGroupRuleCounter"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+
+  log {
+    category = "NetworkSecurityGroupEvent"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+}
+
 resource "azurerm_network_interface" "j1dev" {
   name                = "j1dev"
   location            = "eastus"


### PR DESCRIPTION
# Acceptance Criteria
- Ingest [Azure Monitor Diagnostic Settings](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings)
    - Diagnostic Settings are the new way to send platform logs, including the Azure Activity Log and resource logs, and metrics to different destinations. It should not be used in tandem with Log Profile. Each Azure resource has its own diagnostic settings. These settings define the categories or types of metrics and logs that should be sent somewhere, and one or more destinations to send the logs and metrics. Currently, you can send metrics and logs to Log Analytics workspace, Event Hubs, and Azure Storage. 
    
- 6.4 Ensure that Network Security Group Flow Log retention period is 'greater than 90 days' (Automated)
    - This benchmark aims to ensure that Network Security Group Logs are retained for more than 90 days. To determine if this benchmark is met, we would need to iterate over ingested Network Security Groups and get the Diagnostic Settings for each one. 
    
# What Changed?
- Collected the **Diagnostic Settings** entities and relationships for **Network Security Groups** 
    - **Azure Diagnostic Log Setting** entity
    - **Azure Diagnostic Metric Setting** entity
    - **Azure Resource** has **Azure Diagnostic Log Setting** relationship
    - **Azure Resource** has **Azure Diagnostic Metric Setting** relationship
    - **Azure Diagnostic Log Setting** uses **Azure Storage Account** relationship
    - **Azure Diagnostic Metric Setting** uses **Azure Storage Account** relationship
    
# Graph
<img width="647" alt="Screen Shot 2020-12-22 at 12 15 25 PM" src="https://user-images.githubusercontent.com/6044786/102926010-863b3900-4451-11eb-8712-70fd1bea5817.png">
