### PR TITLE
Release 5.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.23.3 - 2021-04-21
+
 ### Changed
 
 - Changed logic for fetching tables/queues/fileShares of `Premium` tier

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.23.2",
+  "version": "5.23.3",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
```
## 5.23.3 - 2021-04-21

### Changed

- Changed logic for fetching tables/queues/fileShares of `Premium` tier
  storageV1/storageV2 `azure_storage_account`s, because only `Standard` tier
  storage accounts support tables/queues/fileShares.
```