### PR TITLE
Handle policyDefinitionId sourced from management groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added logic to handle `policyDefinition` IDs that are sourced from management
+  groups.
+
 ## 5.23.5 - 2021-04-26
 
 ### Added

--- a/src/steps/resource-manager/policy/client.ts
+++ b/src/steps/resource-manager/policy/client.ts
@@ -34,81 +34,67 @@ export class AzurePolicyClient extends Client {
 
   public async getPolicySetDefinition(
     name: string,
-  ): Promise<PolicySetDefinition | undefined> {
+  ): Promise<PolicySetDefinition> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    try {
-      return await serviceClient.policySetDefinitions.get(name);
-    } catch (err) {
-      this.logger.warn(
-        {
-          name,
-          err,
-        },
-        'Error getting policy set definition by name.',
-      );
-    }
+    return serviceClient.policySetDefinitions.get(name);
   }
 
   public async getBuiltInPolicySetDefinition(
     name: string,
-  ): Promise<PolicySetDefinition | undefined> {
+  ): Promise<PolicySetDefinition> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    try {
-      return await serviceClient.policySetDefinitions.getBuiltIn(name);
-    } catch (err) {
-      this.logger.warn(
-        {
-          name,
-          err,
-        },
-        'Error getting built-in policy set definition by name.',
-      );
-    }
+    return serviceClient.policySetDefinitions.getBuiltIn(name);
   }
 
-  public async getPolicyDefinition(
+  public async getManagementGroupPolicySetDefinition(
     name: string,
-  ): Promise<PolicyDefinition | undefined> {
+    managementGroupId: string,
+  ): Promise<PolicySetDefinition> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    try {
-      return await serviceClient.policyDefinitions.get(name);
-    } catch (err) {
-      this.logger.warn(
-        {
-          name,
-          err,
-        },
-        'Error getting policy definition by name.',
-      );
-    }
+    return serviceClient.policySetDefinitions.getAtManagementGroup(
+      name,
+      managementGroupId,
+    );
+  }
+
+  public async getPolicyDefinition(name: string): Promise<PolicyDefinition> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      PolicyClient,
+    );
+
+    return serviceClient.policyDefinitions.get(name);
   }
 
   public async getBuiltInPolicyDefinition(
     name: string,
-  ): Promise<PolicyDefinition | undefined> {
+  ): Promise<PolicyDefinition> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       PolicyClient,
     );
 
-    try {
-      return await serviceClient.policyDefinitions.getBuiltIn(name);
-    } catch (err) {
-      this.logger.warn(
-        {
-          name,
-          err,
-        },
-        'Error getting built-in policy definition by name.',
-      );
-    }
+    return serviceClient.policyDefinitions.getBuiltIn(name);
+  }
+
+  public async getManagementGroupPolicyDefinition(
+    name: string,
+    managementGroupId: string,
+  ): Promise<PolicyDefinition> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      PolicyClient,
+    );
+
+    return serviceClient.policyDefinitions.getAtManagementGroup(
+      name,
+      managementGroupId,
+    );
   }
 }


### PR DESCRIPTION
```
### Added

- Added logic to handle `policyDefinition` IDs that are sourced from management
  groups.
```

During the original implementation, it wasn't clear that there were management group-based policy definitions, and these were mishandled causing some integrations to fail. Now that these are properly handled, I tore out a good amount of the safety netting and `logger.warn` statements so that this step _does_ fail when the API returns 4xx/5xx responses. See @austinkelleher 's comments in a previous PR https://github.com/JupiterOne/graph-azure/pull/301#pullrequestreview-641402702