### PR TITLE
Add log category documentation to diagnostic settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ and this project adheres to
 
 ### Added
 
-- Added `azure_diagnostic_setting` entity, including the following properties:
-  - `log.Administrative.enabled`
-  - `log.Alert.enabled`
-  - `log.Policy.enabled`
-  - `log.Security.enabled`
-  - `log.AuditEvent.enabled`
-  - `log.AuditEvent.retentionPolicy.enabled`
-  - `log.AuditEvent.retentionPolicy.enabled`
+- Added the following log categories to `azure_diagnostic_settings` for
+  `azure_subscription` entities:
+  - `log.Administrative`
+  - `log.Alert`
+  - `log.Policy`
+  - `log.Security`
+- Added the following log categories to `azure_diagnostic_settings` for
+  `azure_keyvault_service` entities:
+  - `log.AuditEvent`
 - Added `./tools/cli/j1-azure-integration document-diagnostic-settings` command
   to automatcially document which Azure resources currently ingest diagnostic
   settings.

--- a/cli/commands/documentDiagnosticSettings.ts
+++ b/cli/commands/documentDiagnosticSettings.ts
@@ -111,19 +111,34 @@ function getDefaultDocumentationFilePath(
 function generateDiagnosticSettingsDocumentationFromMetadata(
   diagnosticSettingsRelationshipMetadata: (StepRelationshipMetadata & {
     resourceType?: string;
+    logCategories?: string[];
   })[],
 ): string {
-  const entityTypesWithDiagnosticSettings: string[] = [];
+  const diagnosticSettingsMetadata: {
+    resourceType: string;
+    logCategories: string[] | undefined;
+  }[] = [];
 
   for (const relationshipMetadata of diagnosticSettingsRelationshipMetadata) {
     if (relationshipMetadata.resourceType) {
-      entityTypesWithDiagnosticSettings.push(relationshipMetadata.resourceType);
+      diagnosticSettingsMetadata.push({
+        resourceType: relationshipMetadata.resourceType,
+        logCategories: relationshipMetadata.logCategories,
+      });
     }
   }
 
   let diagnosticSettingsListSection = '';
-  for (const entityType of entityTypesWithDiagnosticSettings.sort()) {
-    diagnosticSettingsListSection += `- ${entityType}\n`;
+  for (const metadata of diagnosticSettingsMetadata.sort((a, b) =>
+    a.resourceType > b.resourceType ? 1 : -1,
+  )) {
+    diagnosticSettingsListSection += `- ${metadata.resourceType}\n`;
+    if (metadata.logCategories) {
+      diagnosticSettingsListSection += `  - Log Categories:\n`;
+      for (const category of metadata.logCategories) {
+        diagnosticSettingsListSection += `    - ${category}\n`;
+      }
+    }
   }
 
   return `${J1_DOCUMENTATION_DIAGNOSTIC_SETTINGS_MARKER_START}

--- a/cli/commands/documentDiagnosticSettings.ts
+++ b/cli/commands/documentDiagnosticSettings.ts
@@ -129,8 +129,8 @@ function generateDiagnosticSettingsDocumentationFromMetadata(
   }
 
   let diagnosticSettingsListSection = '';
-  for (const metadata of diagnosticSettingsMetadata.sort((a, b) =>
-    a.resourceType > b.resourceType ? 1 : -1,
+  for (const metadata of sortDiagnosticSettingsMetadata(
+    diagnosticSettingsMetadata,
   )) {
     diagnosticSettingsListSection += `- ${metadata.resourceType}\n`;
     if (metadata.logCategories) {
@@ -165,6 +165,17 @@ END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
 ********************************************************************************
 -->
 ${J1_DOCUMENTATION_DIAGNOSTIC_SETTINGS_MARKER_END}`;
+}
+
+function sortDiagnosticSettingsMetadata(
+  diagnosticSettingsMetadata: {
+    resourceType: string;
+    logCategories?: string[];
+  }[],
+) {
+  return diagnosticSettingsMetadata.sort((a, b) =>
+    a.resourceType > b.resourceType ? 1 : -1,
+  );
 }
 
 function replaceBetweenDocumentMarkers(

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -322,6 +322,8 @@ following entities:
 - azure_event_grid_domain
 - azure_event_grid_topic
 - azure_keyvault_service
+  - Log Categories:
+    - AuditEvent
 - azure_lb
 - azure_mariadb_server
 - azure_mysql_server
@@ -331,6 +333,11 @@ following entities:
 - azure_security_group
 - azure_sql_server
 - azure_subscription
+  - Log Categories:
+    - Administrative
+    - Alert
+    - Policy
+    - Security
 - azure_vnet
 
 <!--

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -98,7 +98,7 @@ export const apiManagementSteps: Step<
     relationships: [
       ApiManagementRelationships.RESOURCE_GROUP_HAS_SERVICE,
       ...getDiagnosticSettingsRelationshipsForResource(
-        ApiManagementEntities.SERVICE._type,
+        ApiManagementEntities.SERVICE,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -199,7 +199,7 @@ export const batchSteps: Step<
     relationships: [
       BatchAccountRelationships.RESOURCE_GROUP_HAS_BATCH_ACCOUNT,
       ...getDiagnosticSettingsRelationshipsForResource(
-        BatchEntities.BATCH_ACCOUNT._type,
+        BatchEntities.BATCH_ACCOUNT,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -96,9 +96,7 @@ export const cdnSteps: Step<
     entities: [CdnEntities.PROFILE, ...diagnosticSettingsEntitiesForResource],
     relationships: [
       CdnRelationships.RESOURCE_GROUP_HAS_PROFILE,
-      ...getDiagnosticSettingsRelationshipsForResource(
-        CdnEntities.PROFILE._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(CdnEntities.PROFILE),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchProfiles,
@@ -109,9 +107,7 @@ export const cdnSteps: Step<
     entities: [CdnEntities.ENDPOINT, ...diagnosticSettingsEntitiesForResource],
     relationships: [
       CdnRelationships.PROFILE_HAS_ENDPOINT,
-      ...getDiagnosticSettingsRelationshipsForResource(
-        CdnEntities.ENDPOINT._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(CdnEntities.ENDPOINT),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CDN_PROFILE],
     executionHandler: fetchEndpoints,

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -104,7 +104,7 @@ export const containerRegistrySteps: Step<
     relationships: [
       ContainerRegistryRelationships.RESOURCE_GROUP_HAS_ZONE,
       ...getDiagnosticSettingsRelationshipsForResource(
-        ContainerRegistryEntities.REGISTRY._type,
+        ContainerRegistryEntities.REGISTRY,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -42,9 +42,7 @@ export const databaseSteps: Step<
     relationships: [
       MariaDBRelationships.RESOURCE_GROUP_HAS_MARIADB_SERVER,
       MariaDBRelationships.MARIADB_SERVER_HAS_MARIADB_DATABASE,
-      ...getDiagnosticSettingsRelationshipsForResource(
-        MariaDBEntities.SERVER._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(MariaDBEntities.SERVER),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMariaDBDatabases,
@@ -60,9 +58,7 @@ export const databaseSteps: Step<
     relationships: [
       MySQLRelationships.RESOURCE_GROUP_HAS_MYSQL_SERVER,
       MySQLRelationships.MYSQL_SERVER_HAS_MYSQL_DATABASE,
-      ...getDiagnosticSettingsRelationshipsForResource(
-        MySQLEntities.SERVER._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(MySQLEntities.SERVER),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMySQLDatabases,

--- a/src/steps/resource-manager/databases/postgresql/index.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.ts
@@ -142,7 +142,7 @@ export const postgreSqlSteps: Step<
     relationships: [
       PostgreSQLRelationships.RESOURCE_GROUP_HAS_POSTGRESQL_SERVER,
       ...getDiagnosticSettingsRelationshipsForResource(
-        PostgreSQLEntities.SERVER._type,
+        PostgreSQLEntities.SERVER,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],

--- a/src/steps/resource-manager/databases/sql/index.ts
+++ b/src/steps/resource-manager/databases/sql/index.ts
@@ -212,7 +212,7 @@ export const sqlSteps: Step<
     name: 'SQL Server Diagnostic Settings',
     entities: [...diagnosticSettingsEntitiesForResource],
     relationships: [
-      ...getDiagnosticSettingsRelationshipsForResource(entities.SERVER._type),
+      ...getDiagnosticSettingsRelationshipsForResource(entities.SERVER),
     ],
     dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS],
     executionHandler: fetchSQLServerDiagnosticSettings,

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -241,7 +241,7 @@ export const eventGridSteps: Step<
     relationships: [
       EventGridRelationships.RESOURCE_GROUP_HAS_DOMAIN,
       ...getDiagnosticSettingsRelationshipsForResource(
-        EventGridEntities.DOMAIN._type,
+        EventGridEntities.DOMAIN,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
@@ -281,9 +281,7 @@ export const eventGridSteps: Step<
     ],
     relationships: [
       EventGridRelationships.RESOURCE_GROUP_HAS_TOPIC,
-      ...getDiagnosticSettingsRelationshipsForResource(
-        EventGridEntities.TOPIC._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(EventGridEntities.TOPIC),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridTopics,

--- a/src/steps/resource-manager/key-vault/constants.ts
+++ b/src/steps/resource-manager/key-vault/constants.ts
@@ -12,6 +12,15 @@ export const STEP_RM_KEYVAULT_VAULTS = 'rm-keyvault-vaults';
 export const KEY_VAULT_SERVICE_ENTITY_TYPE = 'azure_keyvault_service';
 export const KEY_VAULT_SERVICE_ENTITY_CLASS = ['Service'];
 
+export const entities = {
+  KEY_VAULT: {
+    _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
+    _class: KEY_VAULT_SERVICE_ENTITY_CLASS,
+    resourceName: '[RM] Key Vault',
+    diagnosticLogCategories: ['AuditEvent'],
+  },
+};
+
 export const ACCOUNT_KEY_VAULT_RELATIONSHIP_CLASS = RelationshipClass.HAS;
 export const ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE = generateRelationshipType(
   ACCOUNT_KEY_VAULT_RELATIONSHIP_CLASS,

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -16,8 +16,8 @@ import {
   ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE,
   KEY_VAULT_SERVICE_ENTITY_TYPE,
   STEP_RM_KEYVAULT_VAULTS,
-  KEY_VAULT_SERVICE_ENTITY_CLASS,
   ACCOUNT_KEY_VAULT_RELATIONSHIP_CLASS,
+  entities,
 } from './constants';
 import { createKeyVaultEntity } from './converters';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
@@ -59,6 +59,7 @@ export async function fetchKeyVaults(
     await createDiagnosticSettingsEntitiesAndRelationshipsForResource(
       executionContext,
       vaultEntity,
+      entities.KEY_VAULT,
     );
   });
 }
@@ -69,14 +70,7 @@ export const keyvaultSteps: Step<
   {
     id: STEP_RM_KEYVAULT_VAULTS,
     name: 'Key Vaults',
-    entities: [
-      {
-        resourceName: '[RM] Key Vault',
-        _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
-        _class: KEY_VAULT_SERVICE_ENTITY_CLASS,
-      },
-      ...diagnosticSettingsEntitiesForResource,
-    ],
+    entities: [entities.KEY_VAULT, ...diagnosticSettingsEntitiesForResource],
     relationships: [
       {
         _type: ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE,
@@ -87,9 +81,7 @@ export const keyvaultSteps: Step<
       createResourceGroupResourceRelationshipMetadata(
         KEY_VAULT_SERVICE_ENTITY_TYPE,
       ),
-      ...getDiagnosticSettingsRelationshipsForResource(
-        KEY_VAULT_SERVICE_ENTITY_TYPE,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(entities.KEY_VAULT),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchKeyVaults,

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -574,7 +574,7 @@ export const networkSteps: Step<
     relationships: [
       NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_PUBLIC_IP_ADDRESS,
       ...getDiagnosticSettingsRelationshipsForResource(
-        NetworkEntities.PUBLIC_IP_ADDRESS._type,
+        NetworkEntities.PUBLIC_IP_ADDRESS,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
@@ -607,7 +607,7 @@ export const networkSteps: Step<
       NetworkRelationships.NETWORK_VIRTUAL_NETWORK_CONTAINS_NETWORK_SUBNET,
       NetworkRelationships.NETWORK_SECURITY_GROUP_PROTECTS_NETWORK_SUBNET,
       ...getDiagnosticSettingsRelationshipsForResource(
-        NetworkEntities.VIRTUAL_NETWORK._type,
+        NetworkEntities.VIRTUAL_NETWORK,
       ),
     ],
     dependsOn: [
@@ -628,7 +628,7 @@ export const networkSteps: Step<
       NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_SECURITY_GROUP,
       NetworkRelationships.NETWORK_SECURITY_GROUP_PROTECTS_NETWORK_INTERFACE,
       ...getDiagnosticSettingsRelationshipsForResource(
-        NetworkEntities.SECURITY_GROUP._type,
+        NetworkEntities.SECURITY_GROUP,
       ),
     ],
     // SECURITY_GROUP_RULE_RELATIONSHIP_TYPE doesn't seem to exist here.
@@ -650,7 +650,7 @@ export const networkSteps: Step<
       NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_LOAD_BALANCER,
       NetworkRelationships.NETWORK_LOAD_BALANCER_CONNECTS_NETWORK_INTERFACE,
       ...getDiagnosticSettingsRelationshipsForResource(
-        NetworkEntities.LOAD_BALANCER._type,
+        NetworkEntities.LOAD_BALANCER,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
@@ -666,7 +666,7 @@ export const networkSteps: Step<
     relationships: [
       NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_AZURE_FIREWALL,
       ...getDiagnosticSettingsRelationshipsForResource(
-        NetworkEntities.AZURE_FIREWALL._type,
+        NetworkEntities.AZURE_FIREWALL,
       ),
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],

--- a/src/steps/resource-manager/subscriptions/constants.ts
+++ b/src/steps/resource-manager/subscriptions/constants.ts
@@ -18,6 +18,7 @@ export const entities = {
     _type: 'azure_subscription',
     _class: ['Account'],
     resourceName: '[RM] Subscription',
+    diagnosticLogCategories: ['Administrative', 'Alert', 'Policy', 'Security'],
   },
   LOCATION: {
     _type: 'azure_location',

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -40,6 +40,7 @@ export async function fetchSubscriptions(
     await createDiagnosticSettingsEntitiesAndRelationshipsForResource(
       executionContext,
       subscriptionEntity,
+      entities.SUBSCRIPTION,
     );
   });
 }
@@ -109,9 +110,7 @@ export const subscriptionSteps: Step<
     name: 'Subscriptions',
     entities: [entities.SUBSCRIPTION, ...diagnosticSettingsEntitiesForResource],
     relationships: [
-      ...getDiagnosticSettingsRelationshipsForResource(
-        entities.SUBSCRIPTION._type,
-      ),
+      ...getDiagnosticSettingsRelationshipsForResource(entities.SUBSCRIPTION),
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchSubscriptions,


### PR DESCRIPTION
This does a better job of scoping the diagnostic settings log categories, which are different for each resource.