### PR TITLE
Changelog for 5.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 5.30.0 - 2021-06-09
+
 ### Added
 
 - Added support for ingesting the following **new** relationships:


### PR DESCRIPTION
```
## 5.30.0 - 2021-06-09

### Added

- Added support for ingesting the following **new** relationships:

  | Source                   | \_class     | Target                       |
  | ------------------------ | ----------- | ---------------------------- |
  | `azure_vm`               | `GENERATED` | `azure_shared_image_version` |
  | `azure_keyvault_service` | `ALLOWS`    | `ANY_PRINCIPAL`              |

### Changed

- Lowercase the `azure_vm._key` property to allow for mapped relationships
  across different J1 subscriptions.
```