### PR TITLE
Add ad-account step dep to classic admins step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug introduced in `5.25.1` where the
+  `rm-authorization-classic-administrators` step no longer had a dependency on
+  the `ad-account` step, causing `ACCOUNT_ENTITY_NOT_FOUND` errors.
+
 ## 5.26.0 - 2021-06-01
 
 ### Added

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -296,7 +296,7 @@ export const authorizationSteps: Step<
     name: 'Classic Administrators',
     entities: [entities.CLASSIC_ADMIN],
     relationships: [relationships.CLASSIC_ADMIN_GROUP_HAS_USER],
-    dependsOn: [],
+    dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchClassicAdministrators,
   },
 ];


### PR DESCRIPTION
```
### Fixed

- Fixed a bug introduced in `5.25.1` where the
  `rm-authorization-classic-administrators` step no longer had a dependency on
  the `ad-account` step, causing `ACCOUNT_ENTITY_NOT_FOUND` errors.
```