### PR TITLE
387 vm shared image version relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
   | Source               | \_class | Target                       |
   | -------------------- | ------- | ---------------------------- |
   | `azure_shared_image` | `HAS`   | `azure_shared_image_version` |
+  | `azure_vm`           | `USES`  | `azure_shared_image_version` |
 
 - New properties added to resources:
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -391,6 +391,7 @@ The following relationships are created/mapped:
 | `azure_vm`                         | **USES**              | `azure_nic`                                       |
 | `azure_vm`                         | **USES**              | `azure_public_ip`                                 |
 | `azure_vm`                         | **USES**              | `azure_shared_image`                              |
+| `azure_vm`                         | **USES**              | `azure_shared_image_version`                      |
 | `azure_vm`                         | **USES**              | `azure_storage_account`                           |
 | `azure_vnet`                       | **CONTAINS**          | `azure_subnet`                                    |
 | `azure_web_app`                    | **USES**              | `azure_app_service_plan`                          |

--- a/src/steps/resource-manager/compute/__recordings__/rm-compute-virtual-machine-image-relationships_3626092588/recording.har
+++ b/src/steps/resource-manager/compute/__recordings__/rm-compute-virtual-machine-image-relationships_3626092588/recording.har
@@ -2002,6 +2002,504 @@
           "ssl": -1,
           "wait": 1411
         }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "7810d796-590c-48df-a5b9-ef0e22286bb8"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1623038968\",\"not_before\":\"1623035068\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-07-07T03:09:28.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "7810d796-590c-48df-a5b9-ef0e22286bb8"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "922896a0-45ab-4383-a750-265a20f0c100"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11787.14 - NCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Jun 2021 03:09:27 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-07T03:09:27.811Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5fbae2f8-c338-40c3-9cbd-35c5800d0bff"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 471,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 471,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"displayName\":\"nick-auto-ingestion-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/6218e35a-080a-4108-80be-ede2b0d7967c\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"6218e35a-080a-4108-80be-ede2b0d7967c\",\"displayName\":\"additional-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "c909e615-4fa4-490c-ba98-a8bb5e2fdb08"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "c909e615-4fa4-490c-ba98-a8bb5e2fdb08"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210607T030928Z:c909e615-4fa4-490c-ba98-a8bb5e2fdb08"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Jun 2021 03:09:27 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "471"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-07T03:09:28.087Z",
+        "time": 295,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 295
+        }
+      },
+      {
+        "_id": "359a9246b0708acfc363c0419fcf4502",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "61d3f393-5b6b-4ea5-b051-90b20ebc03ad"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-compute/14.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1877,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition/versions?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 582,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 582,
+            "text": "{\"value\":[{\"name\":\"0.0.0\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition/versions/0.0.0\",\"type\":\"Microsoft.Compute/galleries/images/versions\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"publishingProfile\":{\"targetRegions\":[{\"name\":\"East US\",\"regionalReplicaCount\":1,\"storageAccountType\":\"Standard_LRS\"}],\"replicaCount\":1,\"excludeFromLatest\":false,\"publishedDate\":\"2021-05-17T20:14:30.1753637+00:00\",\"storageAccountType\":\"Standard_LRS\"},\"storageProfile\":{\"source\":{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/virtualMachines/machine-from-image\"},\"osDiskImage\":{\"hostCaching\":\"ReadWrite\",\"source\":{}}},\"provisioningState\":\"Succeeded\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-original-request-ids",
+              "value": "21dc9ea4-6cd7-4a52-8eae-a24222a1a3d9, 1b4565e4-826d-4aac-8a41-6b235bcbcefb, a934215c-c195-4403-8d5d-cb39262dab87, f790ce2d-4ee5-4f68-948c-36d4090b5a09, 9fa6f8da-b00b-44aa-936e-af7f8838104d, 4fe38dfc-fdf6-459d-992b-ab16d84728e2, 99b68a6a-a2c8-49bb-b10a-64629d9758b6, da956e55-5ea6-4d81-bbad-c31e118afe23, 78d11a01-c33a-41b9-98ff-0276f125d1c4, 69a1bb41-0e43-48af-8732-814662c07edb, f14c26f8-9589-41d0-abac-d65d1ecbff39, 6f41963b-840d-478c-ad7a-c48528279d97, ef7207ae-a0f4-4edf-99df-1a3b61071cb9, e5c665bc-a4d4-4ebe-a84b-61b952785569, 7f185f7f-99a6-461e-840f-25c6fa896b73, 12c6771a-49ce-423d-ad08-a3b2546e3a40, cc85da6a-97e9-402c-b22f-d3103f6499d4, 71f841b7-0a0b-4e43-9d41-336069d747b0, ef960bb3-b764-40d1-84fa-d0c1b33669dd, 1a07e8ff-c6bc-4bf2-915e-ac52026ce931, 2f96a574-b1e0-403e-ae66-b1c29bcd8520, 88b3cb2e-a454-4782-a47c-59c72f2a3d89, 46c1520b-a9b3-4600-8b7e-fbf52aadc87c, d3540e6b-4b2e-4e23-8742-85f54cd9e784, c68df42f-6993-4bf9-bda6-4a767dec433c, 0c96d238-79a1-4ff9-932a-41f76c644bee, 5220f734-d6b2-4972-9e69-e81eefe3f4f0, 570f5635-0da7-4f96-8fa2-e7f9af3bebcf, 6ead7509-d6d0-41cd-8f9d-9a9073d9a24c, d4938b8d-2f10-44d0-ade1-a87d427cbd73, 442fc9ce-4423-4408-89a9-ea8f80a956bb, 68978edd-a9ba-4284-b7f5-a1811514ff0a, 9022d06a-30b0-4f85-b204-fa673f1c9b1d, 14c11397-c7aa-4c9d-b044-8a55b498d7c6, 6897622c-2c08-4d36-9698-10e5cad6c3eb"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "571813a9-64e8-4e36-818a-36ddb8e50d23"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "571813a9-64e8-4e36-818a-36ddb8e50d23"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210607T030929Z:571813a9-64e8-4e36-818a-36ddb8e50d23"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Jun 2021 03:09:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "582"
+            }
+          ],
+          "headersSize": 1947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-07T03:09:28.389Z",
+        "time": 1366,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1366
+        }
       }
     ],
     "pages": [],

--- a/src/steps/resource-manager/compute/constants.ts
+++ b/src/steps/resource-manager/compute/constants.ts
@@ -101,6 +101,12 @@ export const relationships = {
     _class: RelationshipClass.USES,
     targetType: entities.SHARED_IMAGE._type,
   },
+  VIRTUAL_MACHINE_USES_SHARED_IMAGE_VERSION: {
+    _type: 'azure_vm_uses_shared_image_version',
+    sourceType: VIRTUAL_MACHINE_ENTITY_TYPE,
+    _class: RelationshipClass.USES,
+    targetType: entities.SHARED_IMAGE_VERSION._type,
+  },
   VIRTUAL_MACHINE_USES_UNMANAGED_DISK: {
     _type: 'azure_vm_uses_storage_account',
     sourceType: VIRTUAL_MACHINE_ENTITY_TYPE,


### PR DESCRIPTION
Fixes #387 

```
- Added support for ingesting the following **new** relationships:

  | Source               | \_class | Target                       |
  | -------------------- | ------- | ---------------------------- |
  | `azure_vm`           | `USES`  | `azure_shared_image_version` |
```

<img width="781" alt="Screen Shot 2021-06-06 at 10 57 41 PM" src="https://user-images.githubusercontent.com/15333061/120954404-1bd73600-c71d-11eb-86ba-1d80e811f1f2.png">
