### PR TITLE
Change the azure_policy_state._key suffix to :latest instead of :${ti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Changed
 
+- Changed the policy definition `_key` suffix to `:latest` instead of
+  `:${timestamp}` to reduce policy state churn during integration invocations.
 - Previously, JupiterOne created direct relationships between active directory
   entities and role assignments when active directory entities were ingested in
   the same integration as subscription entities. In an effort to ensure

--- a/src/steps/resource-manager/policy-insights/converters.ts
+++ b/src/steps/resource-manager/policy-insights/converters.ts
@@ -7,19 +7,24 @@ import {
 import { PolicyInsightEntities } from './constants';
 import { PolicyState } from '@azure/arm-policyinsights/esm/models';
 
-export function getPolicyStateKey(data: PolicyState) {
-  return `${data.policyAssignmentId}:${data.policyDefinitionId}:${data.resourceId}:${data.policyDefinitionReferenceId}:${data.timestamp}`;
+export function getPolicyStateKey(data: PolicyState, isLatest: boolean) {
+  return `${data.policyAssignmentId}:${data.policyDefinitionId}:${
+    data.resourceId
+  }:${data.policyDefinitionReferenceId}:${
+    isLatest ? 'latest' : data.timestamp
+  }`;
 }
 
 export function createPolicyStateEntity(
   webLinker: AzureWebLinker,
   data: PolicyState,
+  isLatest: boolean,
 ): Entity {
   return createIntegrationEntity({
     entityData: {
       source: data,
       assign: {
-        _key: getPolicyStateKey(data),
+        _key: getPolicyStateKey(data, isLatest),
         _type: PolicyInsightEntities.POLICY_STATE._type,
         _class: PolicyInsightEntities.POLICY_STATE._class,
         name: data.policyDefinitionReferenceId,

--- a/src/steps/resource-manager/policy-insights/index.ts
+++ b/src/steps/resource-manager/policy-insights/index.ts
@@ -28,7 +28,9 @@ export async function fetchLatestPolicyStatesForSubscription(
   const client = new AzurePolicyInsightsClient(instance.config, logger);
 
   await client.iterateLatestPolicyStatesForSubscription(async (policyState) => {
-    await jobState.addEntity(createPolicyStateEntity(webLinker, policyState));
+    await jobState.addEntity(
+      createPolicyStateEntity(webLinker, policyState, true),
+    );
   });
 }
 


### PR DESCRIPTION
```
### Changed

- Changed the policy definition `_key` suffix to `:latest` instead of
  `:${timestamp}` to reduce policy state churn during integration invocations.
```

A recent job where virtually nothing changed in the implementation: 

```
(10:11:44 AM) - [sync_scheduled] - Scheduled the synchronization of uploaded data (Uploaded entity count=1780, Uploaded relationship count=2851)
(10:11:44 AM) - [sync_entities_start] - Synchronizing entities
(10:12:58 AM) - [sync_entities_end] - Successfully synchronized entities (Entities created = 522, Entities updated = 110, Entities deleted = 517)
(10:12:58 AM) - [sync_relationships_start] - Synchronizing relationships
(10:14:04 AM) - [sync_relationships_end] - Successfully synchronized relationships (Relationships created = 1499, Relationships updated = 4, Relationships deleted = 1494)
(10:14:05 AM) - [job_end] - Job for integration Azure has ended.
```