### PR TITLE
Add new vm extension properties to get things like CD settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to
   | `azure_vm`             | `HAS`      | `azure_shared_image` |
   | `azure_vm`             | `HAS`      | `azure_image`        |
 
+- Changed the following property values on `azure_vm_extension`:
+  - `settings`
+  - `extType`
+  - `publisher`
+
 ## 5.24.0 - 2021-05-11
 
 ### Added

--- a/src/steps/resource-manager/compute/converters.test.ts
+++ b/src/steps/resource-manager/compute/converters.test.ts
@@ -14,7 +14,9 @@ import {
   createGalleryEntity,
   createSharedImage,
   createVirtualMachineEntity,
+  createVirtualMachineExtensionEntity,
   testFunctions,
+  VirtualMachineExtensionSharedProperties,
 } from './converters';
 
 const { usesManagedDisks } = testFunctions;
@@ -308,6 +310,48 @@ describe('createSharedImageEntity', () => {
       webLink: webLinker.portalResourceUrl(
         '/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition',
       ),
+      _rawData: [{ name: 'default', rawData: data }],
+    });
+  });
+});
+
+describe('createVirtualMachineExtensionEntity', () => {
+  test('properties transferred', () => {
+    const data: VirtualMachineExtensionSharedProperties = {
+      name: 'TeamServicesAgentExtension',
+      id:
+        '/subscriptions/d2c1ab8d-f64d-43e2-bca3-ea3b8130679d/resourceGroups/kenan-free-trial/providers/Microsoft.Compute/virtualMachines/kenan-free-trial/extensions/TeamServicesAgentExtension',
+      type: 'Microsoft.Compute/virtualMachines/extensions',
+      autoUpgradeMinorVersion: true,
+      publisher: 'Microsoft.VisualStudio.Services',
+      virtualMachineExtensionType: 'TeamServicesAgentLinux',
+      typeHandlerVersion: '1.0',
+      settings: {
+        VSTSAccountName: 'kenanwarrenj1',
+        TeamProject: 'Test Project',
+        DeploymentGroup: 'test-deployment',
+        AgentName: 'kenan-free-trial',
+        Tags: '',
+      },
+    };
+
+    expect(createVirtualMachineExtensionEntity(data)).toEqual({
+      _key:
+        '/subscriptions/d2c1ab8d-f64d-43e2-bca3-ea3b8130679d/resourceGroups/kenan-free-trial/providers/Microsoft.Compute/virtualMachines/kenan-free-trial/extensions/TeamServicesAgentExtension',
+      _type: 'azure_vm_extension',
+      _class: ['Application'],
+      id:
+        '/subscriptions/d2c1ab8d-f64d-43e2-bca3-ea3b8130679d/resourceGroups/kenan-free-trial/providers/Microsoft.Compute/virtualMachines/kenan-free-trial/extensions/TeamServicesAgentExtension',
+      displayName: 'TeamServicesAgentExtension',
+      extType: 'TeamServicesAgentLinux',
+      name: 'TeamServicesAgentExtension',
+      publisher: 'Microsoft.VisualStudio.Services',
+      'settings.agentName': 'kenan-free-trial',
+      'settings.deploymentGroup': 'test-deployment',
+      'settings.tags': '',
+      'settings.teamProject': 'Test Project',
+      'settings.vstsAccountName': 'kenanwarrenj1',
+      createdOn: undefined,
       _rawData: [{ name: 'default', rawData: data }],
     });
   });

--- a/src/steps/resource-manager/compute/converters.ts
+++ b/src/steps/resource-manager/compute/converters.ts
@@ -137,7 +137,7 @@ export function createImageEntity(
 
 export type VirtualMachineExtensionSharedProperties = Omit<
   VirtualMachineExtension,
-  'id' | 'location' | 'provisioningState'
+  'location' | 'provisioningState'
 >;
 
 export function createVirtualMachineExtensionEntity(
@@ -147,10 +147,13 @@ export function createVirtualMachineExtensionEntity(
     entityData: {
       source: data,
       assign: {
-        _key: getVirtualMachineExtensionKey(data),
+        _key: data.id || getVirtualMachineExtensionKey(data),
         _type: entities.VIRTUAL_MACHINE_EXTENSION._type,
         _class: entities.VIRTUAL_MACHINE_EXTENSION._class,
         name: data.name,
+        publisher: data.publisher,
+        extType: data.virtualMachineExtensionType,
+        ...convertProperties(data.settings, { prefix: 'settings' }),
       },
     },
   });


### PR DESCRIPTION
Partially solves #341 by allowing j1ql queries on extension settings where the continuous delivery information resides.