### PR TITLE
Throw authorization error on 403 in GraphClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Throw `IntegrationProviderAuthorizationError` on 403 response in `GraphClient`
 - Changed `azure_group_has_member` relationships from mapped to direct, because
   group members always exist in the same directory as the group.
 - Bumped `@jupiterone/integration-sdk-*@6.10.0`. This included some new required

--- a/src/azure/graph/client.ts
+++ b/src/azure/graph/client.ts
@@ -129,7 +129,7 @@ export abstract class GraphClient {
 
       // Fetch errors include the properties code, errno, message, name, stack, type.
       if (err instanceof FetchError) {
-        this.logger.error(
+        this.logger.warn(
           { err, resourceUrl: endpoint },
           'Encountered fetch error in Azure Graph client.',
         );
@@ -141,8 +141,20 @@ export abstract class GraphClient {
         });
       }
 
+      if (err.statusCode === 403) {
+        this.logger.warn(
+          { err, resourceUrl: endpoint },
+          'Encountered auth error in Azure Graph client.',
+        );
+        throw new IntegrationProviderAuthorizationError({
+          cause: err,
+          endpoint,
+          status: err.statusCode,
+          statusText: err.statusText || err.message,
+        });
+      }
       if (err.statusCode !== 404) {
-        this.logger.error(
+        this.logger.warn(
           { err, resourceUrl: endpoint },
           'Encountered error in Azure Graph client.',
         );

--- a/src/steps/active-directory/__recordings__/ad-user-registration-details-403_2267542617/recording.har
+++ b/src/steps/active-directory/__recordings__/ad-user-registration-details-403_2267542617/recording.har
@@ -1,0 +1,527 @@
+{
+  "log": {
+    "_recordingName": "ad-user-registration-details-403",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 176,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "176"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1655,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1655,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-08-20T20:17:29.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "df87db36-c6e9-4b54-b175-659582b07902"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11898.8 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Jul 2021 20:17:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1655"
+            }
+          ],
+          "headersSize": 735,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-21T20:17:29.045Z",
+        "time": 447,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 447
+        }
+      },
+      {
+        "_id": "9524bbc307d6550431bddb3b41b4a588",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "922d1b3e-1a74-3223-effb-e129cd509263"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 1949,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://graph.microsoft.com/beta/reports/credentialUserRegistrationDetails"
+        },
+        "response": {
+          "bodySize": 508,
+          "content": {
+            "mimeType": "application/json",
+            "size": 508,
+            "text": "{\"error\":{\"code\":\"Authentication_MSGraphPermissionMissing\",\"message\":\"Calling principal does not have required MSGraph permissions Reports.Read.All\",\"innerError\":{\"date\":\"2021-07-21T20:17:29\",\"request-id\":\"2c9bb4e8-ab5a-47d7-93a5-a53d5215d916\",\"client-request-id\":\"922d1b3e-1a74-3223-effb-e129cd509263\"}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Jul 2021 20:17:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "2c9bb4e8-ab5a-47d7-93a5-a53d5215d916"
+            },
+            {
+              "name": "client-request-id",
+              "value": "922d1b3e-1a74-3223-effb-e129cd509263"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"DS1PEPF00002044\"}}"
+            }
+          ],
+          "headersSize": 456,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 403,
+          "statusText": "Forbidden"
+        },
+        "startedDateTime": "2021-07-21T20:17:29.499Z",
+        "time": 422,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 422
+        }
+      },
+      {
+        "_id": "9524bbc307d6550431bddb3b41b4a588",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "e81a3e38-11ed-ca5f-d01d-4ff20502b535"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 1949,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://graph.microsoft.com/beta/reports/credentialUserRegistrationDetails"
+        },
+        "response": {
+          "bodySize": 506,
+          "content": {
+            "mimeType": "application/json",
+            "size": 506,
+            "text": "{\"error\":{\"code\":\"Authentication_MSGraphPermissionMissing\",\"message\":\"Calling principal does not have required MSGraph permissions Reports.Read.All\",\"innerError\":{\"date\":\"2021-07-21T20:17:30\",\"request-id\":\"fd66dac2-afef-4cfa-b55b-b20840a8f71b\",\"client-request-id\":\"e81a3e38-11ed-ca5f-d01d-4ff20502b535\"}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Jul 2021 20:17:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "fd66dac2-afef-4cfa-b55b-b20840a8f71b"
+            },
+            {
+              "name": "client-request-id",
+              "value": "e81a3e38-11ed-ca5f-d01d-4ff20502b535"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"DS1PEPF0000372F\"}}"
+            }
+          ],
+          "headersSize": 456,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 403,
+          "statusText": "Forbidden"
+        },
+        "startedDateTime": "2021-07-21T20:17:30.132Z",
+        "time": 394,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 394
+        }
+      },
+      {
+        "_id": "9524bbc307d6550431bddb3b41b4a588",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "820dfb9d-0e6c-9ad9-1b44-8c3eedad05c3"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 1949,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://graph.microsoft.com/beta/reports/credentialUserRegistrationDetails"
+        },
+        "response": {
+          "bodySize": 506,
+          "content": {
+            "mimeType": "application/json",
+            "size": 506,
+            "text": "{\"error\":{\"code\":\"Authentication_MSGraphPermissionMissing\",\"message\":\"Calling principal does not have required MSGraph permissions Reports.Read.All\",\"innerError\":{\"date\":\"2021-07-21T20:17:31\",\"request-id\":\"bd7dbcab-9e30-4237-9a50-344009577a71\",\"client-request-id\":\"820dfb9d-0e6c-9ad9-1b44-8c3eedad05c3\"}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 21 Jul 2021 20:17:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "bd7dbcab-9e30-4237-9a50-344009577a71"
+            },
+            {
+              "name": "client-request-id",
+              "value": "820dfb9d-0e6c-9ad9-1b44-8c3eedad05c3"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"DS2PEPF00000A07\"}}"
+            }
+          ],
+          "headersSize": 456,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 403,
+          "statusText": "Forbidden"
+        },
+        "startedDateTime": "2021-07-21T20:17:30.731Z",
+        "time": 367,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 367
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/active-directory/index.test.ts
+++ b/src/steps/active-directory/index.test.ts
@@ -28,6 +28,7 @@ import {
   USER_ENTITY_TYPE,
 } from './constants';
 import { getMockAccountEntity } from '../../../test/helpers/getMockEntity';
+import { IntegrationProviderAuthorizationError } from '@jupiterone/integration-sdk-core';
 
 let recording: Recording;
 
@@ -152,6 +153,31 @@ describe.skip('ad-user-registration-details', () => {
         },
       },
     });
+  });
+
+  test.only('403', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'ad-user-registration-details-403',
+      options: {
+        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        recordFailedRequests: true,
+      },
+    });
+
+    const { accountEntity } = getSetupEntities(configFromEnv);
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: configFromEnv,
+      entities: [accountEntity],
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: accountEntity,
+      },
+    });
+
+    await expect(fetchUserRegistrationDetails(context)).rejects.toThrow(
+      IntegrationProviderAuthorizationError,
+    );
   });
 });
 


### PR DESCRIPTION
We are seeing the following errors from the `ad-user-registration-details` step, which should be reported directly to the user but _not_ to operators.

> `Provider API failed at https://graph.microsoft.com/beta/reports/credentialUserRegistrationDetails: 403 Calling principal does not have required MSGraph permissions Reports.Read.All`


```
### Changed

- Throw `IntegrationProviderAuthorizationError` on 403 response in `GraphClient`
```