### PR TITLE
Add azure_storage_account.networkRuleSet.allowedIpAddresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ and this project adheres to
   | `azure_policy_definition` | `DEFINES`  | `azure_policy_state`     |
   | `ANY_RESOURCE`            | `HAS`      | `azure_policy_state`     |
 
+- Added the following property to `azure_storage_account`:
+  - `networkRuleSet.allowedIpAddresses`
+
+### Changed
+
+- Changed the following property values on `azure_storage_account`:
+
+  | Previous property name        | New property name              |
+  | ----------------------------- | ------------------------------ |
+  | `networkRuleSetDefaultAction` | `networkRuleSet.defaultAction` |
+  | `networkRuleSetBypass`        | `networkRuleSet.bypass`        |
+
 ### Fixed
 
 - Renamed type `azure_network_azure_firewall` to `azure_network_firewall`

--- a/src/steps/resource-manager/storage/converters.ts
+++ b/src/steps/resource-manager/storage/converters.ts
@@ -93,8 +93,11 @@ export function createStorageAccountEntity(
             ? encryptedServices.queue?.enabled
             : undefined,
         allowBlobPublicAccess: data.allowBlobPublicAccess,
-        networkRuleSetDefaultAction: data.networkRuleSet?.defaultAction,
-        networkRuleSetBypass: data.networkRuleSet?.bypass,
+        'networkRuleSet.defaultAction': data.networkRuleSet?.defaultAction,
+        'networkRuleSet.bypass': data.networkRuleSet?.bypass,
+        'networkRuleSet.allowedIpAddresses': data.networkRuleSet?.ipRules
+          ?.map((ipRule) => ipRule.iPAddressOrRange)
+          .join(','),
         blobSoftDeleteEnabled:
           storageAccountServiceProperties.blob?.deleteRetentionPolicy?.enabled,
         blobSoftDeleteRetentionDays:


### PR DESCRIPTION
Fixes #335 

Note that although the property `networkRuleSet.ipRules` is an array that has both an `action` property (e.g. `"allow"`) and an `iPAddressOrRange` property, investigation in the UI shows that rules can only be defined when **All networks** is selected in the **Allow access from** field, not the **Selected networks** property.

Allow access from **All networks** (no option to provide IP address / range)
<img width="855" alt="Screen Shot 2021-05-10 at 11 24 25 PM" src="https://user-images.githubusercontent.com/15333061/117753655-dd665e00-b1e6-11eb-9ef3-d5ca186e5dd9.png">

Allow access from **Selected networks** (option to provide IP address / range. Defaults to **Allow**)
<img width="855" alt="Screen Shot 2021-05-10 at 11 25 07 PM" src="https://user-images.githubusercontent.com/15333061/117753719-f66f0f00-b1e6-11eb-8ccc-cd3addf82223.png">

Hence, it's safe to assume that when `ipRules` is populated, the rules are of type `allow`, and the property `azure_storage_account.networkRuleSet.allowedIpAddresses` is appropriate.


```
### Added

- Added the following property to `azure_storage_account`:
  - `networkRuleSet.allowedIpAddresses`

### Changed

- Changed the following property values on `azure_storage_account`:

  | Previous property name        | New property name              |
  | ----------------------------- | ------------------------------ |
  | `networkRuleSetDefaultAction` | `networkRuleSet.defaultAction` |
  | `networkRuleSetBypass`        | `networkRuleSet.bypass`        |
```
