### PR TITLE
Changelog for 5.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+### 5.26.1 - 2021-06-01
+
 ### Fixed
 
 - Fixed a bug introduced in `5.25.1` where the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.26.0",
+  "version": "5.26.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",


### PR DESCRIPTION
```
### 5.26.1 - 2021-06-01

### Fixed

- Fixed a bug introduced in `5.25.1` where the
  `rm-authorization-classic-administrators` step no longer had a dependency on
  the `ad-account` step, causing `ACCOUNT_ENTITY_NOT_FOUND` errors.
```