### PR TITLE
Add @microsoft/microsoft-graph-types to direct dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.28.1 - 2021-06-07
+
+### Fixed
+
+- Moved `@microsoft/microsft-graph-types` from dev to direct dependency, which
+  was previously causing types to fail on dependent projects after exporting
+  `clients.GraphClient` in `v5.27.1`.
+
 ## 5.28.0 - 2021-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.28.0",
+  "version": "5.28.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@azure/storage-queue": "^12.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",
+    "@microsoft/microsoft-graph-types": "^1.10.0",
     "cross-fetch": "^3.0.4",
     "lodash.map": "^4.6.0",
     "lodash.snakecase": "^4.1.1"
@@ -79,7 +80,6 @@
     "@jupiterone/integration-sdk-core": "^6.0.0",
     "@jupiterone/integration-sdk-dev-tools": "^6.0.0",
     "@jupiterone/integration-sdk-testing": "^6.0.0",
-    "@microsoft/microsoft-graph-types": "^1.10.0",
     "@types/lodash.map": "^4.6.13",
     "@types/lodash.snakecase": "^4.1.6",
     "@types/node": "^13.11.1",


### PR DESCRIPTION
```
## 5.28.1 - 2021-06-07

### Fixed

- Moved `@microsoft/microsft-graph-types` from dev to direct dependency, which
  was previously causing types to fail on dependent projects after exporting
  `clients.GraphClient` in `v5.27.1`.
```