### PR TITLE
Retry azure graph API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Started retrying all request errors that are not handled by the Azure API
   client. Continue retrying 429 errors thrown by the Azure API client.
+- Started retrying API errors in Azure Graph API (Azure Active Directory
+  endpoints.)
 
 ## 5.10.0 - 2020-01-13
 

--- a/src/azure/graph/client.test.ts
+++ b/src/azure/graph/client.test.ts
@@ -2,10 +2,12 @@ import {
   createMockIntegrationLogger,
   Recording,
 } from '@jupiterone/integration-sdk-testing';
+import { FetchError } from 'node-fetch';
 
 import config from '../../../test/integrationInstanceConfig';
 import { GraphClient } from './client';
 import { setupAzureRecording } from '../../../test/helpers/recording';
+import { GraphRequest } from '@microsoft/microsoft-graph-client';
 
 class AnyGraphClient extends GraphClient {}
 
@@ -54,4 +56,44 @@ test('fetchOrganization', async () => {
       }),
     ],
   });
+});
+
+test('client.request should retry requests 3 times', async () => {
+  const client = new AnyGraphClient(createMockIntegrationLogger(), config);
+
+  const graphClientError = new Error('Generic Graph client error');
+  (graphClientError as any).statusCode = 400;
+  (graphClientError as any).statusText = 'Server Error';
+  const mockGet = jest.fn().mockRejectedValue(graphClientError);
+
+  const mockGraphRequest: GraphRequest = ({
+    get: mockGet,
+    buildFullUrl: () => 'https://hostname/endpoint',
+  } as unknown) as GraphRequest;
+
+  await expect(client.request(mockGraphRequest)).rejects.toThrow(
+    'Provider API failed at https://hostname/endpoint: 400 Server Error',
+  );
+
+  expect(mockGet).toHaveBeenCalledTimes(3);
+});
+
+test('client.request should expose node-fetch error codes', async () => {
+  const client = new AnyGraphClient(createMockIntegrationLogger(), config);
+
+  const systemError = new Error('system error');
+  (systemError as any).code = 'ECONNRESET';
+
+  const mockGraphRequest: GraphRequest = ({
+    get: jest
+      .fn()
+      .mockRejectedValue(
+        new FetchError('Error message for system error', 'system', systemError),
+      ),
+    buildFullUrl: () => 'https://hostname/endpoint',
+  } as unknown) as GraphRequest;
+
+  await expect(client.request(mockGraphRequest)).rejects.toThrow(
+    'Provider API failed at https://hostname/endpoint: ECONNRESET Error message for system error',
+  );
 });

--- a/src/azure/graph/client.ts
+++ b/src/azure/graph/client.ts
@@ -104,7 +104,7 @@ export abstract class GraphClient {
 
       this.logger.warn(
         { err, resourceUrl: endpoint },
-        'Encountered non-fatal error in Azure Graph client. Continuing step execution.',
+        'Encountered non-fatal error in Azure Graph client.',
       );
     }
   }

--- a/src/azure/graph/client.ts
+++ b/src/azure/graph/client.ts
@@ -1,14 +1,25 @@
-import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
+import {
+  IntegrationLogger,
+  IntegrationProviderAPIError,
+} from '@jupiterone/integration-sdk-core';
+import { FetchError } from 'node-fetch';
 import {
   AuthenticationProvider,
   Client,
+  GraphRequest,
 } from '@microsoft/microsoft-graph-client';
 import { Organization } from '@microsoft/microsoft-graph-types';
 
 import { IntegrationConfig } from '../../types';
 import authenticate from './authenticate';
+import { retry } from '@lifeomic/attempt';
 
 export type QueryParams = string | { [key: string]: string | number };
+
+interface AzureGraphResponse<TResponseType = any> {
+  value: TResponseType[];
+  ['@odata.nextLink']?: string;
+}
 
 /**
  * Pagination: https://docs.microsoft.com/en-us/graph/paging
@@ -27,13 +38,75 @@ export abstract class GraphClient {
     });
   }
 
-  public async fetchMetadata(): Promise<object> {
-    return this.client.api('/').get();
+  public async fetchMetadata(): Promise<AzureGraphResponse | undefined> {
+    return this.request(this.client.api('/'));
   }
 
   public async fetchOrganization(): Promise<Organization> {
-    const response = await this.client.api('/organization').get();
-    return response.value[0];
+    const response = await this.request<Organization>(
+      this.client.api('/organization'),
+    );
+    return response!.value[0];
+  }
+
+  async retryRequest<TResponseType = any>(
+    graphRequest: GraphRequest,
+  ): Promise<AzureGraphResponse<TResponseType>> {
+    return retry(
+      async () => {
+        return graphRequest.get();
+      },
+      {
+        maxAttempts: 3,
+        delay: 200,
+        handleError: (err, context, options) => {
+          const endpoint = (graphRequest as any).buildFullUrl?.();
+          this.logger.info(
+            {
+              err,
+              endpoint,
+              attemptsRemaining: context.attemptsRemaining,
+            },
+            'Encountered retryable error in Azure Graph API.',
+          );
+        },
+      },
+    );
+  }
+
+  public async request<TResponseType = any>(
+    graphRequest: GraphRequest,
+  ): Promise<AzureGraphResponse<TResponseType> | undefined> {
+    try {
+      const response = await this.retryRequest(graphRequest);
+      return response;
+    } catch (err) {
+      const endpoint = (graphRequest as any).buildFullUrl?.();
+
+      // Fetch errors include the properties code, errno, message, name, stack, type.
+      if (err instanceof FetchError) {
+        throw new IntegrationProviderAPIError({
+          cause: err,
+          endpoint,
+          status: err.code!,
+          statusText: err.message,
+        });
+      }
+
+      if (err.statusCode !== 404) {
+        throw new IntegrationProviderAPIError({
+          cause: err,
+          endpoint,
+          status: err.statusCode,
+          statusText: err.statusText,
+        });
+      }
+
+      this.logger.warn(
+        { err, resourceUrl: endpoint },
+        'Encountered non-fatal error in Azure Graph client. Continuing step execution.',
+      );
+    }
   }
 }
 

--- a/src/azure/resource-manager/client.test.ts
+++ b/src/azure/resource-manager/client.test.ts
@@ -51,7 +51,7 @@ test('client accessToken fetched once and used across resources', async () => {
   expect(requests).toEqual(2);
 });
 
-test('callAzureResourceListApi should expose Azure RestError error codes', async () => {
+test('request should expose Azure RestError error codes', async () => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const noop: any = () => {};
   const azureRequest = {
@@ -104,7 +104,7 @@ test('callAzureResourceListApi should expose Azure RestError error codes', async
   );
 });
 
-test('callAzureResourceListApi should expose node-fetch error codes', async () => {
+test('request should expose node-fetch error codes', async () => {
   // See how node-fetch handles system errors:
   // https://github.com/node-fetch/node-fetch/blob/master/docs/ERROR-HANDLING.md
 

--- a/src/steps/active-directory/client.ts
+++ b/src/steps/active-directory/client.ts
@@ -101,30 +101,22 @@ export class DirectoryGraphClient extends GraphClient {
     query?: QueryParams;
     callback: (item: T) => void | Promise<void>;
   }): Promise<void> {
-    try {
-      let nextLink: string | undefined;
-      do {
-        let api = this.client.api(nextLink || resourceUrl);
-        if (query) {
-          api = api.query(query);
-        }
-
-        const response = await api.get();
-        if (response) {
-          nextLink = response['@odata.nextLink'];
-          for (const value of response.value) {
-            await callback(value);
-          }
-        } else {
-          nextLink = undefined;
-        }
-      } while (nextLink);
-    } catch (err) {
-      if (err.statusCode === 403) {
-        this.logger.warn({ err, resourceUrl }, 'Forbidden');
-      } else if (err.statusCode !== 404) {
-        throw err;
+    let nextLink: string | undefined;
+    do {
+      let api = this.client.api(nextLink || resourceUrl);
+      if (query) {
+        api = api.query(query);
       }
-    }
+
+      const response = await this.request(api);
+      if (response) {
+        nextLink = response['@odata.nextLink'];
+        for (const value of response.value) {
+          await callback(value);
+        }
+      } else {
+        nextLink = undefined;
+      }
+    } while (nextLink);
   }
 }


### PR DESCRIPTION
Add a `request` function to the Azure Graph API, which centralizes requests and error handling for `GraphRequest.get()` requests, used to fetch Azure Active Directory resources.

Also add a `retryRequest` function to retry requests for Azure Graph API.