### PR TITLE
Use case-insensitive switch statement for policy definition source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to
 
 ### Fixed
 
+- Identify policy definition source (subscription, management group, or
+  built-in) using a case-insensitive switch statement, since Azure resource IDs
+  do not use consistent casing.
 - Fixed an issue where DNS Zones and Private DNS Zones threw an error if a
   subscription had not registered the `Microsoft.Network` provider
 

--- a/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
+++ b/src/steps/resource-manager/policy/findOrCreatePolicyDefinitionEntityFromAssignment.ts
@@ -243,17 +243,21 @@ enum PolicyDefinitionSource {
 function getDefinitionSource(
   policyDefinitionId: string,
 ): PolicyDefinitionSource {
-  if (policyDefinitionId.startsWith('/subscriptions/')) {
+  if (policyDefinitionId.toLowerCase().startsWith('/subscriptions/')) {
     return PolicyDefinitionSource.SUBSCRIPTION;
   }
   if (
-    policyDefinitionId.startsWith(
-      '/providers/Microsoft.Management/managementGroups/',
-    )
+    policyDefinitionId
+      .toLowerCase()
+      .startsWith('/providers/microsoft.management/managementgroups/')
   ) {
     return PolicyDefinitionSource.MANAGEMENT_GROUP;
   }
-  if (policyDefinitionId.startsWith('/providers/Microsoft.Authorization/')) {
+  if (
+    policyDefinitionId
+      .toLowerCase()
+      .startsWith('/providers/microsoft.authorization/')
+  ) {
     return PolicyDefinitionSource.BUILT_IN;
   }
 


### PR DESCRIPTION
We are seeing instances in production where the policy definition actually starts with `/providers/Microsoft.Management/managementgroups/`, which is causing us to throw the error `The policy definition  <<POLICY_DEFINITION_ID>> does not match any known sources`


```
### Fixed

- Identify policy definition source (subscription, management group, or
  built-in) using a case-insensitive switch statement, since Azure resource IDs
  do not use consistent casing.
```