### PR TITLE
389 image version source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added support for ingesting the following **new** relationships:
+
+  | Source     | \_class     | Target                       |
+  | ---------- | ----------- | ---------------------------- |
+  | `azure_vm` | `GENERATED` | `azure_shared_image_version` |
+
 ## 5.29.0 - 2021-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to
   | ---------- | ----------- | ---------------------------- |
   | `azure_vm` | `GENERATED` | `azure_shared_image_version` |
 
+### Changed
+
+- Lowercase the `azure_vm._key` property to allow for mapped relationships
+  across different J1 subscriptions.
+
 ## 5.29.0 - 2021-06-07
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -385,6 +385,7 @@ The following relationships are created/mapped:
 | `azure_subscription`               | **HAS**               | `azure_security_center_subscription_pricing`      |
 | `azure_subscription`               | **PERFORMED**         | `azure_security_assessment`                       |
 | `azure_subscription`               | **USES**              | `azure_location`                                  |
+| `azure_vm`                         | **GENERATED**         | `azure_shared_image_version`                      |
 | `azure_vm`                         | **USES**              | `azure_image`                                     |
 | `azure_vm`                         | **USES**              | `azure_managed_disk`                              |
 | `azure_vm`                         | **USES**              | `azure_service_principal`                         |

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -151,6 +151,9 @@ describe('getStepStartStates', () => {
       [computeSteps.GALLERIES]: { disabled: true },
       [computeSteps.SHARED_IMAGES]: { disabled: true },
       [computeSteps.SHARED_IMAGE_VERSIONS]: { disabled: true },
+      [computeSteps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS]: {
+        disabled: true,
+      },
       [computeSteps.VIRTUAL_MACHINE_EXTENSIONS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS]: { disabled: true },
@@ -283,6 +286,9 @@ describe('getStepStartStates', () => {
       [computeSteps.GALLERIES]: { disabled: true },
       [computeSteps.SHARED_IMAGES]: { disabled: true },
       [computeSteps.SHARED_IMAGE_VERSIONS]: { disabled: true },
+      [computeSteps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS]: {
+        disabled: true,
+      },
       [computeSteps.VIRTUAL_MACHINE_EXTENSIONS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS]: { disabled: true },
@@ -415,6 +421,9 @@ describe('getStepStartStates', () => {
       [computeSteps.GALLERIES]: { disabled: false },
       [computeSteps.SHARED_IMAGES]: { disabled: false },
       [computeSteps.SHARED_IMAGE_VERSIONS]: { disabled: false },
+      [computeSteps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS]: {
+        disabled: false,
+      },
       [computeSteps.VIRTUAL_MACHINE_EXTENSIONS]: { disabled: false },
       [computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS]: { disabled: false },
       [computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS]: { disabled: false },
@@ -549,6 +558,9 @@ describe('getStepStartStates', () => {
       [computeSteps.GALLERIES]: { disabled: true },
       [computeSteps.SHARED_IMAGES]: { disabled: true },
       [computeSteps.SHARED_IMAGE_VERSIONS]: { disabled: true },
+      [computeSteps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS]: {
+        disabled: true,
+      },
       [computeSteps.VIRTUAL_MACHINE_EXTENSIONS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS]: { disabled: true },
       [computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS]: { disabled: true },

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -162,6 +162,7 @@ export function getResourceManagerSteps(): GetApiSteps {
       computeSteps.GALLERIES,
       computeSteps.SHARED_IMAGES,
       computeSteps.SHARED_IMAGE_VERSIONS,
+      computeSteps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS,
       computeSteps.VIRTUAL_MACHINE_EXTENSIONS,
       computeSteps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS,
       computeSteps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS,

--- a/src/steps/resource-manager/compute/__recordings__/rm-compute-shared-image-version-source-relationships_3822310037/recording.har
+++ b/src/steps/resource-manager/compute/__recordings__/rm-compute-shared-image-version-source-relationships_3822310037/recording.har
@@ -1,0 +1,2010 @@
+{
+  "log": {
+    "_recordingName": "rm-compute-shared-image-version-source-relationships",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "f9453ac5-ceac-417c-b92d-a4fc41d475a3"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1623270511\",\"not_before\":\"1623266611\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-07-09T19:28:31.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "f9453ac5-ceac-417c-b92d-a4fc41d475a3"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "ad930d53-d800-4512-afb2-8ae2e55b9601"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11787.14 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:31 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:31.365Z",
+        "time": 463,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 463
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "63443227-05a6-4711-b247-ccd8b2b7ae15"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 471,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 471,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"displayName\":\"nick-auto-ingestion-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/6218e35a-080a-4108-80be-ede2b0d7967c\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"6218e35a-080a-4108-80be-ede2b0d7967c\",\"displayName\":\"additional-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1296d27c-fce5-43dd-b918-5d02a6c2c7d9"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "1296d27c-fce5-43dd-b918-5d02a6c2c7d9"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192832Z:1296d27c-fce5-43dd-b918-5d02a6c2c7d9"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:32 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "471"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:31.867Z",
+        "time": 970,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 970
+        }
+      },
+      {
+        "_id": "7b3a69c31165d1adfd37a7c4c2d588b7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f1bf4a4c-fd4b-4faf-839e-46d4ae2523c5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-compute/14.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1801,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Compute/galleries?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 795,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 795,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"testImageGallery\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/galleries/testImageGallery\",\r\n      \"type\": \"Microsoft.Compute/galleries\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"identifier\": {\r\n          \"uniqueName\": \"d3803fd6-2ba4-4286-80aa-f3d613ad59a7-TESTIMAGEGALLERY\"\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-resource",
+              "value": "Microsoft.Compute/ListGalleryInSubscription3Min;99,Microsoft.Compute/ListGalleryInSubscription30Min;997"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-served-by",
+              "value": "e13884eb-fb82-49fa-a993-d40ace056dbd_132524979417830506,e13884eb-fb82-49fa-a993-d40ace056dbd_132524979417830506"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "26611005-0e15-4dcf-aeb8-dc2abb532e94"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "c36577b0-4e59-4e4e-9d8c-474333bc1f4f"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192833Z:c36577b0-4e59-4e4e-9d8c-474333bc1f4f"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:32 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 897,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:32.851Z",
+        "time": 529,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 529
+        }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "087ec1bc-d84f-45db-90e1-4d3c815c5f10"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1623270513\",\"not_before\":\"1623266613\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-07-09T19:28:33.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "087ec1bc-d84f-45db-90e1-4d3c815c5f10"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1e2a7197-c366-4ce3-991b-072274adb701"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11787.14 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:33 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:33.422Z",
+        "time": 239,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 239
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8fd8eafe-8c55-4e57-9aec-5ac3b8d786d3"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 471,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 471,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"displayName\":\"nick-auto-ingestion-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/6218e35a-080a-4108-80be-ede2b0d7967c\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"6218e35a-080a-4108-80be-ede2b0d7967c\",\"displayName\":\"additional-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "4a133f6d-cce3-42d0-9b21-cc4dcfa29d74"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "4a133f6d-cce3-42d0-9b21-cc4dcfa29d74"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192834Z:4a133f6d-cce3-42d0-9b21-cc4dcfa29d74"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:33 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "471"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:33.665Z",
+        "time": 420,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 420
+        }
+      },
+      {
+        "_id": "8d2b012f592e490019899ffb958d7abd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3aab2139-a6d6-4e60-b6f1-71d18dbd90f9"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-compute/14.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1846,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 420,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 420,
+            "text": "{\"value\":[{\"name\":\"test-image-definition\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition\",\"type\":\"Microsoft.Compute/galleries/images\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"hyperVGeneration\":\"V1\",\"osType\":\"Linux\",\"osState\":\"Generalized\",\"identifier\":{\"publisher\":\"ndowmon\",\"offer\":\"ndowmon\",\"sku\":\"ndowmon\"},\"provisioningState\":\"Succeeded\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-original-request-ids",
+              "value": "3923ea61-9bff-4f04-a4a8-3fae57584b53, 36803c3e-0ac7-4c19-8877-f79a937b56f4, a5686f98-296c-41cf-8fe2-26e4bec78ce1, f0121157-d5b3-4a6b-95d5-bb64501e2375, a72319b7-523b-4120-a68e-7ce87ffafdf8, 0f2d1d66-d6e9-4374-b122-ac8486eb4216, 8ba92701-4bef-49c3-a755-bfb00e274284, 14007c69-cff2-4524-aa1d-da6be05a06d1, ce8535d9-6493-4dbd-87b8-9f04600c1935, 6fff6180-6335-47c5-a241-03d11b879908, 628a1e3e-99ed-410f-a8e5-24cac7272573, 0573c315-872b-4879-9061-594a8eea44a9, 87baff85-1813-492b-ab87-4c1ef877b008, 5c436f78-d2cf-49af-86f2-f6fadee68473, 48ba7873-ccd8-4059-98ee-60d36c94f207, ff6ce478-3b87-475a-9aa9-ba3ba034a0e8, 077de295-4a55-49da-9521-21a0f5effdb4, e0be363f-bcd1-4ed5-88fd-18472e36606a, 9b00a036-0794-4a71-893a-9b9d36946e05, 83e9e721-ca75-4975-b661-fa4b204c2571, 9c14c3e1-4f3e-4b85-9c41-a039ee16be4a, 372b2007-7ed0-48e4-82ab-9538d53afc0b, f5767a1d-630e-4529-aa0d-21cef1591793, 9ef6fc9f-d2db-42ea-92c9-107a6b331da1, 8ff87559-8d9a-49f0-ba2c-de9ee34fed41, 640e16d9-3b3d-4e93-9d91-43ad046f9bd4, b149302f-1006-4beb-85a2-7fad711a740b, bcabe77c-4fc5-49d2-8e13-e1cf83113de0, a0bf0a2d-3c79-4281-9aae-672ceb7d3f42, 7b66061a-009a-495e-8e4a-b515a93e76e2, 80e6acc3-91f6-4bf7-9a7a-d9f70fda941f, 23464f00-82cc-4d3f-908d-c3ed74139e37, bda65052-77e3-4700-acad-f2c6aceddf67, 02e23a62-bf4a-4716-9b42-297ef0740d6b, 62056d93-a2bb-4f87-926b-255c15c118a8"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "371e7a9b-45fa-4ea1-b99d-073dbde7cca3"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "371e7a9b-45fa-4ea1-b99d-073dbde7cca3"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192835Z:371e7a9b-45fa-4ea1-b99d-073dbde7cca3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:34 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "420"
+            }
+          ],
+          "headersSize": 1947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:34.091Z",
+        "time": 1511,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1511
+        }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "84771d41-06b2-4fde-90b1-91c6b12920a7"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1623270516\",\"not_before\":\"1623266616\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-07-09T19:28:36.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "84771d41-06b2-4fde-90b1-91c6b12920a7"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "51abb698-7b00-4d48-97a3-129f369cae01"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11787.14 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:35 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:35.609Z",
+        "time": 297,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 297
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5b84df9f-7707-49b0-937d-24422a1c1203"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 471,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 471,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"displayName\":\"nick-auto-ingestion-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/6218e35a-080a-4108-80be-ede2b0d7967c\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"6218e35a-080a-4108-80be-ede2b0d7967c\",\"displayName\":\"additional-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "41b61b10-f5f0-4169-8e68-9504afeb2913"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "41b61b10-f5f0-4169-8e68-9504afeb2913"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192836Z:41b61b10-f5f0-4169-8e68-9504afeb2913"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:36 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "471"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:35.910Z",
+        "time": 284,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 284
+        }
+      },
+      {
+        "_id": "359a9246b0708acfc363c0419fcf4502",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "2b89b527-5d50-409f-939b-20ef7c91279d"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-compute/14.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1877,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition/versions?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 582,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 582,
+            "text": "{\"value\":[{\"name\":\"0.0.0\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition/versions/0.0.0\",\"type\":\"Microsoft.Compute/galleries/images/versions\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"publishingProfile\":{\"targetRegions\":[{\"name\":\"East US\",\"regionalReplicaCount\":1,\"storageAccountType\":\"Standard_LRS\"}],\"replicaCount\":1,\"excludeFromLatest\":false,\"publishedDate\":\"2021-05-17T20:14:30.1753637+00:00\",\"storageAccountType\":\"Standard_LRS\"},\"storageProfile\":{\"source\":{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/virtualMachines/machine-from-image\"},\"osDiskImage\":{\"hostCaching\":\"ReadWrite\",\"source\":{}}},\"provisioningState\":\"Succeeded\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-original-request-ids",
+              "value": "e1e55e21-d3e8-4729-9a92-6176891eeb52, a3569131-16c6-479f-9b7f-87362f1b2222, 56ae6d0c-5388-40d5-8a62-c66a7413cef1, 10e1604f-16ab-45f0-af24-8ae038e674a9, e3153c03-5701-4cc5-9cc8-36d71bbaed9c, cf9b3aca-ec90-4e70-8f77-68870f44bbaf, 438ecb92-2b7d-4e02-830d-add9dde87b6f, 8ff8a7f2-4453-43d7-8f03-262d53a11f8b, bfbada57-0dd8-4054-9f9e-3662f7792457, 48239945-b950-48c6-8e2d-c160cc127344, 5c55ea3d-6747-4670-87b5-12bda7625c71, faa910e0-b0e4-43c9-937b-9d7aba258b55, dcff0927-1cce-4604-9d40-d09055510579, 3a9a75f1-a02a-413b-9036-63361f812d33, 644b5613-4179-4c92-a647-81731367b8ed, 96078b37-5516-485b-a913-e3506ff5b439, 237d3145-68fe-404a-ab58-ff04beb73160, fe973ccf-4712-48ca-abc5-d47bb53ae307, b30b9fb9-20d4-44a8-a1d8-b4558c8bed28, bf422f67-ac12-4eb0-8137-39dd6ee87044, 0133f699-0715-4329-9e3d-85e41c4501c7, 7b647903-c484-4052-96d8-0c213cc2e1a0, 3956cbef-ead0-4bf9-9aba-619f98574648, 6f563a2f-47bf-4e89-b505-2ce0ae6fd289, a5bd323b-c7ce-4c02-b287-8644b2eb5e49, 4d958f74-5209-45a1-b210-766843337f71, ed6fb2ac-389c-44c1-98b1-0f2df8b602c2, e838c1d0-0d22-48b8-8949-ba5d8022b29c, ae01ef83-cf68-4175-8c09-410437fd3f5e, 8a5dcc8c-305b-480e-90aa-b9533136255c, 5545b091-6131-43e6-b82f-8fe6212ab552, a2cd59b4-50d9-4aaa-957a-647869ea8584, 762cd289-1b72-46d9-983c-9c5e7ecc3aad, d042e6e6-b87b-43e2-9ea5-84455eafbc4b, 6d3d435e-e98e-445b-97c4-7f98e721049f"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cf9f38a0-6ac8-4e5d-970e-b13c2c0a3da0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "cf9f38a0-6ac8-4e5d-970e-b13c2c0a3da0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192837Z:cf9f38a0-6ac8-4e5d-970e-b13c2c0a3da0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:37 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "582"
+            }
+          ],
+          "headersSize": 1947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:36.201Z",
+        "time": 1448,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1448
+        }
+      },
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "c760ed81-b0d2-4c85-a7ef-34389e2ef36c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1623270517\",\"not_before\":\"1623266617\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-07-09T19:28:37.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "c760ed81-b0d2-4c85-a7ef-34389e2ef36c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "00415160-79b3-4691-b02d-73a856a38001"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11787.14 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:37 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:37.656Z",
+        "time": 165,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 165
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "2b572684-b46e-4ef2-b27b-de8464a45db1"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 471,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 471,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"0f3bae6f-800f-4f6a-8317-c11e11ab8684\",\"displayName\":\"nick-auto-ingestion-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/6218e35a-080a-4108-80be-ede2b0d7967c\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"6218e35a-080a-4108-80be-ede2b0d7967c\",\"displayName\":\"additional-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "427b0e74-74d2-4a68-85e8-7056ce3cf9df"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "427b0e74-74d2-4a68-85e8-7056ce3cf9df"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192838Z:427b0e74-74d2-4a68-85e8-7056ce3cf9df"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:37 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "471"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:37.826Z",
+        "time": 263,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 263
+        }
+      },
+      {
+        "_id": "8a739320425945adc6214609ac1c1aaf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "2f5ae53f-2063-4970-99d9-8cc16f4ed09b"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-compute/14.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1807,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-07-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Compute/virtualMachines?api-version=2019-07-01"
+        },
+        "response": {
+          "bodySize": 6687,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 6687,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"machine-from-gallery\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/machine-from-gallery\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"eastus\",\r\n      \"identity\": {\r\n        \"type\": \"SystemAssigned\",\r\n        \"principalId\": \"34653d4f-ccf8-4cb4-9d0d-3def13b440ab\",\r\n        \"tenantId\": \"992d7bbe-b367-459c-a10f-cf3fd16103ab\"\r\n      },\r\n      \"properties\": {\r\n        \"vmId\": \"a9c23301-e114-4920-aaf8-abb54a1e8759\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_B1ls\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/galleries/testImageGallery/images/test-image-definition\",\r\n            \"exactVersion\": \"0.0.0\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"machine-from-gallery_OsDisk_1_a0c059c55b8240c499f446591a76e323\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Premium_LRS\",\r\n              \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/disks/machine-from-gallery_OsDisk_1_a0c059c55b8240c499f446591a76e323\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"machine-from-gallery\",\r\n          \"adminUsername\": \"azureuser\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/azureuser/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDPDPNZLYdlOChZL7GxmwIWJfIH\\r\\n91EwoqdE81FYklFj/TI5MDlRAkabRLkpN6YN7iHnKMiIITakoXq19sE9nM6UpaJp\\r\\nCAiZGnGIo+7ldLiIA0HGH37rmHWZOgGbptWfQmLc+cyt5fu4imJZzpMPZoFI+53N\\r\\nGQL6v5CTMbwIgBLTLbbVR4FihoZcx3/Eyd7hEeu4bJttuL11zXS3ZJZSpYfe0CTX\\r\\nfIiDrzDtGB8reWV8UO74ky0TBx7JsiicWEj5AGuSHIZgjUydWRGiB0paxQXMRZHT\\r\\nsB1jmKH5uS76AKzCSORkj0T0PFkcVBaGnBWZCCV5eMIt3A8tENZOJW/m0JwSNfjx\\r\\nbTl/XE7RZr7HmhZIQiWpICSj+ieZVMmnobYt11mx28dMV9TjxFGBaAGQTlysEBqu\\r\\nKURqtDH8mJ1In4VTnwyifso635U6MPUIbycb4Hj9i8L3g6rMm8h7FsMXNa6IESd2\\r\\nGJPH9jKPPGszE0MNdypQWnn5T2e/19JTlXPdRE0= generated-by-azure\\r\\n\"\r\n                }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\": true\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/machine-from-gallery180\"}]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/machine-from-gallery/extensions/OmsAgentForLinux\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"machine-from-image\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/machine-from-image\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"eastus\",\r\n      \"properties\": {\r\n        \"vmId\": \"f3ba7005-90c5-403b-81d2-8ce04d679bc3\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_B1ls\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/images/rfp-linux-image-20210517153655\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"machine-from-image_disk1_279e83de02934f4dab19aa1f52df184a\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/disks/machine-from-image_disk1_279e83de02934f4dab19aa1f52df184a\"\r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"machine-from-image\",\r\n          \"adminUsername\": \"azureuser\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/azureuser/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDPDPNZLYdlOChZL7GxmwIWJfIH\\r\\n91EwoqdE81FYklFj/TI5MDlRAkabRLkpN6YN7iHnKMiIITakoXq19sE9nM6UpaJp\\r\\nCAiZGnGIo+7ldLiIA0HGH37rmHWZOgGbptWfQmLc+cyt5fu4imJZzpMPZoFI+53N\\r\\nGQL6v5CTMbwIgBLTLbbVR4FihoZcx3/Eyd7hEeu4bJttuL11zXS3ZJZSpYfe0CTX\\r\\nfIiDrzDtGB8reWV8UO74ky0TBx7JsiicWEj5AGuSHIZgjUydWRGiB0paxQXMRZHT\\r\\nsB1jmKH5uS76AKzCSORkj0T0PFkcVBaGnBWZCCV5eMIt3A8tENZOJW/m0JwSNfjx\\r\\nbTl/XE7RZr7HmhZIQiWpICSj+ieZVMmnobYt11mx28dMV9TjxFGBaAGQTlysEBqu\\r\\nKURqtDH8mJ1In4VTnwyifso635U6MPUIbycb4Hj9i8L3g6rMm8h7FsMXNa6IESd2\\r\\nGJPH9jKPPGszE0MNdypQWnn5T2e/19JTlXPdRE0= generated-by-azure\\r\\n\"\r\n                }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\": true\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/machine-from-image309\"}]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/machine-from-image/extensions/OmsAgentForLinux\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"rfp-linux\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/rfp-linux\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"eastus\",\r\n      \"properties\": {\r\n        \"vmId\": \"b21753a7-5453-4aed-b638-9458be1c8749\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_B1ls\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"debian\",\r\n            \"offer\": \"debian-10\",\r\n            \"sku\": \"10\",\r\n            \"version\": \"latest\",\r\n            \"exactVersion\": \"0.20210329.591\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"rfp-linux_disk1_58482a2469ff461d88249461c7a6eccb\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/disks/rfp-linux_disk1_58482a2469ff461d88249461c7a6eccb\"\r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"rfp-linux\",\r\n          \"adminUsername\": \"azureuser\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/azureuser/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5dUEk7/hehU82Wtu89Z/HXwJ9\\r\\nOfdeJpPXzMeq5kVmZnTqUNWEg9P0f70mY5SYzVLS8JDIxailbKY6nvRxUHJ8DQMx\\r\\n1wJbyWuEVyDNpAimL/YeeEvNOi9LawQRUo3c2ggjLDqtGVQ+sUIxUpw13Ht/Amg9\\r\\n0c+IbzzrNqazhtW/rQ5Z7dXkD6IQqzafRoC3CAV9b+5vuJ5kKDs4T4QPoe3LNOzk\\r\\neFF91cz3QxCf7p4/O5/j44pbm8TpWI7XSwnnWE1OlgWj1ySs0rvmhiv84h19Iwk7\\r\\nCAqsRBUVN65Iv02w5a02mI0Ij5hcoVs9I98eSWqedrbnnyTt89pmi4te2Wj3MMA/\\r\\nvOGyqlBbKA/DfmvGm1RQjFrgSakE9QpOKnngVTkKPLCw0b8yH6ugUw9cgCOwPd1V\\r\\nw3eB5ySRlsVX/GLDgiHRBy1Wpps94sbvwTll9gyJ5SHzDL6lFo7U/M+7Rxg23X7b\\r\\n1r2rtnpikQdeNsvKdDVY55uZOSy8Bc8l1OqZCyE= generated-by-azure\\r\\n\"\r\n                }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\": true\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/rfp-linux970\"}]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/rfp-linux/extensions/OmsAgentForLinux\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"service-managed-identity\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/service-managed-identity\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"eastus\",\r\n      \"identity\": {\r\n        \"type\": \"SystemAssigned, UserAssigned\",\r\n        \"principalId\": \"2b7fef5b-350c-4f95-9bdb-d8543daa184b\",\r\n        \"tenantId\": \"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\r\n        \"userAssignedIdentities\": {\r\n          \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.managedidentity/userassignedidentities/managed-identity\": {\r\n            \"principalId\": \"7138cb03-56b3-4280-8d30-5dde4a39ea88\",\r\n            \"clientId\": \"187cd961-a690-41c7-af90-a027ca2cb937\"\r\n          }\r\n        }\r\n      },\r\n      \"properties\": {\r\n        \"vmId\": \"3402d790-8d05-4d8a-981d-9df022963da5\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_B1ls\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"18.04-LTS\",\r\n            \"version\": \"latest\",\r\n            \"exactVersion\": \"18.04.202105120\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"service-managed-identity_disk1_9822becdf16943babe0164bdae542c27\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Premium_LRS\",\r\n              \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Compute/disks/service-managed-identity_disk1_9822becdf16943babe0164bdae542c27\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"service-managed-identity\",\r\n          \"adminUsername\": \"azureuser\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/azureuser/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDPDPNZLYdlOChZL7GxmwIWJfIH\\r\\n91EwoqdE81FYklFj/TI5MDlRAkabRLkpN6YN7iHnKMiIITakoXq19sE9nM6UpaJp\\r\\nCAiZGnGIo+7ldLiIA0HGH37rmHWZOgGbptWfQmLc+cyt5fu4imJZzpMPZoFI+53N\\r\\nGQL6v5CTMbwIgBLTLbbVR4FihoZcx3/Eyd7hEeu4bJttuL11zXS3ZJZSpYfe0CTX\\r\\nfIiDrzDtGB8reWV8UO74ky0TBx7JsiicWEj5AGuSHIZgjUydWRGiB0paxQXMRZHT\\r\\nsB1jmKH5uS76AKzCSORkj0T0PFkcVBaGnBWZCCV5eMIt3A8tENZOJW/m0JwSNfjx\\r\\nbTl/XE7RZr7HmhZIQiWpICSj+ieZVMmnobYt11mx28dMV9TjxFGBaAGQTlysEBqu\\r\\nKURqtDH8mJ1In4VTnwyifso635U6MPUIbycb4Hj9i8L3g6rMm8h7FsMXNa6IESd2\\r\\nGJPH9jKPPGszE0MNdypQWnn5T2e/19JTlXPdRE0= generated-by-azure\\r\\n\"\r\n                }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\": true\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/service-managed-iden819\"}]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/service-managed-identity/extensions/OmsAgentForLinux\"\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-resource",
+              "value": "Microsoft.Compute/HighCostGet3Min;139,Microsoft.Compute/HighCostGet30Min;697"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e6e73761-0b5c-46c9-962d-4a739b16c8a7"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "d1a4f0fa-d455-46a2-8b19-526c821691ca"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "CENTRALUS:20210609T192838Z:d1a4f0fa-d455-46a2-8b19-526c821691ca"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 09 Jun 2021 19:28:38 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 741,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-06-09T19:28:38.095Z",
+        "time": 309,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 309
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/resource-manager/compute/constants.ts
+++ b/src/steps/resource-manager/compute/constants.ts
@@ -18,6 +18,8 @@ export const steps = {
   GALLERIES: 'rm-compute-galleries',
   SHARED_IMAGES: 'rm-compute-shared-images',
   SHARED_IMAGE_VERSIONS: 'rm-compute-shared-image-versions',
+  SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS:
+    'rm-compute-shared-image-version-source-relationships',
   VIRTUAL_MACHINE_EXTENSIONS: 'rm-compute-virtual-machine-extensions',
   VIRTUAL_MACHINE_DISK_RELATIONSHIPS:
     'rm-compute-virtual-machine-disk-relationships',
@@ -105,6 +107,12 @@ export const relationships = {
     _type: 'azure_vm_uses_shared_image_version',
     sourceType: VIRTUAL_MACHINE_ENTITY_TYPE,
     _class: RelationshipClass.USES,
+    targetType: entities.SHARED_IMAGE_VERSION._type,
+  },
+  VIRTUAL_MACHINE_GENERATED_SHARED_IMAGE_VERSION: {
+    _type: 'azure_vm_generated_shared_image_version',
+    sourceType: VIRTUAL_MACHINE_ENTITY_TYPE,
+    _class: RelationshipClass.GENERATED,
     targetType: entities.SHARED_IMAGE_VERSION._type,
   },
   VIRTUAL_MACHINE_USES_UNMANAGED_DISK: {

--- a/src/steps/resource-manager/compute/converters.test.ts
+++ b/src/steps/resource-manager/compute/converters.test.ts
@@ -162,7 +162,7 @@ describe('createVirtualMachineEntity', () => {
     expect(createVirtualMachineEntity(webLinker, data)).toEqual({
       ...convertProperties(data),
       _key:
-        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/J1DEV/providers/Microsoft.Compute/virtualMachines/j1dev',
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourcegroups/j1dev/providers/microsoft.compute/virtualmachines/j1dev',
       _type: 'azure_vm',
       _class: ['Host'],
       _rawData: [{ name: 'default', rawData: data }],

--- a/src/steps/resource-manager/compute/converters.ts
+++ b/src/steps/resource-manager/compute/converters.ts
@@ -55,7 +55,12 @@ export function createVirtualMachineEntity(
   const entity = {
     ...convertProperties(data),
     ...osProperties,
-    _key: data.id as string,
+    /**
+     * Explicitly lowercasing the `_key` property due to inconsistent casing.
+     *
+     * See the SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS step for more details.
+     */
+    _key: data.id!.toLowerCase(),
     _type: VIRTUAL_MACHINE_ENTITY_TYPE,
     _class: VIRTUAL_MACHINE_ENTITY_CLASS,
     _rawData: [{ name: 'default', rawData: data }],

--- a/src/steps/resource-manager/compute/index.test.ts
+++ b/src/steps/resource-manager/compute/index.test.ts
@@ -960,7 +960,7 @@ describe('rm-compute-shared-image-version-source-relationships', () => {
     });
   }, 10_000);
 
-  test.skip('success - mapped relationships', async () => {
+  test('success - mapped relationships', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'rm-compute-shared-image-version-source-relationships',
@@ -990,7 +990,6 @@ describe('rm-compute-shared-image-version-source-relationships', () => {
     const mappedImageSourceRelationships =
       context.jobState.collectedRelationships;
 
-    console.log({ keys: virtualMachineEntities.map((e) => e._key) });
     expect(mappedImageSourceRelationships).toHaveLength(1);
     expect(mappedImageSourceRelationships).toCreateValidRelationshipsToEntities(
       virtualMachineEntities,

--- a/src/steps/resource-manager/compute/index.ts
+++ b/src/steps/resource-manager/compute/index.ts
@@ -8,6 +8,7 @@ import {
   getRawData,
   generateRelationshipKey,
   createMappedRelationship,
+  RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
@@ -50,6 +51,7 @@ import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
 import {
   Gallery,
   GalleryImage,
+  GalleryImageVersion,
   VirtualMachine,
 } from '@azure/arm-compute/esm/models';
 import {
@@ -146,6 +148,51 @@ export async function fetchGalleryImageVersions(
           );
         },
       );
+    },
+  );
+}
+
+export async function buildGalleryImageVersionSourceRelationships(
+  executionContext: IntegrationStepExecutionContext,
+): Promise<void> {
+  const { jobState } = executionContext;
+
+  await jobState.iterateEntities(
+    {
+      _type: entities.SHARED_IMAGE_VERSION._type,
+    },
+    async (imageVersionEntity) => {
+      const imageVersion = getRawData<GalleryImageVersion>(imageVersionEntity);
+
+      const sourceId = imageVersion?.storageProfile.source?.id;
+
+      if (!sourceId) return;
+
+      const sourceEntity = await jobState.findEntity(sourceId);
+
+      if (sourceEntity) {
+        await jobState.addRelationship(
+          createDirectRelationship({
+            from: sourceEntity,
+            _class: RelationshipClass.GENERATED,
+            to: imageVersionEntity,
+          }),
+        );
+      } else {
+        await jobState.addRelationship(
+          createMappedRelationship({
+            source: imageVersionEntity,
+            _class: RelationshipClass.GENERATED,
+            target: {
+              _type: 'azure_image_source', // I think this is always going to be azure_vm but I'm not sure.
+              _key: sourceId, // Creating mappings in this way is dangerous considering that Azure is not always using case-sensitive IDs.
+            },
+            targetFilterKeys: [['_key']],
+            relationshipDirection: RelationshipDirection.REVERSE,
+            skipTargetCreation: false,
+          }),
+        );
+      }
     },
   );
 }
@@ -634,11 +681,21 @@ export const computeSteps: Step<
   },
   {
     id: steps.SHARED_IMAGE_VERSIONS,
-    name: 'Gallery Shared Images',
+    name: 'Gallery Shared Image Versions',
     entities: [entities.SHARED_IMAGE_VERSION],
     relationships: [relationships.SHARED_IMAGE_HAS_VERSION],
     dependsOn: [STEP_AD_ACCOUNT, steps.SHARED_IMAGES],
     executionHandler: fetchGalleryImageVersions,
+  },
+  {
+    id: steps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS,
+    name: 'Gallery Shared Image Version to Source Relationships',
+    entities: [],
+    relationships: [
+      relationships.VIRTUAL_MACHINE_GENERATED_SHARED_IMAGE_VERSION,
+    ],
+    dependsOn: [steps.SHARED_IMAGE_VERSIONS, STEP_RM_COMPUTE_VIRTUAL_MACHINES],
+    executionHandler: buildGalleryImageVersionSourceRelationships,
   },
   {
     id: STEP_RM_COMPUTE_VIRTUAL_MACHINE_IMAGES,


### PR DESCRIPTION
Fixes #389

```
### Added

- Added support for ingesting the following **new** relationships:

  | Source     | \_class     | Target                       |
  | ---------- | ----------- | ---------------------------- |
  | `azure_vm` | `GENERATED` | `azure_shared_image_version` |

### Changed

- Lowercase the `azure_vm._key` property to allow for mapped relationships
  across different J1 subscriptions.
```