### PR TITLE
Ingest app service apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
   | Network     | `azure_private_endpoint` |
   | App Service | `azure_web_app`          |
   | App Service | `azure_function_app`     |
+  | App Service | `azure_app_service_plan` |
 
 - Added support for ingesting the following **new** relationships:
 
@@ -28,6 +29,9 @@ and this project adheres to
   | `azure_private_endpoint` | `CONNECTS` | `ANY_RESOURCE`           |
   | `azure_resource_group`   | `HAS`      | `azure_web_app`          |
   | `azure_resource_group`   | `HAS`      | `azure_function_app`     |
+  | `azure_resource_group`   | `HAS`      | `azure_app_service_plan` |
+  | `azure_web_app`          | `USES`     | `azure_app_service_plan` |
+  | `azure_function_app`     | `USES`     | `azure_app_service_plan` |
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to
 
 - Added support for ingesting the following **new** resources:
 
-  | Service | Resource / Entity        |
-  | ------- | ------------------------ |
-  | Network | `azure_private_endpoint` |
+  | Service     | Resource / Entity        |
+  | ----------- | ------------------------ |
+  | Network     | `azure_private_endpoint` |
+  | App Service | `azure_web_app`          |
+  | App Service | `azure_function_app`     |
 
 - Added support for ingesting the following **new** relationships:
 
@@ -24,6 +26,8 @@ and this project adheres to
   | `azure_subnet`           | `HAS`      | `azure_private_endpoint` |
   | `azure_private_endpoint` | `USES`     | `azure_nic`              |
   | `azure_private_endpoint` | `CONNECTS` | `ANY_RESOURCE`           |
+  | `azure_resource_group`   | `HAS`      | `azure_web_app`          |
+  | `azure_resource_group`   | `HAS`      | `azure_function_app`     |
 
 ### Fixed
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -170,6 +170,7 @@ The following entities are created:
 | [RM] Event Grid Domain Topic                   | `azure_event_grid_domain_topic`                   | `Queue`                            |
 | [RM] Event Grid Topic                          | `azure_event_grid_topic`                          | `Queue`                            |
 | [RM] Event Grid Topic Subscription             | `azure_event_grid_topic_subscription`             | `Subscription`                     |
+| [RM] Function App                              | `azure_function_app`                              | `Function`                         |
 | [RM] Image                                     | `azure_image`                                     | `Image`                            |
 | [RM] Key Vault                                 | `azure_keyvault_service`                          | `Service`                          |
 | [RM] Load Balancer                             | `azure_lb`                                        | `Gateway`                          |
@@ -224,6 +225,7 @@ The following entities are created:
 | [RM] Virtual Machine                           | `azure_vm`                                        | `Host`                             |
 | [RM] Virtual Machine Extension                 | `azure_vm_extension`                              | `Application`                      |
 | [RM] Virtual Network                           | `azure_vnet`                                      | `Network`                          |
+| [RM] Web App                                   | `azure_web_app`                                   | `Application`                      |
 
 ### Relationships
 
@@ -281,6 +283,7 @@ The following relationships are created/mapped:
 | `azure_resource_group`             | **HAS**               | `azure_dns_zone`                                  |
 | `azure_resource_group`             | **HAS**               | `azure_event_grid_domain`                         |
 | `azure_resource_group`             | **HAS**               | `azure_event_grid_topic`                          |
+| `azure_resource_group`             | **HAS**               | `azure_function_app`                              |
 | `azure_resource_group`             | **HAS**               | `azure_image`                                     |
 | `azure_resource_group`             | **HAS**               | `azure_keyvault_service`                          |
 | `azure_resource_group`             | **HAS**               | `azure_lb`                                        |
@@ -302,6 +305,7 @@ The following relationships are created/mapped:
 | `azure_resource_group`             | **HAS**               | `azure_storage_account`                           |
 | `azure_resource_group`             | **HAS**               | `azure_vm`                                        |
 | `azure_resource_group`             | **HAS**               | `azure_vnet`                                      |
+| `azure_resource_group`             | **HAS**               | `azure_web_app`                                   |
 | `ANY_SCOPE`                        | **HAS**               | `azure_diagnostic_setting`                        |
 | `ANY_SCOPE`                        | **HAS**               | `azure_advisor_recommendation`                    |
 | `ANY_SCOPE`                        | **HAS**               | `azure_policy_assignment`                         |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -149,6 +149,7 @@ The following entities are created:
 | [RM] API Management API                        | `azure_api_management_api`                        | `ApplicationEndpoint`              |
 | [RM] API Management Service                    | `azure_api_management_service`                    | `Gateway`                          |
 | [RM] Advisor Recommendation                    | `azure_advisor_recommendation`                    | `Finding`                          |
+| [RM] App Service Plan                          | `azure_app_service_plan`                          | `Configuration`                    |
 | [RM] Azure Managed Disk                        | `azure_managed_disk`                              | `DataStore`, `Disk`                |
 | [RM] Batch Account                             | `azure_batch_account`                             | `Service`                          |
 | [RM] Batch Application                         | `azure_batch_application`                         | `Process`                          |
@@ -254,6 +255,7 @@ The following relationships are created/mapped:
 | `azure_event_grid_domain`          | **HAS**               | `azure_event_grid_domain_topic`                   |
 | `azure_event_grid_domain_topic`    | **HAS**               | `azure_event_grid_topic_subscription`             |
 | `azure_event_grid_topic`           | **HAS**               | `azure_event_grid_topic_subscription`             |
+| `azure_function_app`               | **USES**              | `azure_app_service_plan`                          |
 | `azure_user_group`                 | **HAS**               | `azure_user_group`                                |
 | `azure_user_group`                 | **HAS**               | `azure_group_member`                              |
 | `azure_user_group`                 | **HAS**               | `azure_user`                                      |
@@ -275,6 +277,7 @@ The following relationships are created/mapped:
 | `azure_redis_cache`                | **CONNECTS**          | `azure_redis_cache`                               |
 | `azure_redis_cache`                | **HAS**               | `azure_firewall_rule`                             |
 | `azure_resource_group`             | **HAS**               | `azure_api_management_service`                    |
+| `azure_resource_group`             | **HAS**               | `azure_app_service_plan`                          |
 | `azure_resource_group`             | **HAS**               | `azure_batch_account`                             |
 | `azure_resource_group`             | **HAS**               | `azure_cdn_profile`                               |
 | `azure_resource_group`             | **HAS**               | `azure_container_group`                           |
@@ -366,6 +369,7 @@ The following relationships are created/mapped:
 | `azure_vm`                         | **USES**              | `azure_public_ip`                                 |
 | `azure_vm`                         | **USES**              | `azure_storage_account`                           |
 | `azure_vnet`                       | **CONTAINS**          | `azure_subnet`                                    |
+| `azure_web_app`                    | **USES**              | `azure_app_service_plan`                          |
 
 <!--
 ********************************************************************************

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@azure/arm-advisor": "^2.0.0",
     "@azure/arm-apimanagement": "^6.0.0",
+    "@azure/arm-appservice": "^7.0.0",
     "@azure/arm-authorization": "^8.3.2",
     "@azure/arm-batch": "^4.0.0",
     "@azure/arm-cdn": "^5.0.0",

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -96,6 +96,7 @@ import { AdvisorSteps } from './steps/resource-manager/advisor';
 import { SecuritySteps } from './steps/resource-manager/security/constants';
 import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
+import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {
@@ -208,6 +209,7 @@ describe('getStepStartStates', () => {
       [MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS]: {
         disabled: true,
       },
+      [AppServiceSteps.APPS]: { disabled: true },
     });
   });
 
@@ -316,6 +318,7 @@ describe('getStepStartStates', () => {
       [MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS]: {
         disabled: true,
       },
+      [AppServiceSteps.APPS]: { disabled: true },
     });
   });
 
@@ -424,6 +427,7 @@ describe('getStepStartStates', () => {
       [MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS]: {
         disabled: false,
       },
+      [AppServiceSteps.APPS]: { disabled: false },
     });
   });
 });

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -210,6 +210,8 @@ describe('getStepStartStates', () => {
         disabled: true,
       },
       [AppServiceSteps.APPS]: { disabled: true },
+      [AppServiceSteps.APP_SERVICE_PLANS]: { disabled: true },
+      [AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS]: { disabled: true },
     });
   });
 
@@ -319,6 +321,8 @@ describe('getStepStartStates', () => {
         disabled: true,
       },
       [AppServiceSteps.APPS]: { disabled: true },
+      [AppServiceSteps.APP_SERVICE_PLANS]: { disabled: true },
+      [AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS]: { disabled: true },
     });
   });
 
@@ -428,6 +432,8 @@ describe('getStepStartStates', () => {
         disabled: false,
       },
       [AppServiceSteps.APPS]: { disabled: false },
+      [AppServiceSteps.APP_SERVICE_PLANS]: { disabled: false },
+      [AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS]: { disabled: false },
     });
   });
 });

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -214,6 +214,8 @@ export function getResourceManagerSteps(): GetApiSteps {
       PolicySteps.POLICY_ASSIGNMENTS,
       PolicySteps.POLICY_DEFINITIONS,
       AppServiceSteps.APPS,
+      AppServiceSteps.APP_SERVICE_PLANS,
+      AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS,
     ],
     executeLastSteps: [
       AdvisorSteps.RECOMMENDATIONS,

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -98,6 +98,7 @@ import { AdvisorSteps } from './steps/resource-manager/advisor/constants';
 import { SecuritySteps } from './steps/resource-manager/security/constants';
 import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
+import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 
 function makeStepStartStates(
   stepIds: string[],
@@ -212,6 +213,7 @@ export function getResourceManagerSteps(): GetApiSteps {
       MonitorSteps.MONITOR_ACTIVITY_LOG_ALERTS,
       PolicySteps.POLICY_ASSIGNMENTS,
       PolicySteps.POLICY_DEFINITIONS,
+      AppServiceSteps.APPS,
     ],
     executeLastSteps: [
       AdvisorSteps.RECOMMENDATIONS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { advisorSteps } from './steps/resource-manager/advisor';
 import { securitySteps } from './steps/resource-manager/security';
 import { policySteps } from './steps/resource-manager/policy';
 import { monitorSteps } from './steps/resource-manager/monitor';
+import { appServiceSteps } from './steps/resource-manager/appservice';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields: {
@@ -84,6 +85,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...securitySteps,
     ...policySteps,
     ...monitorSteps,
+    ...appServiceSteps,
   ],
 
   normalizeGraphObjectKey: (_key) => _key.toLowerCase(),

--- a/src/steps/resource-manager/appservice/__recordings__/iterateAppServicePlans_4213262849/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/iterateAppServicePlans_4213262849/recording.har
@@ -1,0 +1,516 @@
+{
+  "log": {
+    "_recordingName": "iterateAppServicePlans",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "996415f9-a9b7-4e17-960c-892ad5f25dcf"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620408605\",\"not_before\":\"1620404705\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T16:30:05.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "996415f9-a9b7-4e17-960c-892ad5f25dcf"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "d7f13300-fa9b-4a95-8a95-82e7f5fce300"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:30:04 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:30:04.866Z",
+        "time": 490,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 490
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d28426dd-9aca-48b8-bf45-7297264ebc07"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "871a32a0-1568-4b42-8996-fa4cc0e3a7f4"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "871a32a0-1568-4b42-8996-fa4cc0e3a7f4"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T163006Z:871a32a0-1568-4b42-8996-fa4cc0e3a7f4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:30:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:30:05.360Z",
+        "time": 777,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 777
+        }
+      },
+      {
+        "_id": "5a73616df9b06d628d46b2af96fb7e91",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "90a3889d-6df7-425c-81e0-ce611e334699"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1801,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/serverfarms?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"name\":\"ASP-j1dev-function-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"functionapp\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789047,\"name\":\"ASP-j1dev-function-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":0,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"functionapp\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"Y1\",\"tier\":\"Dynamic\",\"size\":\"Y1\",\"family\":\"Y\",\"capacity\":0}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"name\":\"ASP-j1dev-web-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789048,\"name\":\"ASP-j1dev-web-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":1,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"app\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"F1\",\"tier\":\"Free\",\"size\":\"F1\",\"family\":\"F\",\"capacity\":0}}],\"nextLink\":null,\"id\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7cd8404d-10e3-48c3-91ff-98e3a0464377"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "7bb545d4-b8ca-423e-b379-c2815c806858"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T163006Z:7bb545d4-b8ca-423e-b379-c2815c806858"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:30:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:30:06.144Z",
+        "time": 710,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 710
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/appservice/__recordings__/iterateApps_207803837/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/iterateApps_207803837/recording.har
@@ -1,0 +1,512 @@
+{
+  "log": {
+    "_recordingName": "iterateApps",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "45a995aa-db46-4bd7-8fc2-5a3bc3410687"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620400611\",\"not_before\":\"1620396711\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T14:16:51.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "45a995aa-db46-4bd7-8fc2-5a3bc3410687"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1b78dc5a-b791-4f5d-9c48-eb46950ed300"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 14:16:50 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T14:16:50.872Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8eaceae4-bc3c-45c5-a3a1-7356201080e3"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "068a710b-669e-43fb-81c1-75c888053fda"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "068a710b-669e-43fb-81c1-75c888053fda"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T141651Z:068a710b-669e-43fb-81c1-75c888053fda"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 14:16:50 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T14:16:51.183Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      },
+      {
+        "_id": "fd76f5b214829ee8b088f0a767db3832",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "77e28045-e352-4d76-8886-2a00a70879e7"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1795,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/sites?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 2890,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2890,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/j1dev\",\"name\":\"j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"j1dev\",\"state\":\"Running\",\"hostNames\":[\"j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-171.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-CentralUSwebspace-Linux/sites/j1dev\",\"repositorySiteName\":\"j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"j1dev.azurewebsites.net\",\"j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"Node|14\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-845e\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-06T14:17:35.6866667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"13.89.172.22\",\"possibleInboundIpAddresses\":\"13.89.172.22\",\"ftpUsername\":\"j1dev\\\\$j1dev\",\"ftpsHostName\":\"ftps://waws-prod-dm1-171.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"13.89.172.22,40.77.63.65,104.43.162.5,40.77.61.181,23.99.229.97\",\"possibleOutboundIpAddresses\":\"13.89.172.22,40.77.63.65,104.43.162.5,40.77.61.181,23.99.229.97,23.100.80.194,168.61.160.245,23.101.127.123,23.100.85.210,23.100.85.223\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-171\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev\",\"name\":\"ndowmon1-j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-blu-089.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace-Linux/sites/ndowmon1-j1dev\",\"repositorySiteName\":\"ndowmon1-j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev.azurewebsites.net\",\"ndowmon1-j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-8b84\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-06T16:30:15.8766667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"40.71.177.34\",\"possibleInboundIpAddresses\":\"40.71.177.34\",\"ftpUsername\":\"ndowmon1-j1dev\\\\$ndowmon1-j1dev\",\"ftpsHostName\":\"ftps://waws-prod-blu-089.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"40.71.177.34,40.71.1.129,52.170.233.65,40.71.3.54,52.191.115.185\",\"possibleOutboundIpAddresses\":\"40.71.177.34,40.71.1.129,52.170.233.65,40.71.3.54,52.191.115.185,104.211.20.160,104.211.22.67\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-089\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-original-request-ids",
+              "value": "ed85f1bf-dcb3-4941-a266-6665cb07b600, fc115ee0-ef3e-4a62-bb5e-511e95297e88"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "69edb151-1484-4b77-9cbc-9c61c01f4a6f"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "69edb151-1484-4b77-9cbc-9c61c01f4a6f"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T141651Z:69edb151-1484-4b77-9cbc-9c61c01f4a6f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 14:16:51 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "2890"
+            }
+          ],
+          "headersSize": 694,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T14:16:51.472Z",
+        "time": 387,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 387
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
@@ -1,0 +1,1022 @@
+{
+  "log": {
+    "_recordingName": "rm-appservice-app-plan-relationships",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "f388476d-cd8c-48d4-8d75-afc303c5afda"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620414006\",\"not_before\":\"1620410106\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T18:00:06.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "f388476d-cd8c-48d4-8d75-afc303c5afda"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8c0d40b2-87d5-4ae6-8095-b65966743100"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:06 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:06.284Z",
+        "time": 340,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 340
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "7f3d01f8-ab67-459d-aab5-6218c1d7955e"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "903bf57b-a147-4015-929f-6a42355a02b8"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "903bf57b-a147-4015-929f-6a42355a02b8"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T180007Z:903bf57b-a147-4015-929f-6a42355a02b8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:06.628Z",
+        "time": 712,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 712
+        }
+      },
+      {
+        "_id": "fd76f5b214829ee8b088f0a767db3832",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "73934d32-51eb-4f27-8f30-c382a14c418a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1795,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/sites?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 6335,
+          "content": {
+            "mimeType": "application/json",
+            "size": 6335,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev\",\"name\":\"ndowmon1-j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-blu-231.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace-Linux/sites/ndowmon1-j1dev\",\"repositorySiteName\":\"ndowmon1-j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev.azurewebsites.net\",\"ndowmon1-j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:11.1666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"20.49.104.23\",\"possibleInboundIpAddresses\":\"20.49.104.23\",\"ftpUsername\":\"ndowmon1-j1dev\\\\$ndowmon1-j1dev\",\"ftpsHostName\":\"ftps://waws-prod-blu-231.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,20.49.104.23\",\"possibleOutboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,40.71.234.29,40.71.234.60,40.71.235.182,40.71.236.158,40.71.237.2,40.71.237.25,40.71.238.120,40.71.238.125,52.151.238.38,40.71.238.146,40.71.238.252,40.71.239.94,20.49.104.23\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-231\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev-webapp\",\"name\":\"ndowmon1-j1dev-webapp\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev-webapp\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace\",\"selfLink\":\"https://waws-prod-blu-243.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace/sites/ndowmon1-j1dev-webapp\",\"repositorySiteName\":\"ndowmon1-j1dev-webapp\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Shared\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:18.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev-webapp\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":true,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"app\",\"inboundIpAddress\":\"20.49.104.31\",\"possibleInboundIpAddresses\":\"20.49.104.31\",\"ftpUsername\":\"ndowmon1-j1dev-webapp\\\\$ndowmon1-j1dev-webapp\",\"ftpsHostName\":\"ftps://waws-prod-blu-243.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,20.49.104.31\",\"possibleOutboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,52.188.42.23,52.142.18.177,52.142.18.40,52.149.202.179,52.154.66.123,52.154.69.195,52.154.70.71,52.154.70.135,52.186.99.104,52.186.101.205,52.142.16.201,52.186.102.198,52.147.209.102,52.149.204.214,52.186.102.230,52.147.209.166,52.147.210.37,52.147.215.140,52.149.206.164,52.190.40.233,52.188.42.100,52.190.43.22,52.224.24.232,52.224.26.145,20.49.104.31\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-243\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}}],\"nextLink\":null,\"id\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "etag",
+              "value": "\"1D74359F1F9328C\""
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3847e2cd-db6a-485c-a253-8f6f958765ae"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9f9791a1-891f-4be3-967c-e8ffc7b2f0c0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T180007Z:9f9791a1-891f-4be3-967c-e8ffc7b2f0c0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 687,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:07.346Z",
+        "time": 467,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 467
+        }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "d53e0bb9-b491-4207-93e4-15ee97505479"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620414008\",\"not_before\":\"1620410108\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T18:00:08.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "d53e0bb9-b491-4207-93e4-15ee97505479"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "430e768d-f158-4681-8122-0fbcfd0df900"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:07.823Z",
+        "time": 273,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 273
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "53242dbc-605a-4077-b0d1-5073bca18c92"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T180008Z:0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:08.100Z",
+        "time": 474,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 474
+        }
+      },
+      {
+        "_id": "5a73616df9b06d628d46b2af96fb7e91",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ab25450f-24be-413b-bcf1-766d60b2a98e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1801,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/serverfarms?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"name\":\"ASP-j1dev-function-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"functionapp\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789047,\"name\":\"ASP-j1dev-function-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":0,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"functionapp\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"Y1\",\"tier\":\"Dynamic\",\"size\":\"Y1\",\"family\":\"Y\",\"capacity\":0}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"name\":\"ASP-j1dev-web-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789048,\"name\":\"ASP-j1dev-web-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":1,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"app\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"F1\",\"tier\":\"Free\",\"size\":\"F1\",\"family\":\"F\",\"capacity\":0}}],\"nextLink\":null,\"id\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "409e1f64-6194-495e-88f2-6333f96b8cd5"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "fdabfc8a-dd39-420f-957b-fd2440c98c41"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T180009Z:fdabfc8a-dd39-420f-957b-fd2440c98c41"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 18:00:08 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T18:00:08.580Z",
+        "time": 334,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 334
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-service-plans_1428281048/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-service-plans_1428281048/recording.har
@@ -1,0 +1,516 @@
+{
+  "log": {
+    "_recordingName": "rm-appservice-app-service-plans",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "38636a16-8845-45ed-9e0c-88a03d6bc8b4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620409174\",\"not_before\":\"1620405274\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T16:39:34.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "38636a16-8845-45ed-9e0c-88a03d6bc8b4"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f5cdd96a-445b-4fb6-946f-93a3353fce00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:39:33 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:39:33.774Z",
+        "time": 312,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 312
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "1cc9950a-721a-4d91-927b-09b1b6c84afa"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "bf3554db-c66a-4128-bda8-6799c9d88377"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "bf3554db-c66a-4128-bda8-6799c9d88377"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T163935Z:bf3554db-c66a-4128-bda8-6799c9d88377"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:39:34 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:39:34.091Z",
+        "time": 780,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 780
+        }
+      },
+      {
+        "_id": "5a73616df9b06d628d46b2af96fb7e91",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "23a8eceb-a8d0-4f8a-98a4-84b043f58d4e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1801,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/serverfarms?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"name\":\"ASP-j1dev-function-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"functionapp\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789047,\"name\":\"ASP-j1dev-function-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":0,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"functionapp\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"Y1\",\"tier\":\"Dynamic\",\"size\":\"Y1\",\"family\":\"Y\",\"capacity\":0}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"name\":\"ASP-j1dev-web-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789048,\"name\":\"ASP-j1dev-web-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":1,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"app\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"F1\",\"tier\":\"Free\",\"size\":\"F1\",\"family\":\"F\",\"capacity\":0}}],\"nextLink\":null,\"id\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "353d07e0-1034-4bec-91c3-a8c87fd46612"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "87b9682d-d1e4-4c37-a2cf-9709a65eb6fd"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T163935Z:87b9682d-d1e4-4c37-a2cf-9709a65eb6fd"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 16:39:35 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T16:39:34.880Z",
+        "time": 350,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 350
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
@@ -1,0 +1,520 @@
+{
+  "log": {
+    "_recordingName": "rm-appservice-apps",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "a33d6dd4-ebff-4764-a1d4-a54afa3dbb10"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620406793\",\"not_before\":\"1620402893\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-06T15:59:53.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "a33d6dd4-ebff-4764-a1d4-a54afa3dbb10"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cf1b9c40-b2de-468e-a7be-27d792862800"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11654.25 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 15:59:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T15:59:52.716Z",
+        "time": 348,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 348
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "01054655-e57c-4ef9-84ed-5966e3b87918"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T155953Z:e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 15:59:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T15:59:53.098Z",
+        "time": 780,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 780
+        }
+      },
+      {
+        "_id": "fd76f5b214829ee8b088f0a767db3832",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "71f93b21-b759-436b-9559-ba1c162da62d"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1795,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/sites?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 6379,
+          "content": {
+            "mimeType": "application/json",
+            "size": 6379,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev-webapp\",\"name\":\"ndowmon1-j1dev-webapp\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev-webapp\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace\",\"selfLink\":\"https://waws-prod-blu-243.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace/sites/ndowmon1-j1dev-webapp\",\"repositorySiteName\":\"ndowmon1-j1dev-webapp\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Shared\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:18.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev-webapp\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":true,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"app\",\"inboundIpAddress\":\"20.49.104.31\",\"possibleInboundIpAddresses\":\"20.49.104.31\",\"ftpUsername\":\"ndowmon1-j1dev-webapp\\\\$ndowmon1-j1dev-webapp\",\"ftpsHostName\":\"ftps://waws-prod-blu-243.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,20.49.104.31\",\"possibleOutboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,52.188.42.23,52.142.18.177,52.142.18.40,52.149.202.179,52.154.66.123,52.154.69.195,52.154.70.71,52.154.70.135,52.186.99.104,52.186.101.205,52.142.16.201,52.186.102.198,52.147.209.102,52.149.204.214,52.186.102.230,52.147.209.166,52.147.210.37,52.147.215.140,52.149.206.164,52.190.40.233,52.188.42.100,52.190.43.22,52.224.24.232,52.224.26.145,20.49.104.31\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-243\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev\",\"name\":\"ndowmon1-j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-blu-231.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace-Linux/sites/ndowmon1-j1dev\",\"repositorySiteName\":\"ndowmon1-j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev.azurewebsites.net\",\"ndowmon1-j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:11.1666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"20.49.104.23\",\"possibleInboundIpAddresses\":\"20.49.104.23\",\"ftpUsername\":\"ndowmon1-j1dev\\\\$ndowmon1-j1dev\",\"ftpsHostName\":\"ftps://waws-prod-blu-231.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,20.49.104.23\",\"possibleOutboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,40.71.234.29,40.71.234.60,40.71.235.182,40.71.236.158,40.71.237.2,40.71.237.25,40.71.238.120,40.71.238.125,52.151.238.38,40.71.238.146,40.71.238.252,40.71.239.94,20.49.104.23\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-231\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}}],\"nextLink\":null,\"id\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "etag",
+              "value": "\"1D74359F1F9328C\""
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f9b1154b-942b-467b-ba04-0e7f0d16f399"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "359b9769-1ce2-45b8-bbe6-730ba471b8eb"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210507T155954Z:359b9769-1ce2-45b8-bbe6-730ba471b8eb"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 May 2021 15:59:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 687,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-07T15:59:53.891Z",
+        "time": 499,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 499
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/appservice/client.test.ts
+++ b/src/steps/resource-manager/appservice/client.test.ts
@@ -1,0 +1,41 @@
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+
+import {
+  getMatchRequestsBy,
+  Recording,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { AppServiceClient } from './client';
+import { Site } from '@azure/arm-appservice/esm/models';
+import { configFromEnv } from '../../../../test/integrationInstanceConfig';
+
+let recording: Recording;
+
+afterEach(async () => {
+  await recording.stop();
+});
+
+describe('iterateApps', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iterateApps',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const client = new AppServiceClient(
+      configFromEnv,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const resources: Site[] = [];
+    await client.iterateApps((e) => {
+      resources.push(e);
+    });
+
+    expect(resources.length).toBeGreaterThan(0);
+  });
+});

--- a/src/steps/resource-manager/appservice/client.test.ts
+++ b/src/steps/resource-manager/appservice/client.test.ts
@@ -6,7 +6,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { AppServiceClient } from './client';
-import { Site } from '@azure/arm-appservice/esm/models';
+import { AppServicePlan, Site } from '@azure/arm-appservice/esm/models';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
 
 let recording: Recording;
@@ -33,6 +33,31 @@ describe('iterateApps', () => {
 
     const resources: Site[] = [];
     await client.iterateApps((e) => {
+      resources.push(e);
+    });
+
+    expect(resources.length).toBeGreaterThan(0);
+  });
+});
+
+describe('iterateAppServicePlans', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'iterateAppServicePlans',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const client = new AppServiceClient(
+      configFromEnv,
+      createMockIntegrationLogger(),
+      true,
+    );
+
+    const resources: AppServicePlan[] = [];
+    await client.iterateAppServicePlans((e) => {
       resources.push(e);
     });
 

--- a/src/steps/resource-manager/appservice/client.ts
+++ b/src/steps/resource-manager/appservice/client.ts
@@ -1,5 +1,5 @@
 import { WebSiteManagementClient } from '@azure/arm-appservice';
-import { Site } from '@azure/arm-appservice/esm/models';
+import { AppServicePlan, Site } from '@azure/arm-appservice/esm/models';
 import {
   Client,
   iterateAllResources,
@@ -18,6 +18,22 @@ export class AppServiceClient extends Client {
       serviceClient,
       resourceEndpoint: serviceClient.webApps,
       resourceDescription: 'appService.webApps',
+      callback,
+    });
+  }
+
+  public async iterateAppServicePlans(
+    callback: (s: AppServicePlan) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      WebSiteManagementClient,
+    );
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      resourceEndpoint: serviceClient.appServicePlans,
+      resourceDescription: 'appService.appServicePlans',
       callback,
     });
   }

--- a/src/steps/resource-manager/appservice/client.ts
+++ b/src/steps/resource-manager/appservice/client.ts
@@ -1,0 +1,24 @@
+import { WebSiteManagementClient } from '@azure/arm-appservice';
+import { Site } from '@azure/arm-appservice/esm/models';
+import {
+  Client,
+  iterateAllResources,
+} from '../../../azure/resource-manager/client';
+
+export class AppServiceClient extends Client {
+  public async iterateApps(
+    callback: (s: Site) => void | Promise<void>,
+  ): Promise<void> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      WebSiteManagementClient,
+    );
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      resourceEndpoint: serviceClient.webApps,
+      resourceDescription: 'appService.webApps',
+      callback,
+    });
+  }
+}

--- a/src/steps/resource-manager/appservice/constants.ts
+++ b/src/steps/resource-manager/appservice/constants.ts
@@ -1,0 +1,27 @@
+import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
+
+export const AppServiceSteps = {
+  APPS: 'rm-appservice-apps',
+};
+
+export const AppServiceEntities = {
+  WEB_APP: {
+    _type: 'azure_web_app',
+    _class: ['Application'],
+    resourceName: '[RM] Web App',
+  },
+  FUNCTION_APP: {
+    _type: 'azure_function_app',
+    _class: ['Function'],
+    resourceName: '[RM] Function App',
+  },
+};
+
+export const AppServiceRelationships = {
+  RESOURCE_GROUP_HAS_WEB_APP: createResourceGroupResourceRelationshipMetadata(
+    AppServiceEntities.WEB_APP._type,
+  ),
+  RESOURCE_GROUP_HAS_FUNCTION_APP: createResourceGroupResourceRelationshipMetadata(
+    AppServiceEntities.FUNCTION_APP._type,
+  ),
+};

--- a/src/steps/resource-manager/appservice/constants.ts
+++ b/src/steps/resource-manager/appservice/constants.ts
@@ -1,7 +1,10 @@
+import { RelationshipClass } from '@jupiterone/data-model';
 import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
 
 export const AppServiceSteps = {
   APPS: 'rm-appservice-apps',
+  APP_SERVICE_PLANS: 'rm-appservice-app-service-plans',
+  APP_TO_SERVICE_RELATIONSHIPS: 'rm-appservice-app-plan-relationships',
 };
 
 export const AppServiceEntities = {
@@ -15,6 +18,11 @@ export const AppServiceEntities = {
     _class: ['Function'],
     resourceName: '[RM] Function App',
   },
+  APP_SERVICE_PLAN: {
+    _type: 'azure_app_service_plan',
+    _class: ['Configuration'],
+    resourceName: '[RM] App Service Plan',
+  },
 };
 
 export const AppServiceRelationships = {
@@ -24,4 +32,19 @@ export const AppServiceRelationships = {
   RESOURCE_GROUP_HAS_FUNCTION_APP: createResourceGroupResourceRelationshipMetadata(
     AppServiceEntities.FUNCTION_APP._type,
   ),
+  RESOURCE_GROUP_HAS_APP_SERVICE_PLAN: createResourceGroupResourceRelationshipMetadata(
+    AppServiceEntities.APP_SERVICE_PLAN._type,
+  ),
+  WEB_APP_USES_PLAN: {
+    _type: 'azure_web_app_uses_app_service_plan',
+    sourceType: AppServiceEntities.WEB_APP._type,
+    _class: RelationshipClass.USES,
+    targetType: AppServiceEntities.APP_SERVICE_PLAN._type,
+  },
+  FUNCTION_APP_USES_PLAN: {
+    _type: 'azure_function_app_uses_app_service_plan',
+    sourceType: AppServiceEntities.FUNCTION_APP._type,
+    _class: RelationshipClass.USES,
+    targetType: AppServiceEntities.APP_SERVICE_PLAN._type,
+  },
 };

--- a/src/steps/resource-manager/appservice/converters.ts
+++ b/src/steps/resource-manager/appservice/converters.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  createIntegrationEntity,
+  StepEntityMetadata,
+} from '@jupiterone/integration-sdk-core';
+
+import { AzureWebLinker } from '../../../azure';
+import { Site } from '@azure/arm-appservice/esm/models';
+
+export function createAppEntity(
+  webLinker: AzureWebLinker,
+  data: Site,
+  metadata: StepEntityMetadata,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: data.id as string,
+        _type: metadata._type,
+        _class: metadata._class,
+        id: data.id,
+        name: data.name,
+        type: data.type,
+        kind: data.kind?.split(','),
+        location: data.location,
+        webLink: webLinker.portalResourceUrl(data.id),
+      },
+    },
+  });
+}

--- a/src/steps/resource-manager/appservice/converters.ts
+++ b/src/steps/resource-manager/appservice/converters.ts
@@ -5,7 +5,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker } from '../../../azure';
-import { Site } from '@azure/arm-appservice/esm/models';
+import { AppServicePlan, Site } from '@azure/arm-appservice/esm/models';
+import { AppServiceEntities } from './constants';
 
 export function createAppEntity(
   webLinker: AzureWebLinker,
@@ -24,6 +25,33 @@ export function createAppEntity(
         type: data.type,
         kind: data.kind?.split(','),
         location: data.location,
+        webLink: webLinker.portalResourceUrl(data.id),
+      },
+    },
+  });
+}
+
+export function createAppServicePlanEntity(
+  webLinker: AzureWebLinker,
+  data: AppServicePlan,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: data.id as string,
+        _type: AppServiceEntities.APP_SERVICE_PLAN._type,
+        _class: AppServiceEntities.APP_SERVICE_PLAN._class,
+        id: data.id,
+        name: data.name,
+        type: data.type,
+        kind: data.kind?.split(','),
+        location: data.location,
+        'sku.name': data.sku?.name,
+        'sku.tier': data.sku?.tier,
+        'sku.size': data.sku?.size,
+        'sku.family': data.sku?.family,
+        'sku.capacity': data.sku?.capacity,
         webLink: webLinker.portalResourceUrl(data.id),
       },
     },

--- a/src/steps/resource-manager/appservice/index.test.ts
+++ b/src/steps/resource-manager/appservice/index.test.ts
@@ -1,0 +1,113 @@
+import { fetchApps } from '.';
+import { Recording } from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '../../../types';
+import {
+  getMatchRequestsBy,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { AppServiceEntities, AppServiceRelationships } from './constants';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
+import { configFromEnv } from '../../../../test/integrationInstanceConfig';
+import {
+  getMockAccountEntity,
+  getMockResourceGroupEntity,
+} from '../../../../test/helpers/getMockEntity';
+import { Entity } from '@jupiterone/integration-sdk-core';
+import { filterGraphObjects } from '../../../../test/helpers/filterGraphObjects';
+
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) {
+    await recording.stop();
+  }
+});
+
+describe('rm-appservice-apps', () => {
+  function getSetupEntities(config: IntegrationConfig) {
+    const accountEntity = getMockAccountEntity(config);
+    const resourceGroupEntity = getMockResourceGroupEntity('j1dev');
+
+    return { accountEntity, resourceGroupEntity };
+  }
+
+  function separateAppEntities(collectedEntities: Entity[]) {
+    const {
+      targets: webAppEntities,
+      rest: restAfterWebApps,
+    } = filterGraphObjects(
+      collectedEntities,
+      (e) => e._type === AppServiceEntities.WEB_APP._type,
+    );
+    const {
+      targets: functionAppEntities,
+      rest: restAfterFunctionApps,
+    } = filterGraphObjects(
+      restAfterWebApps,
+      (e) => e._type === AppServiceEntities.FUNCTION_APP._type,
+    );
+    return {
+      webAppEntities,
+      functionAppEntities,
+      rest: restAfterFunctionApps,
+    };
+  }
+
+  test('success', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'rm-appservice-apps',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const { accountEntity, resourceGroupEntity } = getSetupEntities(
+      configFromEnv,
+    );
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: configFromEnv,
+      entities: [resourceGroupEntity],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: accountEntity,
+      },
+    });
+
+    await fetchApps(context);
+
+    const {
+      webAppEntities,
+      functionAppEntities,
+      rest: restEntities,
+    } = separateAppEntities(context.jobState.collectedEntities);
+
+    expect(webAppEntities.length).toBeGreaterThan(0);
+    expect(webAppEntities).toMatchGraphObjectSchema({
+      _class: AppServiceEntities.WEB_APP._class,
+    });
+
+    expect(functionAppEntities.length).toBeGreaterThan(0);
+    expect(functionAppEntities).toMatchGraphObjectSchema({
+      _class: AppServiceEntities.FUNCTION_APP._class,
+    });
+
+    expect(restEntities).toHaveLength(0);
+
+    expect(
+      context.jobState.collectedRelationships,
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _type: {
+            enum: [
+              AppServiceRelationships.RESOURCE_GROUP_HAS_WEB_APP._type,
+              AppServiceRelationships.RESOURCE_GROUP_HAS_FUNCTION_APP._type,
+            ],
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/steps/resource-manager/appservice/index.test.ts
+++ b/src/steps/resource-manager/appservice/index.test.ts
@@ -1,4 +1,8 @@
-import { fetchApps } from '.';
+import {
+  buildAppToPlanRelationships,
+  fetchApps,
+  fetchAppServicePlans,
+} from '.';
 import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import {
@@ -104,6 +108,134 @@ describe('rm-appservice-apps', () => {
             enum: [
               AppServiceRelationships.RESOURCE_GROUP_HAS_WEB_APP._type,
               AppServiceRelationships.RESOURCE_GROUP_HAS_FUNCTION_APP._type,
+            ],
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('rm-appservice-app-service-plans', () => {
+  function getSetupEntities(config: IntegrationConfig) {
+    const accountEntity = getMockAccountEntity(config);
+    const resourceGroupEntity = getMockResourceGroupEntity('j1dev');
+
+    return { accountEntity, resourceGroupEntity };
+  }
+
+  test('success', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'rm-appservice-app-service-plans',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const { accountEntity, resourceGroupEntity } = getSetupEntities(
+      configFromEnv,
+    );
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: configFromEnv,
+      entities: [resourceGroupEntity],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: accountEntity,
+      },
+    });
+
+    await fetchAppServicePlans(context);
+
+    const appServicePlanEntities = context.jobState.collectedEntities;
+
+    expect(appServicePlanEntities.length).toBeGreaterThan(0);
+    expect(appServicePlanEntities).toMatchGraphObjectSchema({
+      _class: AppServiceEntities.APP_SERVICE_PLAN._class,
+    });
+
+    expect(
+      context.jobState.collectedRelationships,
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _type: {
+            const:
+              AppServiceRelationships.RESOURCE_GROUP_HAS_APP_SERVICE_PLAN._type,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('rm-appservice-app-plan-relationships', () => {
+  async function getSetupEntities(config: IntegrationConfig) {
+    const accountEntity = getMockAccountEntity(config);
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: config,
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: accountEntity,
+      },
+    });
+
+    await fetchApps(context);
+    const webAppEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === AppServiceEntities.WEB_APP._type,
+    );
+    expect(webAppEntities.length).toBeGreaterThan(0);
+    const functionAppEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === AppServiceEntities.FUNCTION_APP._type,
+    );
+    expect(functionAppEntities.length).toBeGreaterThan(0);
+
+    await fetchAppServicePlans(context);
+    const appServicePlanEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === AppServiceEntities.APP_SERVICE_PLAN._type,
+    );
+    expect(appServicePlanEntities.length).toBeGreaterThan(0);
+
+    return { webAppEntities, functionAppEntities, appServicePlanEntities };
+  }
+
+  test('success', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'rm-appservice-app-plan-relationships',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const {
+      webAppEntities,
+      functionAppEntities,
+      appServicePlanEntities,
+    } = await getSetupEntities(configFromEnv);
+
+    const appEntities = [...webAppEntities, ...functionAppEntities];
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: configFromEnv,
+      entities: [...appEntities, ...appServicePlanEntities],
+    });
+
+    await buildAppToPlanRelationships(context);
+
+    expect(context.jobState.collectedEntities).toHaveLength(0);
+
+    const appToPlanRelationships = context.jobState.collectedRelationships;
+    expect(appToPlanRelationships.length).toBeGreaterThan(0);
+    expect(appToPlanRelationships).toHaveLength(appEntities.length);
+
+    expect(appToPlanRelationships).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _type: {
+            enum: [
+              AppServiceRelationships.WEB_APP_USES_PLAN._type,
+              AppServiceRelationships.FUNCTION_APP_USES_PLAN._type,
             ],
           },
         },

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -3,6 +3,9 @@ import {
   IntegrationStepExecutionContext,
   StepEntityMetadata,
   IntegrationLogger,
+  getRawData,
+  createDirectRelationship,
+  RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
@@ -14,7 +17,7 @@ import {
   AppServiceRelationships,
   AppServiceSteps,
 } from './constants';
-import { createAppEntity } from './converters';
+import { createAppEntity, createAppServicePlanEntity } from './converters';
 import { Site } from '@azure/arm-appservice/esm/models';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
@@ -74,6 +77,64 @@ function getMetadataForApp(
   return AppServiceEntities.WEB_APP;
 }
 
+export async function fetchAppServicePlans(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await getAccountEntity(jobState);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new AppServiceClient(instance.config, logger);
+
+  await client.iterateAppServicePlans(async (appServicePlan) => {
+    const appEntity = await jobState.addEntity(
+      createAppServicePlanEntity(webLinker, appServicePlan),
+    );
+    await createResourceGroupResourceRelationship(executionContext, appEntity);
+  });
+}
+
+export async function buildAppToPlanRelationships(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { logger, jobState } = executionContext;
+
+  for (const appEntityType of [
+    AppServiceEntities.WEB_APP._type,
+    AppServiceEntities.FUNCTION_APP._type,
+  ]) {
+    await jobState.iterateEntities(
+      { _type: appEntityType },
+      async (appEntity) => {
+        const app = getRawData<Site>(appEntity);
+
+        const appServicePlanId = app?.serverFarmId;
+        const appServicePlanEntity = await jobState.findEntity(
+          appServicePlanId!,
+        );
+
+        if (!appServicePlanEntity) {
+          logger.warn(
+            {
+              appId: app?.id,
+              appServicePlanId: app?.serverFarmId,
+            },
+            'Could not find app service plan in jobState.',
+          );
+          return;
+        }
+
+        await jobState.addRelationship(
+          createDirectRelationship({
+            from: appEntity,
+            _class: RelationshipClass.USES,
+            to: appServicePlanEntity,
+          }),
+        );
+      },
+    );
+  }
+}
+
 export const appServiceSteps: Step<
   IntegrationStepExecutionContext<IntegrationConfig>
 >[] = [
@@ -87,5 +148,26 @@ export const appServiceSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApps,
+  },
+  {
+    id: AppServiceSteps.APP_SERVICE_PLANS,
+    name: 'App Service Plans',
+    entities: [AppServiceEntities.APP_SERVICE_PLAN],
+    relationships: [
+      AppServiceRelationships.RESOURCE_GROUP_HAS_APP_SERVICE_PLAN,
+    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    executionHandler: fetchAppServicePlans,
+  },
+  {
+    id: AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS,
+    name: 'App Service App to Plan Relationships',
+    entities: [],
+    relationships: [
+      AppServiceRelationships.WEB_APP_USES_PLAN,
+      AppServiceRelationships.FUNCTION_APP_USES_PLAN,
+    ],
+    dependsOn: [AppServiceSteps.APPS, AppServiceSteps.APP_SERVICE_PLANS],
+    executionHandler: buildAppToPlanRelationships,
   },
 ];

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -1,0 +1,91 @@
+import {
+  Step,
+  IntegrationStepExecutionContext,
+  StepEntityMetadata,
+  IntegrationLogger,
+} from '@jupiterone/integration-sdk-core';
+
+import { createAzureWebLinker } from '../../../azure';
+import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { AppServiceClient } from './client';
+import {
+  AppServiceEntities,
+  AppServiceRelationships,
+  AppServiceSteps,
+} from './constants';
+import { createAppEntity } from './converters';
+import { Site } from '@azure/arm-appservice/esm/models';
+import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
+
+export async function fetchApps(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await getAccountEntity(jobState);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new AppServiceClient(instance.config, logger);
+
+  await client.iterateApps(async (app) => {
+    const metadata = getMetadataForApp(logger, app);
+    const appEntity = await jobState.addEntity(
+      createAppEntity(webLinker, app, metadata),
+    );
+    await createResourceGroupResourceRelationship(executionContext, appEntity);
+  });
+}
+
+/**
+ * Apps are differentiated by `kind`, a comma-separated string.
+ *
+ * Function app example:
+ * {
+ *   "kind": "functionapp,linux",
+ * }
+ *
+ * Web app example:
+ * {
+ *   "kind": "app,linux",
+ * }
+ */
+function getMetadataForApp(
+  logger: IntegrationLogger,
+  app: Site,
+): StepEntityMetadata {
+  const kinds = app.kind?.split(',');
+
+  if (kinds?.includes('functionapp')) {
+    return AppServiceEntities.FUNCTION_APP;
+  }
+
+  if (kinds?.includes('app')) {
+    return AppServiceEntities.WEB_APP;
+  }
+
+  logger.warn(
+    {
+      appId: app.id,
+      appKind: app.kind,
+    },
+    `AppService: Unknown value for app.kind. Defaulting to ${AppServiceEntities.WEB_APP._type}`,
+  );
+
+  return AppServiceEntities.WEB_APP;
+}
+
+export const appServiceSteps: Step<
+  IntegrationStepExecutionContext<IntegrationConfig>
+>[] = [
+  {
+    id: AppServiceSteps.APPS,
+    name: 'App Service Apps',
+    entities: [AppServiceEntities.WEB_APP, AppServiceEntities.FUNCTION_APP],
+    relationships: [
+      AppServiceRelationships.RESOURCE_GROUP_HAS_WEB_APP,
+      AppServiceRelationships.RESOURCE_GROUP_HAS_FUNCTION_APP,
+    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    executionHandler: fetchApps,
+  },
+];

--- a/terraform/appservice.tf
+++ b/terraform/appservice.tf
@@ -2,8 +2,8 @@ resource "azurerm_app_service_plan" "j1dev" {
   name                = "ASP-j1dev-function-app"
   location            = azurerm_resource_group.j1dev.location
   resource_group_name = azurerm_resource_group.j1dev.name
-	kind                = "FunctionApp"
-	reserved            = true
+  kind                = "FunctionApp"
+  reserved            = true
 
   sku {
     tier = "Dynamic"
@@ -18,16 +18,16 @@ resource "azurerm_function_app" "j1dev" {
   app_service_plan_id        = azurerm_app_service_plan.j1dev.id
   storage_account_name       = azurerm_storage_account.j1dev.name
   storage_account_access_key = azurerm_storage_account.j1dev.primary_access_key
-	enable_builtin_logging     = false
-	os_type                    = "linux"
+  enable_builtin_logging     = false
+  os_type                    = "linux"
 }
 
 resource "azurerm_app_service_plan" "j1dev_web_app" {
   name                = "ASP-j1dev-web-app"
   location            = azurerm_resource_group.j1dev.location
   resource_group_name = azurerm_resource_group.j1dev.name
-	kind                = "app"
-	reserved            = false
+  kind                = "app"
+  reserved            = false
 
   sku {
     tier = "Free"
@@ -40,5 +40,5 @@ resource "azurerm_app_service" "j1dev_web_app" {
   location                   = azurerm_resource_group.j1dev.location
   resource_group_name        = azurerm_resource_group.j1dev.name
   app_service_plan_id        = azurerm_app_service_plan.j1dev_web_app.id
-	client_affinity_enabled    = true
+  client_affinity_enabled    = true
 }

--- a/terraform/appservice.tf
+++ b/terraform/appservice.tf
@@ -1,0 +1,44 @@
+resource "azurerm_app_service_plan" "j1dev" {
+  name                = "ASP-j1dev-function-app"
+  location            = azurerm_resource_group.j1dev.location
+  resource_group_name = azurerm_resource_group.j1dev.name
+	kind                = "FunctionApp"
+	reserved            = true
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+}
+
+resource "azurerm_function_app" "j1dev" {
+  name                       = "${var.developer_id}-j1dev"
+  location                   = azurerm_resource_group.j1dev.location
+  resource_group_name        = azurerm_resource_group.j1dev.name
+  app_service_plan_id        = azurerm_app_service_plan.j1dev.id
+  storage_account_name       = azurerm_storage_account.j1dev.name
+  storage_account_access_key = azurerm_storage_account.j1dev.primary_access_key
+	enable_builtin_logging     = false
+	os_type                    = "linux"
+}
+
+resource "azurerm_app_service_plan" "j1dev_web_app" {
+  name                = "ASP-j1dev-web-app"
+  location            = azurerm_resource_group.j1dev.location
+  resource_group_name = azurerm_resource_group.j1dev.name
+	kind                = "app"
+	reserved            = false
+
+  sku {
+    tier = "Free"
+    size = "F1"
+  }
+}
+
+resource "azurerm_app_service" "j1dev_web_app" {
+  name                       = "${var.developer_id}-j1dev-webapp"
+  location                   = azurerm_resource_group.j1dev.location
+  resource_group_name        = azurerm_resource_group.j1dev.name
+  app_service_plan_id        = azurerm_app_service_plan.j1dev_web_app.id
+	client_affinity_enabled    = true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,15 @@
     "@azure/ms-rest-js" "^2.0.4"
     tslib "^1.10.0"
 
+"@azure/arm-appservice@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/arm-appservice/-/arm-appservice-7.0.0.tgz#f1c57796dd0660b725a97928069f5bd1b47b0639"
+  integrity sha512-6nJUx1nDWCqllK79Pb0VIhtCXooQxWKcQDbZWS/MBRRjzqc6sRPEtvUaX0UgrO3RPhDn4+LlJbQu0q2mgVwDEA==
+  dependencies:
+    "@azure/ms-rest-azure-js" "^2.0.1"
+    "@azure/ms-rest-js" "^2.0.4"
+    tslib "^1.10.0"
+
 "@azure/arm-authorization@^8.3.2":
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/@azure/arm-authorization/-/arm-authorization-8.3.2.tgz#c48dc3fdd205b0fe63bb94913100a2eabb3b3e5f"


### PR DESCRIPTION
The Azure endpoint for `Function App` resources (`providers/Microsoft.Web/sites`) is generic, and returns both function apps (`azure_function_app`) and web apps (`azure_web_app`). I chose to create these as two different `_type`s, because they're well segmented in the azure console, so normalizing on a single `_type` (like `azure_app`) seems super confusing.

That said, the best differentiator from the API response is the `type` property, which is just a comma-separated list that may include `functionapp` or `app`. Don't completely love that as a differentiator, so let me know if you think this should have been done differently.

<img width="1321" alt="Screen Shot 2021-05-07 at 12 20 54 PM" src="https://user-images.githubusercontent.com/15333061/117479734-ad8d3100-af2e-11eb-960b-080c706c2ce3.png">
