### PR TITLE
339 management groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to
 
 - Added support for ingesting the following **new** resources:
 
-  | Service       | Resource / Entity    |
-  | ------------- | -------------------- |
-  | Gallery       | `azure_gallery`      |
-  | Gallery Image | `azure_shared_image` |
+  | Service           | Resource / Entity        |
+  | ----------------- | ------------------------ |
+  | Gallery           | `azure_gallery`          |
+  | Gallery Image     | `azure_shared_image`     |
+  | Management Groups | `azure_management_group` |
 
 - Added support for ingesting the following **new** relationships:
 
@@ -25,6 +26,8 @@ and this project adheres to
   | `azure_gallery`        | `CONTAINS` | `azure_shared_image` |
   | `azure_vm`             | `HAS`      | `azure_shared_image` |
   | `azure_vm`             | `HAS`      | `azure_image`        |
+  | `azure_management_group` | `CONTAINS` | `azure_management_group` |
+  | `azure_account`          | `HAS`      | `azure_management_group` |
 
 - New properties added to resources:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Added
 
+- Added ingestion of Azure Management Groups when the
+  `configureSubscriptionInstances` configuration field is `true`. This ingestion
+  requires users to assign the `Management Group Reader`
+  [role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#management-group-reader)
+  to the service principal used in the given integration configuration to the
+  **Tenant Root Group**
+  [management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory).
+
 - Added support for ingesting the following **new** resources:
 
   | Service           | Resource / Entity        |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -63,7 +63,7 @@ To create the App Registration:
 1. Create a new client secret
 1. Copy the generated secret (you only get one chance!)
 
-#### APIPermissions
+#### API Permissions (Azure Active Directory)
 
 Grant permission to read Microsoft Graph information:
 
@@ -83,6 +83,8 @@ Grant permission to read Microsoft Graph information:
 
 1. Grant admin consent for this directory for the permissions above
 
+#### IAM Roles (Azure Management Groups / Subscriptions)
+
 Please note that minimally [`User.Read` is required][3] even when AD ingestion
 is disabled. The integration will request Organization information to maintain
 the `Account` entity.
@@ -90,13 +92,31 @@ the `Account` entity.
 Grant the `Reader` RBAC subscription role to read Azure Resource Manager
 information:
 
-1. Navigate to **Subscriptions**, choose the subscription from which you want to
-   ingest resources
-1. Copy the **Subscription ID**
+1. Navigate to the correct scope for your integration.
+
+   _If configuring a single Azure Subscription:_
+
+   - navigate to **Subscriptions**, choose the subscription from which you want
+     to ingest resources.
+
+   _If configuring all subscriptions for a tenant (using the
+   `Configure Subscription Instances` flag in JupiterOne):_
+
+   - navigate to **Management Groups**, then to the
+     [Tenant Root Group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory).
+
 1. Navigate to **Access control (IAM)**, then **Add role assignment**
 1. Select **Role** "Reader", **Assign access to** "Azure AD user, group, or
-   service principal"
-1. Search for the App "JupiterOne"
+   service principal", and select the App "JupiterOne"
+1. Create a custom role called "JupiterOne Reader" with the following
+   permissions:
+   - `Microsoft.PolicyInsights/policyStates/queryResults/action`
+1. Select **Role** "JupiterOne Reader", **Assign access to** "Azure AD user,
+   group, or service principal", and select the app "JupiterOne"
+1. _If configuring all subscriptions for a tenant (using the
+   `Configure Subscription Instances` flag in JupiterOne):_
+
+   - Also assign the "Management Group Reader" role to the App "JupiterOne"
 
 ### In JupiterOne
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -177,6 +177,7 @@ The following entities are created:
 | [RM] Key Vault                                 | `azure_keyvault_service`                          | `Service`                          |
 | [RM] Load Balancer                             | `azure_lb`                                        | `Gateway`                          |
 | [RM] Location                                  | `azure_location`                                  | `Site`                             |
+| [RM] Management Group                          | `azure_management_group`                          | `Group`                            |
 | [RM] MariaDB Database                          | `azure_mariadb_database`                          | `Database`, `DataStore`            |
 | [RM] MariaDB Server                            | `azure_mariadb_server`                            | `Database`, `DataStore`, `Host`    |
 | [RM] Monitor Activity Log Alert                | `azure_monitor_activity_log_alert`                | `Rule`                             |
@@ -237,6 +238,7 @@ The following relationships are created/mapped:
 
 | Source Entity `_type`              | Relationship `_class` | Target Entity `_type`                             |
 | ---------------------------------- | --------------------- | ------------------------------------------------- |
+| `azure_account`                    | **HAS**               | `azure_management_group`                          |
 | `azure_account`                    | **HAS**               | `azure_user_group`                                |
 | `azure_account`                    | **HAS**               | `azure_keyvault_service`                          |
 | `azure_account`                    | **HAS**               | `azure_user`                                      |
@@ -265,6 +267,7 @@ The following relationships are created/mapped:
 | `azure_user_group`                 | **HAS**               | `azure_user`                                      |
 | `azure_lb`                         | **CONNECTS**          | `azure_nic`                                       |
 | `azure_location`                   | **HAS**               | `azure_network_watcher`                           |
+| `azure_management_group`           | **CONTAINS**          | `azure_management_group`                          |
 | `azure_mariadb_server`             | **HAS**               | `azure_mariadb_database`                          |
 | `azure_monitor_activity_log_alert` | **MONITORS**          | `ANY_SCOPE`                                       |
 | `azure_monitor_log_profile`        | **USES**              | `azure_storage_account`                           |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -238,9 +238,9 @@ The following relationships are created/mapped:
 
 | Source Entity `_type`              | Relationship `_class` | Target Entity `_type`                             |
 | ---------------------------------- | --------------------- | ------------------------------------------------- |
-| `azure_account`                    | **HAS**               | `azure_management_group`                          |
 | `azure_account`                    | **HAS**               | `azure_user_group`                                |
 | `azure_account`                    | **HAS**               | `azure_keyvault_service`                          |
+| `azure_account`                    | **HAS**               | `azure_management_group`                          |
 | `azure_account`                    | **HAS**               | `azure_user`                                      |
 | `azure_api_management_service`     | **HAS**               | `azure_api_management_api`                        |
 | `azure_security_assessment`        | **IDENTIFIED**        | `azure_advisor_recommendation`                    |

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@azure/arm-dns": "^4.0.0",
     "@azure/arm-eventgrid": "^9.0.0",
     "@azure/arm-keyvault": "^1.2.1",
+    "@azure/arm-managementgroups": "^1.1.0",
     "@azure/arm-mariadb": "^1.4.0",
     "@azure/arm-monitor": "^6.0.0",
     "@azure/arm-mysql": "^3.3.0",

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -99,7 +99,7 @@ import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 import { PolicyInsightSteps } from './steps/resource-manager/policy-insights/constants';
-import { steps as ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
+import { ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -491,9 +491,11 @@ describe('getStepStartStates', () => {
     });
   });
 
-  test('ingestManagementGroups: true', () => {
+  test('configureSubscriptionInstances: true', () => {
     const context = createMockExecutionContext({
-      instanceConfig: { ingestManagementGroups: true } as IntegrationConfig,
+      instanceConfig: {
+        configureSubscriptionInstances: true,
+      } as IntegrationConfig,
     });
     const states = getStepStartStates(context);
     expect(states).toEqual({

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -99,6 +99,7 @@ import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 import { PolicyInsightSteps } from './steps/resource-manager/policy-insights/constants';
+import { steps as ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
 
 describe('getStepStartStates', () => {
   test('all steps represented', () => {
@@ -228,6 +229,9 @@ describe('getStepStartStates', () => {
       [PolicyInsightSteps.POLICY_STATE_TO_RESOURCE_RELATIONSHIPS]: {
         disabled: true,
       },
+      [ManagementGroupSteps.MANAGEMENT_GROUPS]: {
+        disabled: true,
+      },
     });
   });
 
@@ -353,6 +357,9 @@ describe('getStepStartStates', () => {
       [PolicyInsightSteps.POLICY_STATE_TO_RESOURCE_RELATIONSHIPS]: {
         disabled: true,
       },
+      [ManagementGroupSteps.MANAGEMENT_GROUPS]: {
+        disabled: true,
+      },
     });
   });
 
@@ -476,6 +483,137 @@ describe('getStepStartStates', () => {
         disabled: false,
       },
       [PolicyInsightSteps.POLICY_STATE_TO_RESOURCE_RELATIONSHIPS]: {
+        disabled: false,
+      },
+      [ManagementGroupSteps.MANAGEMENT_GROUPS]: {
+        disabled: true,
+      },
+    });
+  });
+
+  test('ingestManagementGroups: true', () => {
+    const context = createMockExecutionContext({
+      instanceConfig: { ingestManagementGroups: true } as IntegrationConfig,
+    });
+    const states = getStepStartStates(context);
+    expect(states).toEqual({
+      [STEP_AD_ACCOUNT]: { disabled: false },
+      [STEP_AD_GROUPS]: { disabled: true },
+      [STEP_AD_GROUP_MEMBERS]: { disabled: true },
+      [STEP_AD_USER_REGISTRATION_DETAILS]: { disabled: true },
+      [STEP_AD_USERS]: { disabled: true },
+      [STEP_AD_SERVICE_PRINCIPALS]: { disabled: true },
+      [STEP_RM_KEYVAULT_VAULTS]: { disabled: true },
+      [STEP_RM_NETWORK_VIRTUAL_NETWORKS]: { disabled: true },
+      [STEP_RM_NETWORK_SECURITY_GROUPS]: { disabled: true },
+      [STEP_RM_NETWORK_SECURITY_GROUP_RULE_RELATIONSHIPS]: { disabled: true },
+      [STEP_RM_NETWORK_INTERFACES]: { disabled: true },
+      [STEP_RM_NETWORK_LOAD_BALANCERS]: { disabled: true },
+      [STEP_RM_NETWORK_FIREWALLS]: { disabled: true },
+      [STEP_RM_NETWORK_PUBLIC_IP_ADDRESSES]: { disabled: true },
+      [STEP_RM_NETWORK_WATCHERS]: { disabled: true },
+      [STEP_RM_NETWORK_LOCATION_WATCHERS]: { disabled: true },
+      [STEP_RM_NETWORK_FLOW_LOGS]: { disabled: true },
+      [STEP_RM_NETWORK_PRIVATE_ENDPOINTS]: { disabled: true },
+      [STEP_RM_NETWORK_PRIVATE_ENDPOINT_SUBNET_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [STEP_RM_NETWORK_PRIVATE_ENDPOINTS_NIC_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [STEP_RM_NETWORK_PRIVATE_ENDPOINTS_RESOURCE_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [STEP_RM_COMPUTE_VIRTUAL_MACHINE_IMAGES]: { disabled: true },
+      [STEP_RM_COMPUTE_VIRTUAL_MACHINE_DISKS]: { disabled: true },
+      [STEP_RM_COMPUTE_VIRTUAL_MACHINES]: { disabled: true },
+      [computeSteps.GALLERIES]: { disabled: true },
+      [computeSteps.SHARED_IMAGES]: { disabled: true },
+      [computeSteps.VIRTUAL_MACHINE_EXTENSIONS]: { disabled: true },
+      [computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS]: { disabled: true },
+      [computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS]: { disabled: true },
+      [STEP_RM_COSMOSDB_SQL_DATABASES]: { disabled: true },
+      [STEP_RM_DATABASE_MARIADB_DATABASES]: { disabled: true },
+      [STEP_RM_DATABASE_MYSQL_DATABASES]: { disabled: true },
+      [sqlDatabaseSteps.SERVERS]: { disabled: true },
+      [sqlDatabaseSteps.SERVER_DIAGNOSTIC_SETTINGS]: { disabled: true },
+      [sqlDatabaseSteps.DATABASES]: { disabled: true },
+      [sqlDatabaseSteps.SERVER_FIREWALL_RULES]: { disabled: true },
+      [sqlDatabaseSteps.SERVER_AD_ADMINS]: { disabled: true },
+      [postgreSqlDatabaseSteps.SERVERS]: { disabled: true },
+      [postgreSqlDatabaseSteps.DATABASES]: { disabled: true },
+      [postgreSqlDatabaseSteps.SERVER_FIREWALL_RULES]: { disabled: true },
+      [storageSteps.STORAGE_CONTAINERS]: { disabled: true },
+      [storageSteps.STORAGE_FILE_SHARES]: { disabled: true },
+      [storageSteps.STORAGE_ACCOUNTS]: { disabled: true },
+      [storageSteps.STORAGE_QUEUES]: { disabled: true },
+      [storageSteps.STORAGE_TABLES]: { disabled: true },
+      [STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS]: { disabled: true },
+      [authorizationSteps.ROLE_ASSIGNMENTS]: { disabled: true },
+      [authorizationSteps.ROLE_ASSIGNMENT_PRINCIPALS]: { disabled: true },
+      [authorizationSteps.ROLE_ASSIGNMENT_SCOPES]: { disabled: true },
+      [authorizationSteps.ROLE_DEFINITIONS]: { disabled: true },
+      [authorizationSteps.ROLE_ASSIGNMENT_DEFINITIONS]: { disabled: true },
+      [authorizationSteps.CLASSIC_ADMINS]: { disabled: true },
+      [STEP_RM_RESOURCES_RESOURCE_GROUPS]: { disabled: true },
+      [subscriptionSteps.SUBSCRIPTION]: { disabled: true },
+      [subscriptionSteps.SUBSCRIPTION_DIAGNOSTIC_SETTINGS]: { disabled: true },
+      [subscriptionSteps.LOCATIONS]: { disabled: true },
+      [STEP_RM_API_MANAGEMENT_SERVICES]: { disabled: true },
+      [STEP_RM_API_MANAGEMENT_APIS]: { disabled: true },
+      [STEP_RM_DNS_ZONES]: { disabled: true },
+      [STEP_RM_DNS_RECORD_SETS]: { disabled: true },
+      [STEP_RM_PRIVATE_DNS_ZONES]: { disabled: true },
+      [STEP_RM_PRIVATE_DNS_RECORD_SETS]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRIES]: { disabled: true },
+      [STEP_RM_CONTAINER_REGISTRY_WEBHOOKS]: { disabled: true },
+      [STEP_RM_SERVICE_BUS_NAMESPACES]: { disabled: true },
+      [STEP_RM_SERVICE_BUS_QUEUES]: { disabled: true },
+      [STEP_RM_SERVICE_BUS_TOPICS]: { disabled: true },
+      [STEP_RM_SERVICE_BUS_SUBSCRIPTIONS]: { disabled: true },
+      [STEP_RM_CDN_PROFILE]: { disabled: true },
+      [STEP_RM_CDN_ENDPOINTS]: { disabled: true },
+      [STEP_RM_BATCH_ACCOUNT]: { disabled: true },
+      [STEP_RM_BATCH_POOL]: { disabled: true },
+      [STEP_RM_BATCH_APPLICATION]: { disabled: true },
+      [STEP_RM_BATCH_CERTIFICATE]: { disabled: true },
+      [STEP_RM_REDIS_CACHES]: { disabled: true },
+      [STEP_RM_REDIS_FIREWALL_RULES]: { disabled: true },
+      [STEP_RM_REDIS_LINKED_SERVERS]: { disabled: true },
+      [STEP_RM_CONTAINER_GROUPS]: { disabled: true },
+      [STEP_RM_EVENT_GRID_DOMAINS]: { disabled: true },
+      [STEP_RM_EVENT_GRID_DOMAIN_TOPICS]: { disabled: true },
+      [STEP_RM_EVENT_GRID_TOPICS]: { disabled: true },
+      [STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS]: { disabled: true },
+      [STEP_RM_EVENT_GRID_DOMAIN_TOPIC_SUBSCRIPTIONS]: { disabled: true },
+      [AdvisorSteps.RECOMMENDATIONS]: { disabled: true },
+      [PolicySteps.POLICY_ASSIGNMENTS]: { disabled: true },
+      [PolicySteps.POLICY_DEFINITIONS]: { disabled: true },
+      [PolicySteps.POLICY_ASSIGNMENT_SCOPE_RELATIONSHIPS]: { disabled: true },
+      [SecuritySteps.ASSESSMENTS]: { disabled: true },
+      [SecuritySteps.SECURITY_CENTER_CONTACTS]: { disabled: true },
+      [SecuritySteps.SETTINGS]: { disabled: true },
+      [SecuritySteps.AUTO_PROVISIONING_SETTINGS]: { disabled: true },
+      [SecuritySteps.PRICING_CONFIGURATIONS]: { disabled: true },
+      [MonitorSteps.MONITOR_LOG_PROFILES]: { disabled: true },
+      [MonitorSteps.MONITOR_ACTIVITY_LOG_ALERTS]: { disabled: true },
+      [MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [AppServiceSteps.APPS]: { disabled: true },
+      [AppServiceSteps.APP_SERVICE_PLANS]: { disabled: true },
+      [AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS]: { disabled: true },
+      [PolicyInsightSteps.SUBSCRIPTION_POLICY_STATES]: { disabled: true },
+      [PolicyInsightSteps.POLICY_STATE_TO_ASSIGNMENT_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [PolicyInsightSteps.POLICY_STATE_TO_DEFINITION_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [PolicyInsightSteps.POLICY_STATE_TO_RESOURCE_RELATIONSHIPS]: {
+        disabled: true,
+      },
+      [ManagementGroupSteps.MANAGEMENT_GROUPS]: {
         disabled: false,
       },
     });

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -101,7 +101,7 @@ import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 import { PolicyInsightSteps } from './steps/resource-manager/policy-insights/constants';
-import { steps as ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
+import { ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
 
 function makeStepStartStates(
   stepIds: string[],

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -251,7 +251,7 @@ export default function getStepStartStates(
 
   const activeDirectory = { disabled: !config.ingestActiveDirectory };
   const resourceManager = { disabled: !hasSubscriptionId(config) };
-  const managementGroups = { disabled: !config.ingestManagementGroups };
+  const managementGroups = { disabled: !config.configureSubscriptionInstances };
 
   const {
     executeFirstSteps: adFirstSteps,

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -101,6 +101,7 @@ import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';
 import { AppServiceSteps } from './steps/resource-manager/appservice/constants';
 import { PolicyInsightSteps } from './steps/resource-manager/policy-insights/constants';
+import { steps as ManagementGroupSteps } from './steps/resource-manager/management-groups/constants';
 
 function makeStepStartStates(
   stepIds: string[],
@@ -127,6 +128,13 @@ export function getActiveDirectorySteps(): GetApiSteps {
       STEP_AD_USERS,
       STEP_AD_SERVICE_PRINCIPALS,
     ],
+    executeLastSteps: [],
+  };
+}
+
+export function getManagementGroupSteps(): GetApiSteps {
+  return {
+    executeFirstSteps: [ManagementGroupSteps.MANAGEMENT_GROUPS],
     executeLastSteps: [],
   };
 }
@@ -243,6 +251,7 @@ export default function getStepStartStates(
 
   const activeDirectory = { disabled: !config.ingestActiveDirectory };
   const resourceManager = { disabled: !hasSubscriptionId(config) };
+  const managementGroups = { disabled: !config.ingestManagementGroups };
 
   const {
     executeFirstSteps: adFirstSteps,
@@ -252,9 +261,14 @@ export default function getStepStartStates(
     executeFirstSteps: rmFirstSteps,
     executeLastSteps: rmLastSteps,
   } = getResourceManagerSteps();
+  const {
+    executeFirstSteps: mgFirstSteps,
+    executeLastSteps: mgLastSteps,
+  } = getManagementGroupSteps();
   return {
     [STEP_AD_ACCOUNT]: { disabled: false },
     ...makeStepStartStates([...adFirstSteps, ...adLastSteps], activeDirectory),
     ...makeStepStartStates([...rmFirstSteps, ...rmLastSteps], resourceManager),
+    ...makeStepStartStates([...mgFirstSteps, ...mgLastSteps], managementGroups),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { policySteps } from './steps/resource-manager/policy';
 import { monitorSteps } from './steps/resource-manager/monitor';
 import { appServiceSteps } from './steps/resource-manager/appservice';
 import { policyInsightSteps } from './steps/resource-manager/policy-insights';
+import { managementGroupSteps } from './steps/resource-manager/management-groups';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields: {
@@ -50,6 +51,10 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
       mask: false,
     },
     ingestActiveDirectory: {
+      type: 'boolean',
+      mask: false,
+    },
+    ingestManagementGroups: {
       type: 'boolean',
       mask: false,
     },
@@ -88,6 +93,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
     ...monitorSteps,
     ...appServiceSteps,
     ...policyInsightSteps,
+    ...managementGroupSteps,
   ],
 
   normalizeGraphObjectKey: (_key) => _key.toLowerCase(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
       type: 'boolean',
       mask: false,
     },
-    ingestManagementGroups: {
+    configureSubscriptionInstances: {
       type: 'boolean',
       mask: false,
     },

--- a/src/steps/resource-manager/management-groups/__recordings__/getManagementGroup_2914528671/recording.har
+++ b/src/steps/resource-manager/management-groups/__recordings__/getManagementGroup_2914528671/recording.har
@@ -1,0 +1,525 @@
+{
+  "log": {
+    "_recordingName": "getManagementGroup",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "09ad3392-1a81-48a1-891a-0b7a5e8d5664"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1621460769\",\"not_before\":\"1621456869\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-18T20:46:10.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "09ad3392-1a81-48a1-891a-0b7a5e8d5664"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "993df934-4853-4517-863d-dcf8ef510a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11774.8 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 19 May 2021 20:46:09 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-19T20:46:09.425Z",
+        "time": 344,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 344
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c2c25a12-c076-4749-857f-8b7e9b796196"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "d8920282-3881-43bf-a9a4-bb3b2b4625ef"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "d8920282-3881-43bf-a9a4-bb3b2b4625ef"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210519T204610Z:d8920282-3881-43bf-a9a4-bb3b2b4625ef"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 19 May 2021 20:46:09 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-19T20:46:09.806Z",
+        "time": 337,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 337
+        }
+      },
+      {
+        "_id": "c7583000977f43a8dbbafed25d56ebfe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "36edb82c-275a-451d-b66d-fa8e8040527a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 915,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\",\"details\":{\"version\":1,\"updatedTime\":\"2020-10-29T19:47:34.6298765Z\",\"updatedBy\":\"Tenant Backfill Job\"},\"children\":[{\"id\":\"/providers/Microsoft.Management/managementGroups/ndowmon-j1dev\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"ndowmon-j1dev\",\"displayName\":\"Nick's J1 Dev Management Group\"},{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"displayName\":\"ParentGroup\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "88412675-947e-4a82-a4a6-48e539506f27"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:88412675-947e-4a82-a4a6-48e539506f27"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "88412675-947e-4a82-a4a6-48e539506f27"
+            },
+            {
+              "name": "request-id",
+              "value": "88412675-947e-4a82-a4a6-48e539506f27"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210519T204610Z:88412675-947e-4a82-a4a6-48e539506f27"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 19 May 2021 20:46:09 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-19T20:46:10.156Z",
+        "time": 390,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 390
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/management-groups/__recordings__/rm-management-groups_1477189011/recording.har
+++ b/src/steps/resource-manager/management-groups/__recordings__/rm-management-groups_1477189011/recording.har
@@ -1,0 +1,1546 @@
+{
+  "log": {
+    "_recordingName": "rm-management-groups",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "b5aa9419-7825-4dca-8408-224fb98cb6da"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1621526512\",\"not_before\":\"1621522612\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-19T15:01:52.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "b5aa9419-7825-4dca-8408-224fb98cb6da"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7d0842b9-35eb-41f5-8aef-0e9271253d00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11774.8 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:51 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:52.360Z",
+        "time": 320,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 320
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "6e45e4a0-e5c2-45be-9bd6-809c1f611b23"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "4d859374-9ec0-425e-8324-6eed083e5015"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "4d859374-9ec0-425e-8324-6eed083e5015"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150153Z:4d859374-9ec0-425e-8324-6eed083e5015"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:52.716Z",
+        "time": 608,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 608
+        }
+      },
+      {
+        "_id": "c7583000977f43a8dbbafed25d56ebfe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ead94abc-468c-4840-a4cb-15b7803ad851"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 915,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\",\"details\":{\"version\":1,\"updatedTime\":\"2020-10-29T19:47:34.6298765Z\",\"updatedBy\":\"Tenant Backfill Job\"},\"children\":[{\"id\":\"/providers/Microsoft.Management/managementGroups/ndowmon-j1dev\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"ndowmon-j1dev\",\"displayName\":\"Nick's J1 Dev Management Group\"},{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"displayName\":\"ParentGroup\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "69c3d0c0-1c08-4c41-8320-f81c91d3cf95"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:69c3d0c0-1c08-4c41-8320-f81c91d3cf95"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "69c3d0c0-1c08-4c41-8320-f81c91d3cf95"
+            },
+            {
+              "name": "request-id",
+              "value": "69c3d0c0-1c08-4c41-8320-f81c91d3cf95"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150153Z:69c3d0c0-1c08-4c41-8320-f81c91d3cf95"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:53.338Z",
+        "time": 261,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 261
+        }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "83a858d1-1e0b-46b3-8e8a-807b0f1f1fba"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1621526513\",\"not_before\":\"1621522613\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-19T15:01:53.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "83a858d1-1e0b-46b3-8e8a-807b0f1f1fba"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "55220603-387f-42c8-af4a-2167c2d56d00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11722.21 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:53.607Z",
+        "time": 475,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 475
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3cff49fc-26e8-45ea-95f4-6d52709b05db"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0633603f-568a-46a0-9b01-517fbfeb078c"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "0633603f-568a-46a0-9b01-517fbfeb078c"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150154Z:0633603f-568a-46a0-9b01-517fbfeb078c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:54.087Z",
+        "time": 260,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 260
+        }
+      },
+      {
+        "_id": "c7583000977f43a8dbbafed25d56ebfe",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9e8ed218-2563-4f4b-9bc7-5b6a44dee6fb"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 915,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\",\"details\":{\"version\":1,\"updatedTime\":\"2020-10-29T19:47:34.6298765Z\",\"updatedBy\":\"Tenant Backfill Job\"},\"children\":[{\"id\":\"/providers/Microsoft.Management/managementGroups/ndowmon-j1dev\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"ndowmon-j1dev\",\"displayName\":\"Nick's J1 Dev Management Group\"},{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"displayName\":\"ParentGroup\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "ccf25745-4f1e-43cd-bd95-2c89350682c3"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:ccf25745-4f1e-43cd-bd95-2c89350682c3"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "ccf25745-4f1e-43cd-bd95-2c89350682c3"
+            },
+            {
+              "name": "request-id",
+              "value": "ccf25745-4f1e-43cd-bd95-2c89350682c3"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150154Z:ccf25745-4f1e-43cd-bd95-2c89350682c3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:54.353Z",
+        "time": 276,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 276
+        }
+      },
+      {
+        "_id": "8eecb3c01d017c73eaff464c63446de0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "cf6a1ea0-c1ed-4c7b-b410-9a2b398a693d"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1834,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/ndowmon-j1dev?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 1025,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1025,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/ndowmon-j1dev\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"ndowmon-j1dev\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Nick's J1 Dev Management Group\",\"details\":{\"version\":1,\"updatedTime\":\"2020-10-29T19:47:53.1144308Z\",\"updatedBy\":\"b6e7f627-8731-47bd-be0e-477d1cbc6e17\",\"parent\":{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\"}},\"children\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"type\":\"/subscriptions\",\"name\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "27af94c3-00ea-474f-a7e3-bb9fdcbc606b"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:27af94c3-00ea-474f-a7e3-bb9fdcbc606b"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "27af94c3-00ea-474f-a7e3-bb9fdcbc606b"
+            },
+            {
+              "name": "request-id",
+              "value": "27af94c3-00ea-474f-a7e3-bb9fdcbc606b"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150154Z:27af94c3-00ea-474f-a7e3-bb9fdcbc606b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:54 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:54.638Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
+        }
+      },
+      {
+        "_id": "12ba07f55bc25f7419bb9c565b10e7cb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5658e534-0410-4c47-a806-ee387faf5025"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 987,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 987,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"ParentGroup\",\"details\":{\"version\":1,\"updatedTime\":\"2021-05-19T20:03:28.7774342Z\",\"updatedBy\":\"64242f8f-67ee-4f0c-b644-0766b42e8e91\",\"parent\":{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\"}},\"children\":[{\"id\":\"/providers/Microsoft.Management/managementGroups/48b1f1a0-95d9-46f7-ab81-a22bd971bd71\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"48b1f1a0-95d9-46f7-ab81-a22bd971bd71\",\"displayName\":\"ChildGroup\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "3860ece8-fd17-439b-bf76-04dc5ecc3688"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:3860ece8-fd17-439b-bf76-04dc5ecc3688"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "3860ece8-fd17-439b-bf76-04dc5ecc3688"
+            },
+            {
+              "name": "request-id",
+              "value": "3860ece8-fd17-439b-bf76-04dc5ecc3688"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150155Z:3860ece8-fd17-439b-bf76-04dc5ecc3688"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:54 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:54.916Z",
+        "time": 252,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 252
+        }
+      },
+      {
+        "_id": "c144b08a4dda56a211d1fbb25fa5d9e0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9b4cdb78-d70f-4d82-92e1-dd2af6b13056"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/48b1f1a0-95d9-46f7-ab81-a22bd971bd71?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 941,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 941,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/48b1f1a0-95d9-46f7-ab81-a22bd971bd71\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"48b1f1a0-95d9-46f7-ab81-a22bd971bd71\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"ChildGroup\",\"details\":{\"version\":1,\"updatedTime\":\"2021-05-19T20:37:33.7681621Z\",\"updatedBy\":\"64242f8f-67ee-4f0c-b644-0766b42e8e91\",\"parent\":{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"displayName\":\"ParentGroup\"}},\"children\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5aced328-5e14-4559-ab8c-d3919ac3f62b"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:5aced328-5e14-4559-ab8c-d3919ac3f62b"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "5aced328-5e14-4559-ab8c-d3919ac3f62b"
+            },
+            {
+              "name": "request-id",
+              "value": "5aced328-5e14-4559-ab8c-d3919ac3f62b"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T150155Z:5aced328-5e14-4559-ab8c-d3919ac3f62b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:01:55 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:01:55.175Z",
+        "time": 324,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 324
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/management-groups/__recordings__/validateManagementGroupStepInvocation-badCredentials_2778872183/recording.har
+++ b/src/steps/resource-manager/management-groups/__recordings__/validateManagementGroupStepInvocation-badCredentials_2778872183/recording.har
@@ -1,0 +1,513 @@
+{
+  "log": {
+    "_recordingName": "validateManagementGroupStepInvocation#badCredentials",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "686b0b8c-85fe-4d02-b857-17bd76bf5f11"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1621528169\",\"not_before\":\"1621524269\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-19T15:29:29.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "686b0b8c-85fe-4d02-b857-17bd76bf5f11"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "add35c1d-2f4a-4228-b788-64486951c900"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11722.21 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:29:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:29:29.103Z",
+        "time": 252,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 252
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ca7af46a-ffd0-45db-853d-656369815b3a"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 133,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 133,
+            "text": "{\"value\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "b5ca5a12-8cba-45cb-939f-db0dfb77ce32"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "b5ca5a12-8cba-45cb-939f-db0dfb77ce32"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T152929Z:b5ca5a12-8cba-45cb-939f-db0dfb77ce32"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:29:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "133"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:29:29.359Z",
+        "time": 275,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 275
+        }
+      },
+      {
+        "_id": "c7583000977f43a8dbbafed25d56ebfe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e3d52c2c-0ce5-4069-b5eb-a6a00199e5ed"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 436,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 436,
+            "text": "{\"error\":{\"code\":\"AuthorizationFailed\",\"message\":\"The client '61715bd4-dc30-4496-a937-b247655936b3' with object id '61715bd4-dc30-4496-a937-b247655936b3' does not have authorization to perform action 'Microsoft.Management/managementGroups/read' over scope '/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab' or the scope is invalid. If access was recently granted, please refresh your credentials.\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "x-ms-failure-cause",
+              "value": "gateway"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1e5b67ed-9790-4ba5-a6cc-6d79d5e57058"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "1e5b67ed-9790-4ba5-a6cc-6d79d5e57058"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T152929Z:1e5b67ed-9790-4ba5-a6cc-6d79d5e57058"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:29:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "436"
+            }
+          ],
+          "headersSize": 520,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 403,
+          "statusText": "Forbidden"
+        },
+        "startedDateTime": "2021-05-20T15:29:29.640Z",
+        "time": 277,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 277
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/management-groups/__recordings__/validateManagementGroupStepInvocation-success_1089248527/recording.har
+++ b/src/steps/resource-manager/management-groups/__recordings__/validateManagementGroupStepInvocation-success_1089248527/recording.har
@@ -1,0 +1,525 @@
+{
+  "log": {
+    "_recordingName": "validateManagementGroupStepInvocation#success",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "e3b1b051-6d01-4b50-b5b7-f5aca0c211a1"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1621527879\",\"not_before\":\"1621523979\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-06-19T15:24:39.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "e3b1b051-6d01-4b50-b5b7-f5aca0c211a1"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "31af5285-5677-4eed-81b9-d41d24a13c00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11774.8 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:24:38 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:24:39.303Z",
+        "time": 294,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 294
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5f002dbc-41ad-47cb-8095-d73d8bd6ef3b"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 358,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 358,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "79a91bb6-7ac3-4cc0-bdec-025eddcd2fc2"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "79a91bb6-7ac3-4cc0-bdec-025eddcd2fc2"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T152439Z:79a91bb6-7ac3-4cc0-bdec-025eddcd2fc2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:24:39 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "358"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:24:39.601Z",
+        "time": 340,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 340
+        }
+      },
+      {
+        "_id": "c7583000977f43a8dbbafed25d56ebfe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "89143412-2759-4634-8fc7-031c8ce5769d"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-managementgroups/0.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1857,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2018-03-01-preview"
+            },
+            {
+              "name": "$expand",
+              "value": "children"
+            }
+          ],
+          "url": "https://management.azure.com/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab?api-version=2018-03-01-preview&%24expand=children"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 915,
+            "text": "{\"id\":\"/providers/Microsoft.Management/managementGroups/992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"properties\":{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"displayName\":\"Tenant Root Group\",\"details\":{\"version\":1,\"updatedTime\":\"2020-10-29T19:47:34.6298765Z\",\"updatedBy\":\"Tenant Backfill Job\"},\"children\":[{\"id\":\"/providers/Microsoft.Management/managementGroups/ndowmon-j1dev\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"ndowmon-j1dev\",\"displayName\":\"Nick's J1 Dev Management Group\"},{\"id\":\"/providers/Microsoft.Management/managementGroups/627d706f-40c0-4dff-8421-be284de0073c\",\"type\":\"/providers/Microsoft.Management/managementGroups\",\"name\":\"627d706f-40c0-4dff-8421-be284de0073c\",\"displayName\":\"ParentGroup\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "539bc827-2b12-4762-80e3-00a4316d3918"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "centralus:539bc827-2b12-4762-80e3-00a4316d3918"
+            },
+            {
+              "name": "x-ba-restapi",
+              "value": "1.0.3.1624"
+            },
+            {
+              "name": "client-request-id",
+              "value": "539bc827-2b12-4762-80e3-00a4316d3918"
+            },
+            {
+              "name": "request-id",
+              "value": "539bc827-2b12-4762-80e3-00a4316d3918"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210520T152440Z:539bc827-2b12-4762-80e3-00a4316d3918"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 20 May 2021 15:24:39 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-20T15:24:39.948Z",
+        "time": 252,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 252
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/management-groups/client.test.ts
+++ b/src/steps/resource-manager/management-groups/client.test.ts
@@ -1,0 +1,42 @@
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+
+import {
+  getMatchRequestsBy,
+  Recording,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { ManagementGroupClient } from './client';
+import { configFromEnv } from '../../../../test/integrationInstanceConfig';
+
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) {
+    await recording.stop();
+  }
+});
+
+describe('getManagementGroup', () => {
+  test('all', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'getManagementGroup',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const client = new ManagementGroupClient(
+      configFromEnv,
+      createMockIntegrationLogger(),
+    );
+
+    /**
+     * The default management group for a tenant ("Tenant Root Group") shares the same ID as the tenant/directory ID.
+     */
+    const managementGroup = await client.getManagementGroup(
+      configFromEnv.directoryId,
+    );
+    expect(managementGroup.children?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/steps/resource-manager/management-groups/client.ts
+++ b/src/steps/resource-manager/management-groups/client.ts
@@ -1,0 +1,25 @@
+import {
+  ManagementGroups,
+  ManagementGroupsAPIContext,
+} from '@azure/arm-managementgroups';
+import { ManagementGroup } from '@azure/arm-managementgroups/esm/models';
+import { Client } from '../../../azure/resource-manager/client';
+
+export class ManagementGroupClient extends Client {
+  public async getManagementGroup(
+    managementGroupId: string,
+  ): Promise<ManagementGroup> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      ManagementGroupsAPIContext,
+      {
+        passSubscriptionId: false,
+      },
+    );
+
+    const managementGroups = new ManagementGroups(serviceClient);
+
+    return managementGroups.get(managementGroupId, {
+      expand: 'children',
+    });
+  }
+}

--- a/src/steps/resource-manager/management-groups/constants.ts
+++ b/src/steps/resource-manager/management-groups/constants.ts
@@ -1,0 +1,29 @@
+import { RelationshipClass } from '@jupiterone/integration-sdk-core';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+
+export const steps = {
+  MANAGEMENT_GROUPS: 'rm-management-groups',
+};
+
+export const entities = {
+  MANAGEMENT_GROUP: {
+    _type: 'azure_management_group',
+    _class: ['Group'],
+    resourceName: '[RM] Management Group',
+  },
+};
+
+export const relationships = {
+  ACCOUNT_CONTAINS_ROOT_MANAGEMENT_GROUP: {
+    _type: 'azure_account_contains_management_group',
+    sourceType: ACCOUNT_ENTITY_TYPE,
+    _class: RelationshipClass.HAS,
+    targetType: entities.MANAGEMENT_GROUP._type,
+  },
+  MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP: {
+    _type: 'azure_management_group_contains_group',
+    sourceType: entities.MANAGEMENT_GROUP._type,
+    _class: RelationshipClass.CONTAINS,
+    targetType: entities.MANAGEMENT_GROUP._type,
+  },
+};

--- a/src/steps/resource-manager/management-groups/constants.ts
+++ b/src/steps/resource-manager/management-groups/constants.ts
@@ -1,11 +1,11 @@
 import { RelationshipClass } from '@jupiterone/integration-sdk-core';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
 
-export const steps = {
+export const ManagementGroupSteps = {
   MANAGEMENT_GROUPS: 'rm-management-groups',
 };
 
-export const entities = {
+export const ManagementGroupEntities = {
   MANAGEMENT_GROUP: {
     _type: 'azure_management_group',
     _class: ['Group'],
@@ -13,17 +13,17 @@ export const entities = {
   },
 };
 
-export const relationships = {
-  ACCOUNT_CONTAINS_ROOT_MANAGEMENT_GROUP: {
-    _type: 'azure_account_contains_management_group',
+export const ManagementGroupRelationships = {
+  ACCOUNT_HAS_ROOT_MANAGEMENT_GROUP: {
+    _type: 'azure_account_has_management_group',
     sourceType: ACCOUNT_ENTITY_TYPE,
     _class: RelationshipClass.HAS,
-    targetType: entities.MANAGEMENT_GROUP._type,
+    targetType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
   },
   MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP: {
     _type: 'azure_management_group_contains_group',
-    sourceType: entities.MANAGEMENT_GROUP._type,
+    sourceType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
     _class: RelationshipClass.CONTAINS,
-    targetType: entities.MANAGEMENT_GROUP._type,
+    targetType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
   },
 };

--- a/src/steps/resource-manager/management-groups/converters.ts
+++ b/src/steps/resource-manager/management-groups/converters.ts
@@ -4,7 +4,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker } from '../../../azure';
-import { entities } from './constants';
+import { ManagementGroupEntities } from './constants';
 import { ManagementGroup } from '@azure/arm-managementgroups/esm/models';
 
 export function createManagementGroupEntity(
@@ -16,8 +16,8 @@ export function createManagementGroupEntity(
       source: data,
       assign: {
         _key: data.id as string,
-        _type: entities.MANAGEMENT_GROUP._type,
-        _class: entities.MANAGEMENT_GROUP._class,
+        _type: ManagementGroupEntities.MANAGEMENT_GROUP._type,
+        _class: ManagementGroupEntities.MANAGEMENT_GROUP._class,
         id: data.id,
         type: data.type,
         name: data.name,

--- a/src/steps/resource-manager/management-groups/converters.ts
+++ b/src/steps/resource-manager/management-groups/converters.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  createIntegrationEntity,
+} from '@jupiterone/integration-sdk-core';
+
+import { AzureWebLinker } from '../../../azure';
+import { entities } from './constants';
+import { ManagementGroup } from '@azure/arm-managementgroups/esm/models';
+
+export function createManagementGroupEntity(
+  webLinker: AzureWebLinker,
+  data: ManagementGroup,
+): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: data.id as string,
+        _type: entities.MANAGEMENT_GROUP._type,
+        _class: entities.MANAGEMENT_GROUP._class,
+        id: data.id,
+        type: data.type,
+        name: data.name,
+        tenantId: data.tenantId,
+        displayName: data.displayName,
+        webLink: webLinker.portalResourceUrl(data.id),
+      },
+    },
+  });
+}

--- a/src/steps/resource-manager/management-groups/index.test.ts
+++ b/src/steps/resource-manager/management-groups/index.test.ts
@@ -72,7 +72,7 @@ describe('rm-management-groups', () => {
     };
   }
 
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-management-groups',

--- a/src/steps/resource-manager/management-groups/index.test.ts
+++ b/src/steps/resource-manager/management-groups/index.test.ts
@@ -1,0 +1,120 @@
+import { Recording } from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig } from '../../../types';
+import {
+  getMatchRequestsBy,
+  setupAzureRecording,
+} from '../../../../test/helpers/recording';
+import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { fetchManagementGroups } from '.';
+import { configFromEnv } from '../../../../test/integrationInstanceConfig';
+import { getMockAccountEntity } from '../../../../test/helpers/getMockEntity';
+import {
+  ManagementGroupEntities,
+  ManagementGroupRelationships,
+} from './constants';
+import { Relationship } from '@jupiterone/integration-sdk-core';
+import { filterGraphObjects } from '../../../../test/helpers/filterGraphObjects';
+
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) {
+    await recording.stop();
+  }
+});
+
+describe('rm-management-groups', () => {
+  function getSetupEntities(config: IntegrationConfig) {
+    const accountEntity = getMockAccountEntity(config);
+
+    return { accountEntity };
+  }
+
+  function separateManagementGroupRelationships(
+    collectedRelationships: Relationship[],
+  ) {
+    const {
+      targets: mappedRelationships,
+      rest: restAfterMapped,
+    } = filterGraphObjects(
+      collectedRelationships,
+      (r) => r._mapping !== undefined,
+    );
+    const {
+      targets: accountManagementGroupRelationships,
+      rest: restAfterAccountGroup,
+    } = filterGraphObjects(
+      restAfterMapped,
+      (r) =>
+        r._type ===
+        ManagementGroupRelationships.ACCOUNT_HAS_ROOT_MANAGEMENT_GROUP._type,
+    );
+    const {
+      targets: managementGroupGroupRelationships,
+      rest: restAfterGroupGroup,
+    } = filterGraphObjects(
+      restAfterAccountGroup,
+      (r) =>
+        r._type ===
+        ManagementGroupRelationships.MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP
+          ._type,
+    );
+
+    return {
+      mappedRelationships,
+      accountManagementGroupRelationships,
+      managementGroupGroupRelationships,
+      rest: restAfterGroupGroup,
+    };
+  }
+
+  test('sucess', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'rm-management-groups',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+      },
+    });
+
+    const { accountEntity } = getSetupEntities(configFromEnv);
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: configFromEnv,
+      entities: [accountEntity],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: accountEntity,
+      },
+    });
+
+    await fetchManagementGroups(context);
+
+    const managementGroupEntities = context.jobState.collectedEntities;
+
+    // Require 2 or more management group entities to ensure that recursion works as expected.
+    expect(managementGroupEntities.length).toBeGreaterThan(1);
+    expect(managementGroupEntities).toMatchGraphObjectSchema({
+      _class: ManagementGroupEntities.MANAGEMENT_GROUP._class,
+    });
+
+    const {
+      accountManagementGroupRelationships,
+      managementGroupGroupRelationships,
+      mappedRelationships: managementGroupSubscriptionRelationships,
+      rest: restRelationships,
+    } = separateManagementGroupRelationships(
+      context.jobState.collectedRelationships,
+    );
+
+    // There should be exactly 1 relationship between management group + account - the Tenant Root Group
+    expect(accountManagementGroupRelationships).toHaveLength(1);
+    // Every management group _except 1_ (the Tenant Root Group) has a parent.
+    expect(managementGroupGroupRelationships).toHaveLength(
+      managementGroupEntities.length - 1,
+    );
+    // Require at least 1 management group to ensure mapped relationships work.
+    expect(managementGroupSubscriptionRelationships.length).toBeGreaterThan(0);
+    expect(restRelationships).toHaveLength(0);
+  });
+});

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -1,0 +1,147 @@
+import {
+  Step,
+  IntegrationStepExecutionContext,
+  createDirectRelationship,
+  RelationshipClass,
+  createMappedRelationship,
+  RelationshipDirection,
+  IntegrationExecutionContext,
+  IntegrationProviderAuthorizationError,
+} from '@jupiterone/integration-sdk-core';
+
+import { AzureWebLinker, createAzureWebLinker } from '../../../azure';
+import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { ManagementGroupClient } from './client';
+import { entities, relationships, steps } from './constants';
+import { entities as SubscriptionEntities } from '../subscriptions/constants';
+import { createManagementGroupEntity } from './converters';
+
+export async function fetchManagementGroups(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  await validateManagementGroupStepInvocation(executionContext);
+
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await getAccountEntity(jobState);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new ManagementGroupClient(instance.config, logger);
+
+  const {
+    managementGroupEntity: tenantRootManagementGroupEntity,
+  } = await getGraphObjectsForManagementGroup({
+    webLinker,
+    executionContext,
+    client,
+    managementGroupId: instance.config.directoryId,
+  });
+
+  await jobState.addRelationship(
+    createDirectRelationship({
+      from: accountEntity,
+      _class: RelationshipClass.HAS,
+      to: tenantRootManagementGroupEntity,
+    }),
+  );
+}
+
+export async function validateManagementGroupStepInvocation(
+  context: IntegrationExecutionContext<IntegrationConfig>,
+) {
+  const client = new ManagementGroupClient(
+    context.instance.config,
+    context.logger,
+  );
+  const tenantId = context.instance.config.directoryId;
+  try {
+    await client.getManagementGroup(tenantId);
+  } catch (err) {
+    context.logger.publishEvent({
+      name: 'mgmt_group_auth_error',
+      description: `Error validating call to fetch the Tenant Root Management Group (https://management.azure.com/providers/Microsoft.Management/managementGroups/${tenantId}). Please grant the "Managemnt Group Reader" role on the Tenant Root Group in order to fetch management group entities/relationships.`,
+    });
+    throw new IntegrationProviderAuthorizationError({
+      cause: err,
+      status: err.status || err.code,
+      statusText: err.statusText || err.message,
+      endpoint: `https://management.azure.com/providers/Microsoft.Management/managementGroups/${tenantId}`,
+    });
+  }
+}
+
+export async function getGraphObjectsForManagementGroup(options: {
+  managementGroupId: string;
+  client: ManagementGroupClient;
+  executionContext: IntegrationStepContext;
+  webLinker: AzureWebLinker;
+}) {
+  const { client, managementGroupId, executionContext, webLinker } = options;
+  const { jobState, logger } = executionContext;
+  const managementGroup = await client.getManagementGroup(managementGroupId);
+
+  const managementGroupEntity = await jobState.addEntity(
+    createManagementGroupEntity(webLinker, managementGroup),
+  );
+
+  for (const child of managementGroup.children || []) {
+    if (child.type === '/providers/Microsoft.Management/managementGroups') {
+      const {
+        managementGroupEntity: childManagementGroupEntity,
+      } = await getGraphObjectsForManagementGroup({
+        ...options,
+        managementGroupId: child.name!,
+      });
+      await jobState.addRelationship(
+        createDirectRelationship({
+          from: managementGroupEntity,
+          _class: RelationshipClass.CONTAINS,
+          to: childManagementGroupEntity,
+        }),
+      );
+    } else if (child.type === '/subscriptions') {
+      await jobState.addRelationship(
+        createMappedRelationship({
+          _class: RelationshipClass.HAS,
+          _mapping: {
+            sourceEntityKey: managementGroupEntity._key,
+            relationshipDirection: RelationshipDirection.FORWARD,
+            targetFilterKeys: [['_type', 'id']],
+            targetEntity: {
+              _type: SubscriptionEntities.SUBSCRIPTION._type,
+              id: child.id,
+              name: child.name,
+              displayName: child.displayName,
+            },
+          },
+        }),
+      );
+    } else {
+      logger.warn(
+        {
+          managementGroupId: managementGroup.id,
+          childId: child.id,
+          childType: child.type,
+        },
+        'Unrecognized value for `type` on management group child.',
+      );
+    }
+  }
+
+  return { managementGroup, managementGroupEntity };
+}
+
+export const managementGroupSteps: Step<
+  IntegrationStepExecutionContext<IntegrationConfig>
+>[] = [
+  {
+    id: steps.MANAGEMENT_GROUPS,
+    name: 'Management Groups',
+    entities: [entities.MANAGEMENT_GROUP],
+    relationships: [
+      relationships.ACCOUNT_CONTAINS_ROOT_MANAGEMENT_GROUP,
+      relationships.MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP,
+    ], // TODO add support for mapped relationship documentation
+    dependsOn: [STEP_AD_ACCOUNT],
+    executionHandler: fetchManagementGroups,
+  },
+];

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -13,7 +13,11 @@ import { AzureWebLinker, createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
 import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
 import { ManagementGroupClient } from './client';
-import { entities, relationships, steps } from './constants';
+import {
+  ManagementGroupEntities,
+  ManagementGroupRelationships,
+  ManagementGroupSteps,
+} from './constants';
 import { entities as SubscriptionEntities } from '../subscriptions/constants';
 import { createManagementGroupEntity } from './converters';
 
@@ -134,12 +138,12 @@ export const managementGroupSteps: Step<
   IntegrationStepExecutionContext<IntegrationConfig>
 >[] = [
   {
-    id: steps.MANAGEMENT_GROUPS,
+    id: ManagementGroupSteps.MANAGEMENT_GROUPS,
     name: 'Management Groups',
-    entities: [entities.MANAGEMENT_GROUP],
+    entities: [ManagementGroupEntities.MANAGEMENT_GROUP],
     relationships: [
-      relationships.ACCOUNT_CONTAINS_ROOT_MANAGEMENT_GROUP,
-      relationships.MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP,
+      ManagementGroupRelationships.ACCOUNT_HAS_ROOT_MANAGEMENT_GROUP,
+      ManagementGroupRelationships.MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP,
     ], // TODO add support for mapped relationship documentation
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchManagementGroups,

--- a/src/steps/resource-manager/policy-insights/index.test.ts
+++ b/src/steps/resource-manager/policy-insights/index.test.ts
@@ -36,7 +36,7 @@ describe('rm-policy-states-for-subscription', () => {
 
     return { accountEntity };
   }
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-policy-states-for-subscription',
@@ -92,7 +92,7 @@ describe('rm-policy-state-to-policy-assignment-relationships', () => {
 
     return { accountEntity, policyStateEntities, policyAssignmentEntities };
   }
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-policy-state-to-policy-assignment-relationships',
@@ -164,7 +164,7 @@ describe('rm-policy-state-to-policy-definition-relationships', () => {
 
     return { accountEntity, policyStateEntities, policyDefinitionEntities };
   }
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-policy-state-to-policy-definition-relationships',
@@ -235,7 +235,7 @@ describe('rm-policy-state-to-resource-relationships', () => {
 
     return { accountEntity, policyStateEntities, keyVaultEntities };
   }
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-policy-state-to-resource-relationships',

--- a/src/steps/resource-manager/policy/index.test.ts
+++ b/src/steps/resource-manager/policy/index.test.ts
@@ -30,7 +30,7 @@ describe('rm-policy-assignments', () => {
 
     return { accountEntity };
   }
-  test('sucess', async () => {
+  test('success', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-policy-assignments',

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,4 +58,6 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
    * instances.
    */
   ingestActiveDirectory?: boolean;
+
+  ingestManagementGroups?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,5 +59,5 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
    */
   ingestActiveDirectory?: boolean;
 
-  ingestManagementGroups?: boolean;
+  configureSubscriptionInstances?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,6 +126,15 @@
     "@azure/ms-rest-js" "^1.8.1"
     tslib "^1.9.3"
 
+"@azure/arm-managementgroups@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@azure/arm-managementgroups/-/arm-managementgroups-1.1.0.tgz#2ef8979e0fd34264f8cc8f801ddee828a924dca3"
+  integrity sha512-QWqWAjcIH9cNSlXa6Onem5kguyoECpZusjwuFG2co51wwZck5EPcbDSIzTHYPks28WfuE1JAymZmPYqdzGJPCg==
+  dependencies:
+    "@azure/ms-rest-azure-js" "^1.1.0"
+    "@azure/ms-rest-js" "^1.1.0"
+    tslib "^1.9.3"
+
 "@azure/arm-mariadb@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@azure/arm-mariadb/-/arm-mariadb-1.4.0.tgz#a049e0b35a1f8411df0ce483b8d704fe4d7ec599"


### PR DESCRIPTION
This introduces a new config field `ingestManagementGroups` that should be used like the `ingestActiveDirectory` config field. However, it may be best to remove `intestManagementGroups` and just ingest them when `ingestActiveDirectory` is set to `true`.

Here's a look at the management group structure in Azure:
![Screen Shot 2021-05-20 at 11 45 28 AM](https://user-images.githubusercontent.com/15333061/119009576-42e1e980-b961-11eb-8a60-8ebf8c9b8deb.png)

![Screen Shot 2021-05-20 at 11 44 52 AM](https://user-images.githubusercontent.com/15333061/119009553-3c537200-b961-11eb-95e8-c588aeedc3ea.png)
