### PR TITLE
Change azure_group_has_member relationships from mapped to direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Changed
 
+- Changed `azure_group_has_member` relationships from mapped to direct, because
+  group members always exist in the same directory as the group.
 - Bumped `@jupiterone/integration-sdk-*@6.10.0`. This included some new required
   properties for entities of `_class` `Service` and `User`. Added the `function`
   property to the following entites:

--- a/src/steps/active-directory/__recordings__/ad-group-members_1372959748/recording.har
+++ b/src/steps/active-directory/__recordings__/ad-group-members_1372959748/recording.har
@@ -70,7 +70,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-07-06T13:41:37.000Z",
+              "expires": "2021-08-14T21:22:51.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -126,11 +126,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "328bfd21-1eed-46b5-b778-396c6c1fdd00"
+              "value": "45662907-f321-4ac5-bcd6-9a6ac4121302"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11787.14 - WUS2 ProdSlices"
+              "value": "2.1.11898.8 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -149,7 +149,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 06 Jun 2021 13:41:37 GMT"
+              "value": "Thu, 15 Jul 2021 21:22:51 GMT"
             },
             {
               "name": "connection",
@@ -160,14 +160,14 @@
               "value": "1680"
             }
           ],
-          "headersSize": 736,
+          "headersSize": 734,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-06T13:41:37.473Z",
-        "time": 351,
+        "startedDateTime": "2021-07-15T21:22:51.340Z",
+        "time": 435,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -175,7 +175,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 351
+          "wait": 435
         }
       },
       {
@@ -194,7 +194,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "9b21dcd8-89f2-19ac-9a5f-ac1bebf4a10b"
+              "value": "d59a8a17-ae49-1264-80d7-46c7146ae8ab"
             },
             {
               "_fromType": "array",
@@ -233,11 +233,11 @@
           "url": "https://graph.microsoft.com/v1.0/groups"
         },
         "response": {
-          "bodySize": 1084,
+          "bodySize": 1512,
           "content": {
             "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
-            "size": 1084,
-            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#groups\",\"value\":[{\"id\":\"c13d20a5-a062-4635-b243-1e1688085d87\",\"deletedDateTime\":null,\"classification\":null,\"createdDateTime\":\"2020-07-29T19:15:02Z\",\"creationOptions\":[],\"description\":null,\"displayName\":\"nick-integration-test\",\"expirationDateTime\":null,\"groupTypes\":[],\"isAssignableToRole\":null,\"mail\":null,\"mailEnabled\":false,\"mailNickname\":\"71764602-4\",\"membershipRule\":null,\"membershipRuleProcessingState\":null,\"onPremisesDomainName\":null,\"onPremisesLastSyncDateTime\":null,\"onPremisesNetBiosName\":null,\"onPremisesSamAccountName\":null,\"onPremisesSecurityIdentifier\":null,\"onPremisesSyncEnabled\":null,\"preferredDataLocation\":null,\"preferredLanguage\":null,\"proxyAddresses\":[],\"renewedDateTime\":\"2020-07-29T19:15:02Z\",\"resourceBehaviorOptions\":[],\"resourceProvisioningOptions\":[],\"securityEnabled\":true,\"securityIdentifier\":\"S-1-12-1-3242008741-1177919586-371082162-2271021192\",\"theme\":null,\"visibility\":null,\"onPremisesProvisioningErrors\":[]}]}"
+            "size": 1512,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#groups\",\"value\":[{\"id\":\"1f70c83c-1ebb-4ff7-be53-81e666312a39\",\"deletedDateTime\":null,\"classification\":null,\"createdDateTime\":\"2021-07-15T14:59:26Z\",\"creationOptions\":[],\"description\":null,\"displayName\":\"Crypto Team\",\"expirationDateTime\":null,\"groupTypes\":[],\"isAssignableToRole\":null,\"mail\":null,\"mailEnabled\":false,\"mailNickname\":\"b6ccff58-1\",\"membershipRule\":null,\"membershipRuleProcessingState\":null,\"onPremisesDomainName\":null,\"onPremisesLastSyncDateTime\":null,\"onPremisesNetBiosName\":null,\"onPremisesSamAccountName\":null,\"onPremisesSecurityIdentifier\":null,\"onPremisesSyncEnabled\":null,\"preferredDataLocation\":null,\"preferredLanguage\":null,\"proxyAddresses\":[],\"renewedDateTime\":\"2021-07-15T14:59:26Z\",\"resourceBehaviorOptions\":[],\"resourceProvisioningOptions\":[],\"securityEnabled\":true,\"securityIdentifier\":\"S-1-12-1-527484988-1341595323-3867235262-959066470\",\"theme\":null,\"visibility\":null,\"onPremisesProvisioningErrors\":[]},{\"id\":\"c028f907-7e1a-47eb-8507-75dd442dcbc0\",\"deletedDateTime\":null,\"classification\":null,\"createdDateTime\":\"2021-07-15T14:58:56Z\",\"creationOptions\":[],\"description\":null,\"displayName\":\"Developers\",\"expirationDateTime\":null,\"groupTypes\":[],\"isAssignableToRole\":null,\"mail\":null,\"mailEnabled\":false,\"mailNickname\":\"684a22aa-7\",\"membershipRule\":null,\"membershipRuleProcessingState\":null,\"onPremisesDomainName\":null,\"onPremisesLastSyncDateTime\":null,\"onPremisesNetBiosName\":null,\"onPremisesSamAccountName\":null,\"onPremisesSecurityIdentifier\":null,\"onPremisesSyncEnabled\":null,\"preferredDataLocation\":null,\"preferredLanguage\":null,\"proxyAddresses\":[],\"renewedDateTime\":\"2021-07-15T14:58:56Z\",\"resourceBehaviorOptions\":[],\"resourceProvisioningOptions\":[],\"securityEnabled\":true,\"securityIdentifier\":\"S-1-12-1-3223910663-1206615578-3715434373-3234540868\",\"theme\":null,\"visibility\":null,\"onPremisesProvisioningErrors\":[]},{\"id\":\"c13d20a5-a062-4635-b243-1e1688085d87\",\"deletedDateTime\":null,\"classification\":null,\"createdDateTime\":\"2020-07-29T19:15:02Z\",\"creationOptions\":[],\"description\":null,\"displayName\":\"nick-integration-test\",\"expirationDateTime\":null,\"groupTypes\":[],\"isAssignableToRole\":null,\"mail\":null,\"mailEnabled\":false,\"mailNickname\":\"71764602-4\",\"membershipRule\":null,\"membershipRuleProcessingState\":null,\"onPremisesDomainName\":null,\"onPremisesLastSyncDateTime\":null,\"onPremisesNetBiosName\":null,\"onPremisesSamAccountName\":null,\"onPremisesSecurityIdentifier\":null,\"onPremisesSyncEnabled\":null,\"preferredDataLocation\":null,\"preferredLanguage\":null,\"proxyAddresses\":[],\"renewedDateTime\":\"2020-07-29T19:15:02Z\",\"resourceBehaviorOptions\":[],\"resourceProvisioningOptions\":[],\"securityEnabled\":true,\"securityIdentifier\":\"S-1-12-1-3242008741-1177919586-371082162-2271021192\",\"theme\":null,\"visibility\":null,\"onPremisesProvisioningErrors\":[]}]}"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +247,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 06 Jun 2021 13:41:36 GMT"
+              "value": "Thu, 15 Jul 2021 21:22:52 GMT"
             },
             {
               "name": "content-type",
@@ -267,15 +267,15 @@
             },
             {
               "name": "request-id",
-              "value": "2041ee41-78d0-44b1-996f-53542ead895d"
+              "value": "7bfb8755-6177-4480-a797-49aa175c4107"
             },
             {
               "name": "client-request-id",
-              "value": "9b21dcd8-89f2-19ac-9a5f-ac1bebf4a10b"
+              "value": "d59a8a17-ae49-1264-80d7-46c7146ae8ab"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"CH01EPF000076C7\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"DS2PEPF00000A0B\"}}"
             },
             {
               "name": "x-ms-resource-unit",
@@ -286,14 +286,14 @@
               "value": "4.0"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 606,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-06T13:41:37.830Z",
-        "time": 310,
+        "startedDateTime": "2021-07-15T21:22:51.778Z",
+        "time": 500,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,7 +301,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 310
+          "wait": 500
         }
       },
       {
@@ -367,7 +367,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-07-06T13:41:37.000Z",
+              "expires": "2021-08-14T21:22:52.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -423,11 +423,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "c3843554-fe05-49ac-86d8-319816d6db00"
+              "value": "b0af1aae-0163-42a3-baeb-258e9bfe0e02"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11787.14 - SCUS ProdSlices"
+              "value": "2.1.11898.8 - SCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -446,7 +446,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 06 Jun 2021 13:41:37 GMT"
+              "value": "Thu, 15 Jul 2021 21:22:52 GMT"
             },
             {
               "name": "connection",
@@ -457,14 +457,14 @@
               "value": "1680"
             }
           ],
-          "headersSize": 736,
+          "headersSize": 735,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-06T13:41:38.151Z",
-        "time": 254,
+        "startedDateTime": "2021-07-15T21:22:52.282Z",
+        "time": 518,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -472,7 +472,561 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 254
+          "wait": 518
+        }
+      },
+      {
+        "_id": "68a77028f5a29f2d156580a914e580df",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "e9d03716-3639-084f-7147-9060a527ed21"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 2121,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "$select",
+              "value": "businessPhones,displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,userPrincipalName,id,userType,accountEnabled"
+            }
+          ],
+          "url": "https://graph.microsoft.com/v1.0/users?%24select=businessPhones%2CdisplayName%2CgivenName%2CjobTitle%2Cmail%2CmobilePhone%2CofficeLocation%2CpreferredLanguage%2Csurname%2CuserPrincipalName%2Cid%2CuserType%2CaccountEnabled"
+        },
+        "response": {
+          "bodySize": 1628,
+          "content": {
+            "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
+            "size": 1628,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#users(businessPhones,displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,userPrincipalName,id,userType,accountEnabled)\",\"value\":[{\"businessPhones\":[],\"displayName\":\"Austin Kelleher\",\"givenName\":null,\"jobTitle\":null,\"mail\":null,\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"austin.kelleher@ndowmongmail.onmicrosoft.com\",\"id\":\"f4cb0699-41f7-4c69-a1f2-f497d3f11ced\",\"userType\":\"Member\",\"accountEnabled\":false},{\"businessPhones\":[],\"displayName\":\"Austin Kelleher\",\"givenName\":null,\"jobTitle\":null,\"mail\":\"austin.kellher@jupiterone.com\",\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"austin.kellher_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"d87d02c5-e07e-4093-a274-0232864312fe\",\"userType\":\"Guest\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"George Tang\",\"givenName\":null,\"jobTitle\":null,\"mail\":\"george.tang@jupiterone.com\",\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"george.tang_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"3d3792aa-2a78-462f-b1ae-29444eddf42e\",\"userType\":\"Guest\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"Kenan Warren\",\"givenName\":null,\"jobTitle\":null,\"mail\":\"kenan.warren@jupiterone.com\",\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"kenan.warren_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"cdf4e7df-d739-4dfb-a6dd-9bae437ae342\",\"userType\":\"Guest\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"Hacker\",\"givenName\":null,\"jobTitle\":null,\"mail\":null,\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"malicious-user@ndowmongmail.onmicrosoft.com\",\"id\":\"3716c478-49bf-4750-b445-dfe82fe7fce6\",\"userType\":\"Member\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"Michael Knoedel\",\"givenName\":\"Michael\",\"jobTitle\":null,\"mail\":\"michael.knoedel@adamjupiteronehotmailcom.onmicrosoft.com\",\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":\"Knoedel\",\"userPrincipalName\":\"michael.knoedel_adamjupiteronehotmailcom.onmicrosoft.c#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"b7e4c9d6-b02b-471e-a68b-90952788dc81\",\"userType\":\"Guest\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"Nick Dowmon\",\"givenName\":\"Nick\",\"jobTitle\":null,\"mail\":null,\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":\"en\",\"surname\":\"Dowmon\",\"userPrincipalName\":\"ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"b6e7f627-8731-47bd-be0e-477d1cbc6e17\",\"userType\":\"Member\",\"accountEnabled\":true},{\"businessPhones\":[],\"displayName\":\"Nick Dowmon\",\"givenName\":null,\"jobTitle\":null,\"mail\":\"nick.dowmon@jupiterone.com\",\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":null,\"surname\":null,\"userPrincipalName\":\"nick.dowmon_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\",\"id\":\"184bb7d9-1fab-4e08-8cf5-d618a22e2873\",\"userType\":\"Guest\",\"accountEnabled\":true}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Jul 2021 21:22:52 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "918af5c7-35c1-4fa0-9881-60d66b46c994"
+            },
+            {
+              "name": "client-request-id",
+              "value": "e9d03716-3639-084f-7147-9060a527ed21"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"DS2PEPF000009B3\"}}"
+            },
+            {
+              "name": "x-ms-resource-unit",
+              "value": "2"
+            },
+            {
+              "name": "odata-version",
+              "value": "4.0"
+            }
+          ],
+          "headersSize": 606,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-15T21:22:52.802Z",
+        "time": 322,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 322
+        }
+      },
+      {
+        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 176,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "176"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1680,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1680,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-08-14T21:22:53.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "45fcf3ac-ff35-4479-9164-d351693a2f02"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11898.8 - EUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Jul 2021 21:22:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1680"
+            }
+          ],
+          "headersSize": 734,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-15T21:22:53.128Z",
+        "time": 372,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 372
+        }
+      },
+      {
+        "_id": "2e7551996100df0ce4860e42ff94345d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "a0613fec-5d12-5029-3d55-1bc5df4236a9"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 1984,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://graph.microsoft.com/v1.0/groups/1f70c83c-1ebb-4ff7-be53-81e666312a39/members"
+        },
+        "response": {
+          "bodySize": 620,
+          "content": {
+            "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
+            "size": 620,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#directoryObjects\",\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"b6e7f627-8731-47bd-be0e-477d1cbc6e17\",\"businessPhones\":[],\"displayName\":\"Nick Dowmon\",\"givenName\":\"Nick\",\"jobTitle\":null,\"mail\":null,\"mobilePhone\":null,\"officeLocation\":null,\"preferredLanguage\":\"en\",\"surname\":\"Dowmon\",\"userPrincipalName\":\"ndowmon_gmail.com#EXT#@ndowmongmail.onmicrosoft.com\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Jul 2021 21:22:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "78c2b332-bc6c-4b9e-b61c-06d601845a99"
+            },
+            {
+              "name": "client-request-id",
+              "value": "a0613fec-5d12-5029-3d55-1bc5df4236a9"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"DS1PEPF00002044\"}}"
+            },
+            {
+              "name": "x-ms-resource-unit",
+              "value": "3"
+            },
+            {
+              "name": "odata-version",
+              "value": "4.0"
+            }
+          ],
+          "headersSize": 606,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-15T21:22:53.502Z",
+        "time": 359,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 359
+        }
+      },
+      {
+        "_id": "93792aaaf8310639e5181e938764aef7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "client-request-id",
+              "value": "afbaf5ff-2c4b-bace-9f4b-11ef9dc75b27"
+            },
+            {
+              "_fromType": "array",
+              "name": "sdkversion",
+              "value": "graph-js/2.0.0 (featureUsage=7)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "graph.microsoft.com"
+            }
+          ],
+          "headersSize": 1984,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://graph.microsoft.com/v1.0/groups/c028f907-7e1a-47eb-8507-75dd442dcbc0/members"
+        },
+        "response": {
+          "bodySize": 1126,
+          "content": {
+            "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
+            "size": 1126,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#directoryObjects\",\"value\":[{\"@odata.type\":\"#microsoft.graph.group\",\"id\":\"1f70c83c-1ebb-4ff7-be53-81e666312a39\",\"deletedDateTime\":null,\"classification\":null,\"createdDateTime\":\"2021-07-15T14:59:26Z\",\"creationOptions\":[],\"description\":null,\"displayName\":\"Crypto Team\",\"expirationDateTime\":null,\"groupTypes\":[],\"isAssignableToRole\":null,\"mail\":null,\"mailEnabled\":false,\"mailNickname\":\"b6ccff58-1\",\"membershipRule\":null,\"membershipRuleProcessingState\":null,\"onPremisesDomainName\":null,\"onPremisesLastSyncDateTime\":null,\"onPremisesNetBiosName\":null,\"onPremisesSamAccountName\":null,\"onPremisesSecurityIdentifier\":null,\"onPremisesSyncEnabled\":null,\"preferredDataLocation\":null,\"preferredLanguage\":null,\"proxyAddresses\":[],\"renewedDateTime\":\"2021-07-15T14:59:26Z\",\"resourceBehaviorOptions\":[],\"resourceProvisioningOptions\":[],\"securityEnabled\":true,\"securityIdentifier\":\"S-1-12-1-527484988-1341595323-3867235262-959066470\",\"theme\":null,\"visibility\":null,\"onPremisesProvisioningErrors\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Jul 2021 21:22:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "request-id",
+              "value": "caefd52d-c030-428e-b352-02f8ce258fec"
+            },
+            {
+              "name": "client-request-id",
+              "value": "afbaf5ff-2c4b-bace-9f4b-11ef9dc75b27"
+            },
+            {
+              "name": "x-ms-ags-diagnostic",
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"DS1PEPF0000203A\"}}"
+            },
+            {
+              "name": "x-ms-resource-unit",
+              "value": "3"
+            },
+            {
+              "name": "odata-version",
+              "value": "4.0"
+            }
+          ],
+          "headersSize": 606,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-15T21:22:53.863Z",
+        "time": 336,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 336
         }
       },
       {
@@ -491,7 +1045,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "6785a6ef-a8d2-8eb7-54a1-659a395e1d85"
+              "value": "9c61a87f-8692-d34f-7473-f0632f1b4600"
             },
             {
               "_fromType": "array",
@@ -544,7 +1098,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 06 Jun 2021 13:41:38 GMT"
+              "value": "Thu, 15 Jul 2021 21:22:54 GMT"
             },
             {
               "name": "content-type",
@@ -564,15 +1118,15 @@
             },
             {
               "name": "request-id",
-              "value": "ade2259d-1b03-4094-94a3-446aea1adbcb"
+              "value": "bfbe015f-5d98-445c-a6d1-427c25403589"
             },
             {
               "name": "client-request-id",
-              "value": "6785a6ef-a8d2-8eb7-54a1-659a395e1d85"
+              "value": "9c61a87f-8692-d34f-7473-f0632f1b4600"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"CH01EPF000076CA\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Central US\",\"Slice\":\"E\",\"Ring\":\"2\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"DS1PEPF0000202E\"}}"
             },
             {
               "name": "x-ms-resource-unit",
@@ -583,14 +1137,14 @@
               "value": "4.0"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 606,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-06T13:41:38.408Z",
-        "time": 258,
+        "startedDateTime": "2021-07-15T21:22:54.202Z",
+        "time": 371,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -598,7 +1152,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 258
+          "wait": 371
         }
       }
     ],

--- a/src/steps/active-directory/converters.test.ts
+++ b/src/steps/active-directory/converters.test.ts
@@ -1,15 +1,7 @@
-import {
-  Entity,
-  IntegrationInstance,
-  MappedRelationship,
-  RelationshipDirection,
-} from '@jupiterone/integration-sdk-core';
+import { IntegrationInstance } from '@jupiterone/integration-sdk-core';
 import { Organization, User, Group } from '@microsoft/microsoft-graph-types';
 
-import {
-  GroupMember,
-  IdentitySecurityDefaultsEnforcementPolicy,
-} from './client';
+import { IdentitySecurityDefaultsEnforcementPolicy } from './client';
 import {
   GROUP_ENTITY_CLASS,
   GROUP_ENTITY_TYPE,
@@ -22,7 +14,6 @@ import {
   createAccountGroupRelationship,
   createAccountUserRelationship,
   createGroupEntity,
-  createGroupMemberRelationship,
   createUserEntity,
   createServicePrincipalEntity,
 } from './converters';
@@ -399,139 +390,5 @@ describe('createAccountUserRelationship', () => {
       _type: 'azure_account_has_user',
       displayName: 'HAS',
     });
-  });
-});
-
-describe('createGroupMemberRelationship', () => {
-  const groupEntity: Entity = {
-    id: '89fac263-2430-48fd-9278-dacfdfc89792',
-    _key: '89fac263-2430-48fd-9278-dacfdfc89792',
-    _type: GROUP_ENTITY_TYPE,
-    _class: GROUP_ENTITY_CLASS,
-  };
-
-  test('properties transferred for users', () => {
-    const member: GroupMember = {
-      '@odata.type': '#microsoft.graph.user',
-      id: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      displayName: 'User Name',
-      jobTitle: 'Job Title',
-      mail: 'user@example.com',
-    };
-
-    const relationship: MappedRelationship & {
-      groupId: string;
-      memberId: string;
-      memberType: string;
-    } = {
-      _class: 'HAS',
-      _key:
-        '89fac263-2430-48fd-9278-dacfdfc89792_324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      _type: 'azure_group_has_member',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '89fac263-2430-48fd-9278-dacfdfc89792',
-        targetFilterKeys: [['_type', '_key']],
-        targetEntity: {
-          _key: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-          _type: 'azure_user',
-          _class: 'User',
-          displayName: 'User Name',
-          jobTitle: 'Job Title',
-          email: 'user@example.com',
-        },
-      },
-      groupId: '89fac263-2430-48fd-9278-dacfdfc89792',
-      memberId: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      memberType: '#microsoft.graph.user',
-      displayName: 'HAS',
-    };
-
-    expect(createGroupMemberRelationship(groupEntity, member)).toEqual(
-      relationship,
-    );
-  });
-
-  test('properties transferred for groups', () => {
-    const member: GroupMember = {
-      '@odata.type': '#microsoft.graph.group',
-      id: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      displayName: 'Managers',
-      jobTitle: null,
-      mail: null,
-    };
-
-    const relationship: MappedRelationship & {
-      groupId: string;
-      memberId: string;
-      memberType: string;
-    } = {
-      _class: 'HAS',
-      _key:
-        '89fac263-2430-48fd-9278-dacfdfc89792_324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      _type: 'azure_group_has_member',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '89fac263-2430-48fd-9278-dacfdfc89792',
-        targetFilterKeys: [['_type', '_key']],
-        targetEntity: {
-          _key: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-          _type: 'azure_user_group',
-          _class: 'UserGroup',
-          displayName: 'Managers',
-          jobTitle: null,
-          email: null,
-        },
-      },
-      groupId: '89fac263-2430-48fd-9278-dacfdfc89792',
-      memberId: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      memberType: '#microsoft.graph.group',
-      displayName: 'HAS',
-    };
-
-    expect(createGroupMemberRelationship(groupEntity, member)).toEqual(
-      relationship,
-    );
-  });
-
-  test('properties transferred for other', () => {
-    const member: GroupMember = {
-      '@odata.type': '#microsoft.graph.directoryObject',
-      id: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      displayName: "Don't really know",
-      jobTitle: null,
-    };
-
-    const relationship: MappedRelationship & {
-      groupId: string;
-      memberId: string;
-      memberType: string;
-    } = {
-      _class: 'HAS',
-      _key:
-        '89fac263-2430-48fd-9278-dacfdfc89792_324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      _type: 'azure_group_has_member',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '89fac263-2430-48fd-9278-dacfdfc89792',
-        targetFilterKeys: [['_type', '_key']],
-        targetEntity: {
-          _key: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-          _type: 'azure_group_member',
-          _class: 'User',
-          displayName: "Don't really know",
-          jobTitle: null,
-          email: undefined,
-        },
-      },
-      groupId: '89fac263-2430-48fd-9278-dacfdfc89792',
-      memberId: '324e8daa-9c29-42a4-a74b-b9893e6d9750',
-      memberType: '#microsoft.graph.directoryObject',
-      displayName: 'HAS',
-    };
-
-    expect(createGroupMemberRelationship(groupEntity, member)).toEqual(
-      relationship,
-    );
   });
 });

--- a/src/steps/active-directory/converters.ts
+++ b/src/steps/active-directory/converters.ts
@@ -8,20 +8,13 @@ import {
   getTime,
   IntegrationInstance,
   Relationship,
-  RelationshipDirection,
   assignTags,
-  createMappedRelationship,
   setRawData,
 } from '@jupiterone/integration-sdk-core';
 import { Group, Organization, User } from '@microsoft/microsoft-graph-types';
 
+import { generateEntityKey } from '../../utils/generateKeys';
 import {
-  generateEntityKey,
-  generateRelationshipKey,
-} from '../../utils/generateKeys';
-import {
-  GroupMember,
-  MemberType,
   IdentitySecurityDefaultsEnforcementPolicy,
   CredentialUserRegistrationDetails,
 } from './client';
@@ -31,9 +24,6 @@ import {
   ACCOUNT_GROUP_RELATIONSHIP_TYPE,
   GROUP_ENTITY_CLASS,
   GROUP_ENTITY_TYPE,
-  GROUP_MEMBER_ENTITY_CLASS,
-  GROUP_MEMBER_ENTITY_TYPE,
-  GROUP_MEMBER_RELATIONSHIP_TYPE,
   USER_ENTITY_CLASS,
   USER_ENTITY_TYPE,
   SERVICE_PRINCIPAL_ENTITY_CLASS,
@@ -205,61 +195,4 @@ export function createAccountUserRelationship(
     toType: USER_ENTITY_TYPE,
     toKey,
   });
-}
-
-export function createGroupMemberRelationship(
-  group: Entity,
-  member: GroupMember,
-): Relationship {
-  const memberEntityType = getGroupMemberEntityType(member);
-  const memberEntityClass = getGroupMemberEntityClass(member);
-
-  const groupKey = generateEntityKey(group.id);
-  const memberKey = generateEntityKey(member.id);
-
-  return createMappedRelationship({
-    _class: RelationshipClass.HAS,
-    _key: generateRelationshipKey(groupKey, memberKey),
-    _type: GROUP_MEMBER_RELATIONSHIP_TYPE,
-    _mapping: {
-      relationshipDirection: RelationshipDirection.FORWARD,
-      sourceEntityKey: groupKey,
-      targetFilterKeys: [['_type', '_key']],
-      targetEntity: {
-        _type: memberEntityType,
-        _class: memberEntityClass,
-        _key: memberKey,
-        displayName: member.displayName,
-        jobTitle: member.jobTitle,
-        email: member.mail,
-      },
-    },
-    properties: {
-      groupId: group.id as string,
-      memberId: member.id,
-      memberType: member['@odata.type'],
-    },
-  });
-}
-
-function getGroupMemberEntityType(member: GroupMember): string {
-  switch (member['@odata.type']) {
-    case MemberType.USER:
-      return USER_ENTITY_TYPE;
-    case MemberType.GROUP:
-      return GROUP_ENTITY_TYPE;
-    default:
-      return GROUP_MEMBER_ENTITY_TYPE;
-  }
-}
-
-function getGroupMemberEntityClass(member: GroupMember): string {
-  switch (member['@odata.type']) {
-    case MemberType.USER:
-      return USER_ENTITY_CLASS;
-    case MemberType.GROUP:
-      return GROUP_ENTITY_CLASS;
-    default:
-      return GROUP_MEMBER_ENTITY_CLASS;
-  }
 }


### PR DESCRIPTION
I noticed when working on a blog post that the mapped relationships we're creating here are unnecessary and not as reliable as direct relationships.

```
### Changed

- Changed `azure_group_has_member` relationships from mapped to direct, because
  group members always exist in the same directory as the group.
```