### PR TITLE
Fix DuplicateKeyError for azure_vm_uses_storage_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `_key` property on `azure_vm_uses_storage_account` to fix
+  `DuplicateKeyError`s when multiple data disks point to the same storage
+  account.
+
 ## 5.21.0 - 2021-04-02
 
 ### Added

--- a/src/steps/resource-manager/compute/index.ts
+++ b/src/steps/resource-manager/compute/index.ts
@@ -6,6 +6,7 @@ import {
   createDirectRelationship,
   RelationshipClass,
   getRawData,
+  generateRelationshipKey,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
@@ -172,6 +173,11 @@ export async function createVirtualMachineDiskRelationships(
         _class: RelationshipClass.USES,
         to: storageAccountEntity,
         properties: {
+          _key: generateRelationshipKey(
+            RelationshipClass.USES,
+            vmEntity,
+            vhdUri,
+          ),
           vhdUri,
           diskType,
         },


### PR DESCRIPTION
```
### Changed

- Changed `_key` property on `azure_vm_uses_storage_account` to fix
  `DuplicateKeyError`s when multiple data disks point to the same storage
  account.
```