### PR TITLE
Release 5.23.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.23.6 - 2021-04-28
+
 ### Added
 
 - Added logic to handle `policyDefinition` IDs that are sourced from management

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.23.5",
+  "version": "5.23.6",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
```
## 5.23.6 - 2021-04-28

### Added

- Added logic to handle `policyDefinition` IDs that are sourced from management
  groups.