### PR TITLE
Fix compute galleries step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
   | `azure_policy_definition` | Automatically convert `metadata` to J1 tags |
   | `azure_policy_definition` | `accountEnabled`                            |
 
+### Changed
+
+- Fixed a bug where the compute galleries execution handler was not invoked, and
+  instead the VM images execution handler was invoked twice. This caused
+  DuplicateKeyErrors in either the compute galleries step or the VM images step.
+
 ### 5.27.1 - 2021-06-02
 
 ### Changed

--- a/src/steps/resource-manager/compute/index.ts
+++ b/src/steps/resource-manager/compute/index.ts
@@ -550,7 +550,7 @@ export const computeSteps: Step<
     entities: [entities.GALLERY],
     relationships: [relationships.RESOURCE_GROUP_HAS_GALLERY],
     dependsOn: [STEP_RM_RESOURCES_RESOURCE_GROUPS],
-    executionHandler: fetchVirtualMachineImages,
+    executionHandler: fetchGalleries,
   },
   {
     id: steps.SHARED_IMAGES,


### PR DESCRIPTION
Fixes #374 

```
### Changed

- Fixed a bug where the compute galleries execution handler was not invoked, and
  instead the VM images execution handler was invoked twice. This caused
  DuplicateKeyErrors in either the compute galleries step or the VM images step.
```