### PR TITLE
Handle errors thrown from getBlobServiceProperties()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Changed
 
+- Handle errors thrown from `getBlobServiceProperties()` instead of allowing
+  storage account step to fail.
 - Changed `_key` property on `azure_vm_uses_storage_account` to fix
   `DuplicateKeyError`s when multiple data disks point to the same storage
   account.

--- a/src/steps/resource-manager/storage/client.ts
+++ b/src/steps/resource-manager/storage/client.ts
@@ -24,7 +24,7 @@ export function createStorageAccountServiceClient(options: {
   logger: IntegrationLogger;
   storageAccount: { name: string; kind: Kind };
 }) {
-  const { config, storageAccount } = options;
+  const { config, logger, storageAccount } = options;
   const credential = new ClientSecretCredential(
     config.directoryId,
     config.clientId,
@@ -37,8 +37,18 @@ export function createStorageAccountServiceClient(options: {
         `https://${storageAccount.name}.blob.core.windows.net`,
         credential,
       );
-      const response = await client.getProperties();
-      return response._response.parsedBody;
+      try {
+        const response = await client.getProperties();
+        return response._response.parsedBody;
+      } catch (e) {
+        logger.warn(
+          {
+            storageAccount,
+            e,
+          },
+          'Failed to get blob service properties for storage account',
+        );
+      }
     },
 
     getQueueServiceProperties: async () => {
@@ -47,8 +57,18 @@ export function createStorageAccountServiceClient(options: {
           `https://${storageAccount.name}.queue.core.windows.net`,
           credential,
         );
-        const response = await client.getProperties();
-        return response._response.parsedBody;
+        try {
+          const response = await client.getProperties();
+          return response._response.parsedBody;
+        } catch (e) {
+          logger.warn(
+            {
+              storageAccount,
+              e,
+            },
+            'Failed to get queue service properties for storage account',
+          );
+        }
       }
     },
   };

--- a/src/steps/resource-manager/storage/converters.ts
+++ b/src/steps/resource-manager/storage/converters.ts
@@ -55,7 +55,7 @@ export function createStorageAccountEntity(
   webLinker: AzureWebLinker,
   data: StorageAccount,
   storageAccountServiceProperties: {
-    blob: BlobServiceProperties;
+    blob?: BlobServiceProperties;
     queue?: QueueServiceProperties;
   },
 ): Entity {
@@ -96,15 +96,15 @@ export function createStorageAccountEntity(
         networkRuleSetDefaultAction: data.networkRuleSet?.defaultAction,
         networkRuleSetBypass: data.networkRuleSet?.bypass,
         blobSoftDeleteEnabled:
-          storageAccountServiceProperties.blob.deleteRetentionPolicy?.enabled,
+          storageAccountServiceProperties.blob?.deleteRetentionPolicy?.enabled,
         blobSoftDeleteRetentionDays:
-          storageAccountServiceProperties.blob.deleteRetentionPolicy?.days,
+          storageAccountServiceProperties.blob?.deleteRetentionPolicy?.days,
         blobAnalyticsLoggingReadEnabled:
-          storageAccountServiceProperties.blob.blobAnalyticsLogging?.read,
+          storageAccountServiceProperties.blob?.blobAnalyticsLogging?.read,
         blobAnalyticsLoggingWriteEnabled:
-          storageAccountServiceProperties.blob.blobAnalyticsLogging?.write,
+          storageAccountServiceProperties.blob?.blobAnalyticsLogging?.write,
         blobAnalyticsLoggingDeleteEnabled:
-          storageAccountServiceProperties.blob.blobAnalyticsLogging
+          storageAccountServiceProperties.blob?.blobAnalyticsLogging
             ?.deleteProperty,
         queueAnalyticsLoggingReadEnabled:
           storageAccountServiceProperties.queue?.queueAnalyticsLogging?.read,


### PR DESCRIPTION
```
### Changed

- Handle errors thrown from `getBlobServiceProperties()` instead of allowing
  storage account step to fail.
```