### PR TITLE
Fix how RM exposes ECONNRESET and node-fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - Diagnostic Settings entities and relationships for Network Security Groups
 
+### Fixed
+
+- Fixed the way `IntegrationProviderAPIError` exposes error code/message of
+  `node-fetch` errors, such as `ECONNRESET`.
+
 ## 5.9.0 - 2020-12-17
 
 ### Added

--- a/src/azure/resource-manager/client.test.ts
+++ b/src/azure/resource-manager/client.test.ts
@@ -6,15 +6,20 @@ import {
 } from '@jupiterone/integration-sdk-testing';
 
 import config from '../../../test/integrationInstanceConfig';
-import { Client } from './client';
+import { Client, callAzureResourceListApi } from './client';
 import { setupAzureRecording } from '../../../test/helpers/recording';
+
+import { FetchError } from 'node-fetch';
+import { RestError as AzureRestError } from '@azure/ms-rest-js';
 
 class SomeClient extends Client {}
 
 let recording: Recording;
 
 afterEach(async () => {
-  await recording.stop();
+  if (recording) {
+    await recording.stop();
+  }
 });
 
 test('client accessToken fetched once and used across resources', async () => {
@@ -44,4 +49,81 @@ test('client accessToken fetched once and used across resources', async () => {
     client.getAuthenticatedServiceClient(SqlManagementClient),
   ).resolves.toBeInstanceOf(SqlManagementClient);
   expect(requests).toEqual(2);
+});
+
+test('callAzureResourceListApi should expose Azure RestError error codes', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop: any = () => {};
+  const request = {
+    url: 'some-url',
+    method: 'GET' as any,
+    headers: {
+      set: noop,
+      get: noop,
+      contains: noop,
+      remove: noop,
+      rawHeaders: noop,
+      headerNames: noop,
+      headerValues: noop,
+      headersArray: noop,
+      clone: noop,
+      toJson: noop,
+    },
+    withCredentials: false,
+    timeout: 1000,
+    validateRequestProperties: noop,
+    clone: noop,
+    prepare: noop,
+  };
+
+  await expect(
+    callAzureResourceListApi(
+      () => {
+        throw new AzureRestError(
+          'Error message for azure rest error',
+          'Error Code',
+          400,
+          request,
+          {
+            request,
+            status: 400,
+            headers: request.headers,
+          },
+          {
+            code: 'FeatureNotSupportedForAccount',
+            message: 'Table is not supported for the account',
+          },
+        );
+      },
+      createMockIntegrationLogger(),
+      'fake-resource',
+      1000,
+    ),
+  ).rejects.toThrow(
+    'Provider API failed at fake-resource: FeatureNotSupportedForAccount Table is not supported for the account',
+  );
+});
+
+test('callAzureResourceListApi should expose node-fetch error codes', async () => {
+  // See how node-fetch handles system errors:
+  // https://github.com/node-fetch/node-fetch/blob/master/docs/ERROR-HANDLING.md
+
+  const systemError = new Error('system error');
+  (systemError as any).code = 'ECONNRESET';
+  await expect(
+    callAzureResourceListApi(
+      () => {
+        throw new FetchError(
+          'Error message for system error',
+          'system',
+          systemError,
+        );
+      },
+      createMockIntegrationLogger(),
+      'fake-resource',
+      1000,
+    ),
+  ).rejects.toThrow(
+    'Provider API failed at fake-resource: ECONNRESET Error message for system error',
+  );
 });


### PR DESCRIPTION
The RM client was not properly handling system / `node-fetch` errors, which caused errors to be exposed like:

```
Error: Provider API failed at storage.tables: undefined undefined
```

The proper error message should have been something like 
```
Error: Provider API failed at storage.tables: ECONNRESET Connection reset by server
```
or something similar.

More PRs to come, including retries and re-using this logic in Azure AD (Graph) APIs.
