### PR TITLE
Add try/catch logic to AzurePolicyClient methods for policy definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Added try/catch logic to `AzurePolicyClient` methods for policy definitions &
+  policy set definitions so step does not fail from 404s.
+
 ## 5.23.3 - 2021-04-21
 
 ### Changed

--- a/src/steps/resource-manager/policy/client.ts
+++ b/src/steps/resource-manager/policy/client.ts
@@ -34,39 +34,81 @@ export class AzurePolicyClient extends Client {
 
   public async getPolicySetDefinition(
     name: string,
-  ): Promise<PolicySetDefinition> {
+  ): Promise<PolicySetDefinition | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    return serviceClient.policySetDefinitions.get(name);
+    try {
+      return await serviceClient.policySetDefinitions.get(name);
+    } catch (err) {
+      this.logger.warn(
+        {
+          name,
+          err,
+        },
+        'Error getting policy set definition by name.',
+      );
+    }
   }
 
   public async getBuiltInPolicySetDefinition(
     name: string,
-  ): Promise<PolicySetDefinition> {
+  ): Promise<PolicySetDefinition | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    return serviceClient.policySetDefinitions.getBuiltIn(name);
+    try {
+      return await serviceClient.policySetDefinitions.getBuiltIn(name);
+    } catch (err) {
+      this.logger.warn(
+        {
+          name,
+          err,
+        },
+        'Error getting built-in policy set definition by name.',
+      );
+    }
   }
 
-  public async getPolicyDefinition(name: string): Promise<PolicyDefinition> {
+  public async getPolicyDefinition(
+    name: string,
+  ): Promise<PolicyDefinition | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    return serviceClient.policyDefinitions.get(name);
+    try {
+      return await serviceClient.policyDefinitions.get(name);
+    } catch (err) {
+      this.logger.warn(
+        {
+          name,
+          err,
+        },
+        'Error getting policy definition by name.',
+      );
+    }
   }
 
   public async getBuiltInPolicyDefinition(
     name: string,
-  ): Promise<PolicyDefinition> {
+  ): Promise<PolicyDefinition | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    return serviceClient.policyDefinitions.getBuiltIn(name);
+    try {
+      return await serviceClient.policyDefinitions.getBuiltIn(name);
+    } catch (err) {
+      this.logger.warn(
+        {
+          name,
+          err,
+        },
+        'Error getting built-in policy definition by name.',
+      );
+    }
   }
 }

--- a/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
+++ b/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
@@ -108,6 +108,8 @@ async function findOrCreatePolicyDefinitionEntity(
         policyDefinitionId,
         name,
       );
+      if (!policyDefinition) return;
+
       return jobState.addEntity(
         createPolicyDefinitionEntity(webLinker, policyDefinition),
       );
@@ -118,6 +120,8 @@ async function findOrCreatePolicyDefinitionEntity(
         policyDefinitionId,
         name,
       );
+      if (!policySetDefinition) return;
+
       const policySetDefinitionEntity = await jobState.addEntity(
         createPolicySetDefinitionEntity(webLinker, policySetDefinition),
       );
@@ -136,7 +140,7 @@ async function getPolicyDefinition(
   client: AzurePolicyClient,
   policyDefinitionId: string,
   name: string,
-): Promise<PolicyDefinition> {
+): Promise<PolicyDefinition | undefined> {
   if (isBuiltInDefinition(policyDefinitionId)) {
     return client.getBuiltInPolicyDefinition(name);
   } else {
@@ -148,7 +152,7 @@ async function getPolicySetDefinition(
   client: AzurePolicyClient,
   policyDefinitionId: string,
   name: string,
-): Promise<PolicySetDefinition> {
+): Promise<PolicySetDefinition | undefined> {
   if (isBuiltInDefinition(policyDefinitionId)) {
     return client.getBuiltInPolicySetDefinition(name);
   } else {

--- a/src/steps/resource-manager/storage/client.ts
+++ b/src/steps/resource-manager/storage/client.ts
@@ -241,12 +241,12 @@ export class StorageClient extends Client {
       logger: this.logger,
       serviceClient,
       resourceEndpoint: {
-        list: async () => {
+        list: async function listFileShares() {
           return serviceClient.fileShares.list(resourceGroup, accountName);
         },
-        listNext: /* istanbul ignore next: testing iteration might be difficult */ async (
+        listNext: /* istanbul ignore next: testing iteration might be difficult */ async function listNextFileShares(
           nextLink: string,
-        ) => {
+        ) {
           return serviceClient.fileShares.listNext(nextLink);
         },
       },


### PR DESCRIPTION
```
### Changed

- Added try/catch logic to `AzurePolicyClient` methods for policy definitions &
  policy set definitions so step does not fail from 404s.
```