### PR TITLE
Add logger.warn to expose policyDefinitionId

### DIFF
--- a/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
+++ b/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
@@ -108,7 +108,16 @@ async function findOrCreatePolicyDefinitionEntity(
         policyDefinitionId,
         name,
       );
-      if (!policyDefinition) return;
+      if (!policyDefinition) {
+        logger.warn(
+          {
+            policyDefinitionId,
+            name,
+          },
+          'Could not find policy definition by policyDefinitionId',
+        );
+        return;
+      }
 
       return jobState.addEntity(
         createPolicyDefinitionEntity(webLinker, policyDefinition),
@@ -120,7 +129,16 @@ async function findOrCreatePolicyDefinitionEntity(
         policyDefinitionId,
         name,
       );
-      if (!policySetDefinition) return;
+      if (!policySetDefinition) {
+        logger.warn(
+          {
+            policyDefinitionId,
+            name,
+          },
+          'Could not find policy set definition by policyDefinitionId',
+        );
+        return;
+      }
 
       const policySetDefinitionEntity = await jobState.addEntity(
         createPolicySetDefinitionEntity(webLinker, policySetDefinition),


### PR DESCRIPTION
When the policy definition is not found because of 404s, it's unclear why. I am wondering whether, for example, we are getting policy definitions with ID like `/SUBSCRIPTIONS/${s-id}/providers/Microsoft.Authorization/policyDefinitions/${pd-id}`. 

