### PR TITLE
Diagnostic Settings for Azure Container Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Diagnostic Settings entities and relationships for Azure Container Registry
+
 ## 5.10.1 - 2020-01-15
 
 ### Fixed

--- a/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registries_2250806650/recording.har
+++ b/src/steps/resource-manager/container-registry/__recordings__/resource-manager-step-container-registries_2250806650/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "a083439df9cb90ab0ef889609d0aa995",
+        "_id": "3440be136d06dd892a0cafcdd940df38",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "8b76ef9c-fdf2-4a40-b6e0-55b6b3bb18bb"
+              "value": "66a8798f-55e5-4327-b2e5-e0f0a5c9bfb4"
             },
             {
               "name": "return-client-request-id",
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1599754361\",\"not_before\":\"1599750461\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1610994796\",\"not_before\":\"1610990896\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2020-10-10T15:12:41.000Z",
+              "expires": "2021-02-17T17:33:16.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "8b76ef9c-fdf2-4a40-b6e0-55b6b3bb18bb"
+              "value": "66a8798f-55e5-4327-b2e5-e0f0a5c9bfb4"
             },
             {
               "name": "x-ms-request-id",
-              "value": "cda96b49-e47d-4b54-912b-358e24811d00"
+              "value": "2fe77cf3-2552-41f6-a519-a83ecbde5f00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11021.14 - WUS2 ProdSlices"
+              "value": "2.1.11397.13 - CHI ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Sep 2020 15:12:40 GMT"
+              "value": "Mon, 18 Jan 2021 17:33:16 GMT"
             },
             {
               "name": "connection",
@@ -177,14 +177,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 783,
+          "headersSize": 782,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-09-10T15:12:40.769Z",
-        "time": 681,
+        "startedDateTime": "2021-01-18T17:33:15.943Z",
+        "time": 411,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 681
+          "wait": 411
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5fa628ed-eaf1-40b0-a5d5-eca17d5443b5"
+              "value": "2d7b2061-092c-4d1f-b4c9-193b52aebd43"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 355,
+          "bodySize": 336,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 355,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"FreeTrial_2014-09-01\",\"spendingLimit\":\"On\"}}]}"
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "631d7220-9621-4cbc-9c68-0b20f6febdb5"
+              "value": "ddf408df-ce0e-4109-ad9e-279559088022"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "631d7220-9621-4cbc-9c68-0b20f6febdb5"
+              "value": "ddf408df-ce0e-4109-ad9e-279559088022"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20200910T151241Z:631d7220-9621-4cbc-9c68-0b20f6febdb5"
+              "value": "WESTCENTRALUS:20210118T173316Z:ddf408df-ce0e-4109-ad9e-279559088022"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Sep 2020 15:12:41 GMT"
+              "value": "Mon, 18 Jan 2021 17:33:16 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "355"
+              "value": "336"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 588,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-09-10T15:12:41.481Z",
-        "time": 300,
+        "startedDateTime": "2021-01-18T17:33:16.387Z",
+        "time": 275,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,11 +345,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 300
+          "wait": 275
         }
       },
       {
-        "_id": "3c8facecec869b975ba799366056ecd9",
+        "_id": "af15d9b4f9f0f6bc59aae7a83d9a9058",
         "_order": 0,
         "cache": {},
         "request": {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "bd4d71fc-4ec3-4286-aacb-ab27569dfc46"
+              "value": "52110d04-9615-4b05-9455-f6e2a97826dd"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-19.5.0)"
+              "value": "@azure/arm-containerregistry/8.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1828,
+          "headersSize": 1829,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -415,14 +415,14 @@
               "value": "2019-12-01-preview"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.ContainerRegistry/registries?api-version=2019-12-01-preview"
+          "url": "https://management.azure.com/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/providers/Microsoft.ContainerRegistry/registries?api-version=2019-12-01-preview"
         },
         "response": {
-          "bodySize": 1403,
+          "bodySize": 1451,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1403,
-            "text": "{\"value\":[{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"type\":\"Microsoft.ContainerRegistry/registries\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"createdByType\":\"Application\",\"createdAt\":\"2020-09-10T14:52:11.2991507+00:00\",\"lastModifiedBy\":\"d2c4cc5a-4ace-480c-aeff-2c97326511ba\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2020-09-10T14:52:11.2991507+00:00\"},\"properties\":{\"loginServer\":\"ndowmon1j1dev.azurecr.io\",\"creationDate\":\"2020-09-10T14:52:11.2991507Z\",\"provisioningState\":\"Succeeded\",\"adminUserEnabled\":false,\"policies\":{\"quarantinePolicy\":{\"status\":\"disabled\"},\"trustPolicy\":{\"type\":\"Notary\",\"status\":\"disabled\"},\"retentionPolicy\":{\"days\":7,\"lastUpdatedTime\":\"2020-09-10T14:52:12.3914099+00:00\",\"status\":\"disabled\"}},\"encryption\":{\"status\":\"disabled\"},\"dataEndpointEnabled\":false,\"dataEndpointHostNames\":[],\"privateEndpointConnections\":[],\"publicNetworkAccess\":\"Enabled\"}}]}"
+            "size": 1451,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Basic\",\"tier\":\"Basic\"},\"type\":\"Microsoft.ContainerRegistry/registries\",\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/keionnedj1dev\",\"name\":\"keionnedj1dev\",\"location\":\"eastus\",\"tags\":{},\"systemData\":{\"createdBy\":\"14f9c435-7684-4ce6-a621-260aff889cc7\",\"createdByType\":\"Application\",\"createdAt\":\"2021-01-18T17:28:27.3874171+00:00\",\"lastModifiedBy\":\"14f9c435-7684-4ce6-a621-260aff889cc7\",\"lastModifiedByType\":\"Application\",\"lastModifiedAt\":\"2021-01-18T17:28:27.3874171+00:00\"},\"properties\":{\"loginServer\":\"keionnedj1dev.azurecr.io\",\"creationDate\":\"2021-01-18T17:28:27.3874171Z\",\"provisioningState\":\"Succeeded\",\"adminUserEnabled\":false,\"policies\":{\"quarantinePolicy\":{\"status\":\"disabled\"},\"trustPolicy\":{\"type\":\"Notary\",\"status\":\"disabled\"},\"retentionPolicy\":{\"days\":7,\"lastUpdatedTime\":\"2021-01-18T17:28:28.3483315+00:00\",\"status\":\"disabled\"}},\"encryption\":{\"status\":\"disabled\"},\"dataEndpointEnabled\":false,\"dataEndpointHostNames\":[],\"privateEndpointConnections\":[],\"publicNetworkAccess\":\"Enabled\",\"networkRuleBypassOptions\":\"AzureServices\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -460,15 +460,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "436f7092-6bbd-4201-86dd-021ff7e4ce22"
+              "value": "de8f4581-3bcb-4b0a-845d-61a4953c618a"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "436f7092-6bbd-4201-86dd-021ff7e4ce22"
+              "value": "de8f4581-3bcb-4b0a-845d-61a4953c618a"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20200910T151242Z:436f7092-6bbd-4201-86dd-021ff7e4ce22"
+              "value": "WESTCENTRALUS:20210118T173317Z:de8f4581-3bcb-4b0a-845d-61a4953c618a"
             },
             {
               "name": "x-content-type-options",
@@ -476,21 +476,21 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Sep 2020 15:12:41 GMT"
+              "value": "Mon, 18 Jan 2021 17:33:17 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 628,
+          "headersSize": 632,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-09-10T15:12:41.794Z",
-        "time": 497,
+        "startedDateTime": "2021-01-18T17:33:16.678Z",
+        "time": 650,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -498,7 +498,501 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 497
+          "wait": 650
+        }
+      },
+      {
+        "_id": "3440be136d06dd892a0cafcdd940df38",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "d20412b6-add4-4782-90cf-9b6dbe31d16e"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/bcd90474-9b62-4040-9d7b-8af257b1427d/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1610994797\",\"not_before\":\"1610990897\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-02-17T17:33:17.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "d20412b6-add4-4782-90cf-9b6dbe31d16e"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e6c8ffd5-acee-45d4-b95e-8dac94a56a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11397.13 - CHI ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 18 Jan 2021 17:33:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 782,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-01-18T17:33:17.344Z",
+        "time": 365,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 365
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "72bd5bcb-8888-48bf-9194-408205454382"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 336,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 336,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"40474ebe-55a2-4071-8fa8-b610acdd8e56\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "64c39883-3c0d-4ccb-ae04-c1c1c7acf1c1"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "64c39883-3c0d-4ccb-ae04-c1c1c7acf1c1"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20210118T173318Z:64c39883-3c0d-4ccb-ae04-c1c1c7acf1c1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 18 Jan 2021 17:33:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "336"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-01-18T17:33:17.712Z",
+        "time": 231,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 231
+        }
+      },
+      {
+        "_id": "e8d673e78ca0e3227083c1c810a7833c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c57b7666-abf0-432b-b5fa-7945d79db387"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1903,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2017-05-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com//subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/keionnedj1dev/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+        },
+        "response": {
+          "bodySize": 1085,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1085,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/keionnedj1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set\",\"type\":\"Microsoft.Insights/diagnosticSettings\",\"name\":\"j1dev_cont_reg_diag_set\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/40474ebe-55a2-4071-8fa8-b610acdd8e56/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev\",\"serviceBusRuleId\":null,\"workspaceId\":null,\"eventHubAuthorizationRuleId\":null,\"eventHubName\":null,\"metrics\":[],\"logs\":[{\"category\":\"ContainerRegistryLoginEvents\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logAnalyticsDestinationType\":null},\"identity\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "13eaf0b4-c8b2-4b21-bac9-5769ffa066e2"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "7de6d5e9-c45f-41ab-b30d-0119b5ffa776"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "WESTCENTRALUS:20210118T173318Z:7de6d5e9-c45f-41ab-b30d-0119b5ffa776"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 18 Jan 2021 17:33:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-01-18T17:33:17.958Z",
+        "time": 702,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 702
         }
       }
     ],

--- a/src/steps/resource-manager/container-registry/index.test.ts
+++ b/src/steps/resource-manager/container-registry/index.test.ts
@@ -1,116 +1,230 @@
 import { fetchContainerRegistries, fetchContainerRegistryWebhooks } from '.';
-import { Recording } from '@jupiterone/integration-sdk-testing';
+import {
+  MockIntegrationStepExecutionContext,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ContainerRegistryEntities } from './constants';
+import { MonitorEntities } from '../monitor/constants';
+
 let recording: Recording;
+let instanceConfig: IntegrationConfig;
+let context: MockIntegrationStepExecutionContext<IntegrationConfig>;
 
-afterEach(async () => {
-  if (recording) {
-    await recording.stop();
-  }
+describe('step - container registries', () => {
+  beforeAll(async () => {
+    instanceConfig = {
+      clientId: process.env.CLIENT_ID || 'clientId',
+      clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+      directoryId: 'bcd90474-9b62-4040-9d7b-8af257b1427d',
+      subscriptionId: '40474ebe-55a2-4071-8fa8-b610acdd8e56',
+      developerId: 'keionned',
+    };
+
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'resource-manager-step-container-registries',
+    });
+
+    context = createMockAzureStepExecutionContext({
+      instanceConfig,
+      entities: [
+        {
+          _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+          _type: 'azure_resource_group',
+          _class: ['Group'],
+        },
+      ],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
+      },
+    });
+
+    await fetchContainerRegistries(context);
+  });
+
+  afterAll(async () => {
+    if (recording) {
+      await recording.stop();
+    }
+  });
+
+  it('should collect an Azure Container Registry entity', () => {
+    const { collectedEntities } = context.jobState;
+
+    expect(collectedEntities).toContainEqual(
+      expect.objectContaining({
+        id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        _class: ContainerRegistryEntities.REGISTRY._class,
+        _type: ContainerRegistryEntities.REGISTRY._type,
+        adminUserEnabled: false,
+        classification: null,
+        dataEndpointEnabled: false,
+        displayName: `${instanceConfig.developerId}j1dev`,
+        encrypted: false,
+        location: 'eastus',
+        loginServer: `${instanceConfig.developerId}j1dev.azurecr.io`,
+        name: `${instanceConfig.developerId}j1dev`,
+        provisioningState: 'Succeeded',
+        publicNetworkAccess: 'Enabled',
+        type: 'Microsoft.ContainerRegistry/registries',
+        webLink: `https://portal.azure.com/#@www.fake-domain.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+      }),
+    );
+  });
+
+  it('should collect an Azure Diagnostic Log Settings entity', () => {
+    const { collectedEntities } = context.jobState;
+
+    expect(collectedEntities).toContainEqual(
+      expect.objectContaining({
+        id: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true`,
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true`,
+        _class: MonitorEntities.DIAGNOSTIC_LOG_SETTING._class,
+        _type: MonitorEntities.DIAGNOSTIC_LOG_SETTING._type,
+        category: 'ContainerRegistryLoginEvents',
+        displayName: 'j1dev_cont_reg_diag_set',
+        enabled: true,
+        eventHubAuthorizationRuleId: null,
+        eventHubName: null,
+        logAnalyticsDestinationType: null,
+        name: 'j1dev_cont_reg_diag_set',
+        'retentionPolicy.days': 1,
+        'retentionPolicy.enabled': true,
+        serviceBusRuleId: null,
+        storageAccountId: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+        webLink: `https://portal.azure.com/#@www.fake-domain.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set`,
+        workspaceId: null,
+      }),
+    );
+  });
+
+  it('should collect an Azure Resource Group has Azure Container Registry relationship', () => {
+    const { collectedRelationships } = context.jobState;
+
+    expect(collectedRelationships).toContainEqual(
+      expect.objectContaining({
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        _type: 'azure_resource_group_has_container_registry',
+        _class: 'HAS',
+        _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
+        _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        displayName: 'HAS',
+      }),
+    );
+  });
+
+  it('should collect an Azure Container Registry has Azure Diagnostic Log Setting relationship', () => {
+    const { collectedRelationships } = context.jobState;
+
+    expect(collectedRelationships).toContainEqual(
+      expect.objectContaining({
+        _class: 'HAS',
+        _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true`,
+        _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true`,
+        _type: 'azure_resource_has_diagnostic_log_setting',
+        displayName: 'HAS',
+      }),
+    );
+  });
+
+  it('should collect an Azure Diagnostic Log Setting uses Azure Storage Account relationship', () => {
+    const { collectedRelationships } = context.jobState;
+
+    expect(collectedRelationships).toContainEqual(
+      expect.objectContaining({
+        _class: 'USES',
+        _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true`,
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourcegroups/j1dev/providers/microsoft.containerregistry/registries/${instanceConfig.developerId}j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_cont_reg_diag_set/logs/ContainerRegistryLoginEvents/true/1/true|uses|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+        _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/${instanceConfig.developerId}j1dev`,
+        _type: 'azure_diagnostic_log_setting_uses_storage_account',
+        displayName: 'USES',
+      }),
+    );
+  });
 });
 
-test('step - container registries', async () => {
-  const instanceConfig: IntegrationConfig = {
-    clientId: process.env.CLIENT_ID || 'clientId',
-    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
-    directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
-    subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
-  };
+describe('step - container registry webhooks', () => {
+  beforeAll(async () => {
+    instanceConfig = {
+      clientId: process.env.CLIENT_ID || 'clientId',
+      clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
+      directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
+      subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
+      developerId: 'ndowmon1',
+    };
 
-  recording = setupAzureRecording({
-    directory: __dirname,
-    name: 'resource-manager-step-container-registries',
-  });
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'resource-manager-step-container-registry-webhooks',
+    });
 
-  const context = createMockAzureStepExecutionContext({
-    instanceConfig,
-    entities: [
-      {
-        _key:
-          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev',
-        _type: 'azure_resource_group',
-        _class: ['Group'],
+    context = createMockAzureStepExecutionContext({
+      instanceConfig,
+      entities: [
+        {
+          _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+          _type: 'azure_container_registry',
+          _class: ['DataStore'],
+          id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+          name: 'ndowmon1j1dev',
+        },
+      ],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
       },
-    ],
-    setData: {
-      [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
-    },
+    });
+
+    await fetchContainerRegistryWebhooks(context);
   });
 
-  await fetchContainerRegistries(context);
-
-  expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
-  expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
-    _class: 'DataStore',
+  afterAll(async () => {
+    if (recording) {
+      await recording.stop();
+    }
   });
 
-  expect(context.jobState.collectedRelationships).toEqual([
-    {
-      _key:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev|has|/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
-      _type: 'azure_resource_group_has_container_registry',
-      _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev',
-      _toEntityKey:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
-      displayName: 'HAS',
-    },
-  ]);
-});
+  it('should collect an Azure Container Registry Webhook entity', () => {
+    const { collectedEntities } = context.jobState;
 
-test('step - container registry webhooks', async () => {
-  const instanceConfig: IntegrationConfig = {
-    clientId: process.env.CLIENT_ID || 'clientId',
-    clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
-    directoryId: '992d7bbe-b367-459c-a10f-cf3fd16103ab',
-    subscriptionId: 'd3803fd6-2ba4-4286-80aa-f3d613ad59a7',
-  };
-
-  recording = setupAzureRecording({
-    directory: __dirname,
-    name: 'resource-manager-step-container-registry-webhooks',
+    expect(collectedEntities).toContainEqual(
+      expect.objectContaining({
+        id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev/webhooks/j1dev`,
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev/webhooks/j1dev`,
+        _class: ContainerRegistryEntities.WEBHOOK._class,
+        _type: ContainerRegistryEntities.WEBHOOK._type,
+        actions: ['push'],
+        active: true,
+        address: 'NOT_RETURNED_FROM_AZURE_API',
+        displayName: 'j1dev',
+        location: 'eastus',
+        name: 'j1dev',
+        provisioningState: 'Succeeded',
+        scope: '',
+        status: 'enabled',
+        type: 'Microsoft.ContainerRegistry/registries/webhooks',
+        webLink: `https://portal.azure.com/#@www.fake-domain.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev/webhooks/j1dev`,
+      }),
+    );
   });
 
-  const context = createMockAzureStepExecutionContext({
-    instanceConfig,
-    entities: [
-      {
-        _key:
-          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
-        _type: 'azure_container_registry',
-        _class: ['DataStore'],
-        id:
-          '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
-        name: 'ndowmon1j1dev',
-      },
-    ],
-    setData: {
-      [ACCOUNT_ENTITY_TYPE]: { defaultDomain: 'www.fake-domain.com' },
-    },
+  it('should collect an Azure Container Registry has Azure Container Registry Webhook relationship', () => {
+    const { collectedRelationships } = context.jobState;
+
+    expect(collectedRelationships).toContainEqual(
+      expect.objectContaining({
+        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev/webhooks/j1dev`,
+        _type: 'azure_container_registry_has_webhook',
+        _class: 'HAS',
+        _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev`,
+        _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/${instanceConfig.developerId}j1dev/webhooks/j1dev`,
+        displayName: 'HAS',
+      }),
+    );
   });
-
-  await fetchContainerRegistryWebhooks(context);
-
-  expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
-  expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
-    _class: 'ApplicationEndpoint',
-  });
-
-  expect(context.jobState.collectedRelationships).toEqual([
-    {
-      _key:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev|has|/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev',
-      _type: 'azure_container_registry_has_webhook',
-      _class: 'HAS',
-      _fromEntityKey:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev',
-      _toEntityKey:
-        '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.ContainerRegistry/registries/ndowmon1j1dev/webhooks/j1dev',
-      displayName: 'HAS',
-    },
-  ]);
 });

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -22,6 +22,11 @@ import {
 } from './converters';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
+import {
+  createDiagnosticSettingsEntitiesAndRelationshipsForResource,
+  diagnosticSettingsEntitiesForResource,
+  diagnosticSettingsRelationshipsForResource,
+} from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 export * from './constants';
 
 export async function fetchContainerRegistries(
@@ -41,6 +46,11 @@ export async function fetchContainerRegistries(
     await jobState.addEntity(registryEntity);
 
     await createResourceGroupResourceRelationship(
+      executionContext,
+      registryEntity,
+    );
+
+    await createDiagnosticSettingsEntitiesAndRelationshipsForResource(
       executionContext,
       registryEntity,
     );
@@ -90,8 +100,14 @@ export const containerRegistrySteps: Step<
   {
     id: STEP_RM_CONTAINER_REGISTRIES,
     name: 'Container Registries',
-    entities: [ContainerRegistryEntities.REGISTRY],
-    relationships: [ContainerRegistryRelationships.RESOURCE_GROUP_HAS_ZONE],
+    entities: [
+      ContainerRegistryEntities.REGISTRY,
+      ...diagnosticSettingsEntitiesForResource,
+    ],
+    relationships: [
+      ContainerRegistryRelationships.RESOURCE_GROUP_HAS_ZONE,
+      ...diagnosticSettingsRelationshipsForResource,
+    ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchContainerRegistries,
   },

--- a/terraform/container-registry.tf
+++ b/terraform/container-registry.tf
@@ -20,6 +20,22 @@ resource "azurerm_container_registry" "j1dev" {
   sku                 = "Basic"
 }
 
+resource "azurerm_monitor_diagnostic_setting" "j1dev_cont_reg_diag_set" {
+  name               = "j1dev_cont_reg_diag_set"
+  target_resource_id = azurerm_container_registry.j1dev[0].id
+  storage_account_id = azurerm_storage_account.j1dev.id
+
+  log {
+    category = "ContainerRegistryLoginEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+}
+
 resource "azurerm_container_registry_webhook" "j1dev" {
   count               = local.container_registry_resource_count
   name                = "j1dev"


### PR DESCRIPTION
# Acceptance Criteria
- Ingest [Azure Monitor Diagnostic Settings](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings)
    - Diagnostic Settings are the new way to send platform logs, including the Azure Activity Log and resource logs, and metrics to different destinations. It should not be used in tandem with Log Profile. Each Azure resource has its own diagnostic settings. These settings define the categories or types of metrics and logs that should be sent somewhere, and one or more destinations to send the logs and metrics. Currently, you can send metrics and logs to Log Analytics workspace, Event Hubs, and Azure Storage. 

-  5.3 Ensure that Diagnostic Logs are enabled for all services which support it. (Automated)
    - Unlike diagnostic logs that capture activity for the subscription level (Activity Log), there are also logs for actions taken on specific resources. This benchmark aims to ensure that resource-level diagnostic logs provide insight into operations that were performed within that resource itself. 

    - There are 76 different Azure resources that support diagnostic logging. Container Registries are one of those 76 Azure resources.
   
# What Changed?
- Collected the **Diagnostic Settings** entities and relationships for an Azure **Container Registry**
    - **Azure Diagnostic Log Setting** entity
    - **Azure Diagnostic Metric Setting** entity
    - **Azure Resource** has **Azure Diagnostic Log Setting** relationship
    - **Azure Resource** has **Azure Diagnostic Metric Setting** relationship
    - **Azure Diagnostic Log Setting** uses **Azure Storage Account** relationship
    - **Azure Diagnostic Metric Setting** uses **Azure Storage Account** relationship
    
# Graph
<img width="1629" alt="Screen Shot 2021-01-18 at 11 03 29 AM" src="https://user-images.githubusercontent.com/6044786/104950173-6f6b0200-597d-11eb-877e-75244fe09156.png">