### PR TITLE
INT-1782 - Add AppServices (Section 9) CIS benchmarks

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -112,6 +112,9 @@ information:
 1. Create a custom role called "JupiterOne Reader" with the following
    permissions:
    - `Microsoft.PolicyInsights/policyStates/queryResults/action`
+1. (Optional) If you'd like integration to be able to fetch auth settings for
+   all Web Apps, add the following permissions to the same custom role:
+   - `Microsoft.Web/sites/config/list/Action`
 1. Select **Role** "JupiterOne Reader", **Assign access to** "Azure AD user,
    group, or service principal", and select the app "JupiterOne"
 1. _If configuring all subscriptions for a tenant (using the

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -2147,3 +2147,236 @@ questions:
     requirements:
       - '7.7'
 
+##########################################
+# CIS 9 - AppService
+##########################################
+- id: integration-question-azure-appservice-authentication-enabled
+  title: Is app service authentication enabled for all Azure app services?
+  description:
+    Checks the app service authentication state of all Azure app services
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with authEnabled = true
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with authEnabled = false
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.1'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.1'
+- id: integration-question-azure-appservice-http-https-redirection
+  title: Are all Azure Web Apps redirecting HTTP traffic to HTTPS?
+  description:
+    Checks the HTTPS redirection SSL settings of all Azure Web Apps.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with httpsOnly = true
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with httpsOnly = false
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.2'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.2'
+- id: integration-question-azure-appservice-tls-version
+  title: Are all Azure Web Apps using latest version of TLS encryption?
+  description:
+    Checks the version of TLS in use of all Azure Web Apps.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with minTlsVersion = "1.2"
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with minTlsVersion != "1.2"
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.3'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.3'
+- id: integration-question-azure-appservice-client-certificates
+  title: Are all Azure Web Apps requiring the client certificates?
+  description:
+    Checks that all Azure Web Apps has option "client certificate mode" set to "require".
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with clientCertEnabled = true
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with clientCertEnabled = false
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.4'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.4'
+- id: integration-question-azure-appservice-register-azure-active-directory
+  title: Are all Azure Web Apps using "Register with Azure Active Directory"?
+  description:
+    Checks that all Azure Web Apps have "Register with Azure Active Directory" enabled.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with principalId != undefined
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with principalId = undefined
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.5'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.5'
+- id: integration-question-azure-appservice-php-latest-version
+  title: Are all Azure Web Apps using PHP's latest version?
+  description:
+    Checks that all Azure Web Apps are using the latest version of PHP.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with phpVersion = "8.0.11"
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with phpVersion != "8.0.11"
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.6'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.6'
+- id: integration-question-azure-appservice-python-latest-version
+  title: Are all Azure Web Apps using Python's latest version?
+  description:
+    Checks that all Azure Web Apps are using the latest version of Python.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with pythonVersion = "3.9.7"
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with pythonVersion != "3.9.7"
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.7'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.7'
+- id: integration-question-azure-appservice-java-latest-version
+  title: Are all Azure Web Apps using Java's latest version?
+  description:
+    Checks that all Azure Web Apps are using the latest version of Java.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with javaVersion = "16.0.2"
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with javaVersion != "16.0.2"
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.8'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.8'
+- id: integration-question-azure-appservice-http-latest-version
+  title: Are all Azure Web Apps using HTTP's latest version?
+  description:
+    Checks that all Azure Web Apps are using the latest version of HTTP.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with http20Enabled = true
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with http20Enabled != true
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.9'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.9'
+- id: integration-question-azure-appservice-ftp-disabled
+  title: Are all Azure Web Apps FTP deployments disabled?
+  description:
+    Checks that all Azure Web Apps have disabled FTP deployments.
+  queries:
+  - name: good
+    query: |
+      Find (azure_function_app | azure_web_app) with ftpsState != "AllAllowed"
+  - name: bad
+    query: |
+      Find (azure_function_app | azure_web_app) with ftpsState = "AllAllowed"
+  tags:
+  - azure
+  - data
+  compliance:
+  - standard: CIS Azure Foundations v1.3.0
+    version: v1.3.0
+    requirements:
+      - '9.10'
+  - standard: CIS Azure Foundations v1.3.1
+    version: v1.3.1
+    requirements:
+      - '9.10'

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "f388476d-cd8c-48d4-8d75-afc303c5afda"
+              "value": "01367650-8bb7-4b7c-9455-cdea39e44fd5"
             },
             {
               "name": "return-client-request-id",
@@ -41,7 +41,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -56,7 +56,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620414006\",\"not_before\":\"1620410106\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807879\",\"not_before\":\"1631803979\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-06-06T18:00:06.000Z",
+              "expires": "2021-10-16T14:57:59.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -114,10 +114,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -139,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "f388476d-cd8c-48d4-8d75-afc303c5afda"
+              "value": "01367650-8bb7-4b7c-9455-cdea39e44fd5"
             },
             {
               "name": "x-ms-request-id",
-              "value": "8c0d40b2-87d5-4ae6-8095-b65966743100"
+              "value": "8954c7c5-577e-4870-94a9-e2ff5be34000"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - WUS2 ProdSlices"
+              "value": "2.1.12025.15 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -170,11 +166,15 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:06 GMT"
+              "value": "Thu, 16 Sep 2021 14:57:59 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             }
           ],
           "headersSize": 787,
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:06.284Z",
-        "time": 340,
+        "startedDateTime": "2021-09-16T14:57:58.947Z",
+        "time": 811,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 340
+          "wait": 811
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "7f3d01f8-ab67-459d-aab5-6218c1d7955e"
+              "value": "96e8dcfd-063c-4096-9213-f14c87618535"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "903bf57b-a147-4015-929f-6a42355a02b8"
+              "value": "f5a05b0e-c4ad-46b5-b881-85c90388c47e"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "903bf57b-a147-4015-929f-6a42355a02b8"
+              "value": "f5a05b0e-c4ad-46b5-b881-85c90388c47e"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T180007Z:903bf57b-a147-4015-929f-6a42355a02b8"
+              "value": "GERMANYWESTCENTRAL:20210916T145800Z:f5a05b0e-c4ad-46b5-b881-85c90388c47e"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:07 GMT"
+              "value": "Thu, 16 Sep 2021 14:58:00 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:06.628Z",
-        "time": 712,
+        "startedDateTime": "2021-09-16T14:57:59.826Z",
+        "time": 823,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,7 +345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 712
+          "wait": 823
         }
       },
       {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "73934d32-51eb-4f27-8f30-c382a14c418a"
+              "value": "9df5916b-7ac6-41e5-b9a8-7224d95e242e"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1795,
+          "headersSize": 1804,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -415,14 +415,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/sites?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/sites?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 6335,
+          "bodySize": 7565,
           "content": {
             "mimeType": "application/json",
-            "size": 6335,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev\",\"name\":\"ndowmon1-j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-blu-231.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace-Linux/sites/ndowmon1-j1dev\",\"repositorySiteName\":\"ndowmon1-j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev.azurewebsites.net\",\"ndowmon1-j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:11.1666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"20.49.104.23\",\"possibleInboundIpAddresses\":\"20.49.104.23\",\"ftpUsername\":\"ndowmon1-j1dev\\\\$ndowmon1-j1dev\",\"ftpsHostName\":\"ftps://waws-prod-blu-231.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,20.49.104.23\",\"possibleOutboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,40.71.234.29,40.71.234.60,40.71.235.182,40.71.236.158,40.71.237.2,40.71.237.25,40.71.238.120,40.71.238.125,52.151.238.38,40.71.238.146,40.71.238.252,40.71.239.94,20.49.104.23\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-231\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev-webapp\",\"name\":\"ndowmon1-j1dev-webapp\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev-webapp\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace\",\"selfLink\":\"https://waws-prod-blu-243.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace/sites/ndowmon1-j1dev-webapp\",\"repositorySiteName\":\"ndowmon1-j1dev-webapp\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Shared\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:18.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev-webapp\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":true,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"app\",\"inboundIpAddress\":\"20.49.104.31\",\"possibleInboundIpAddresses\":\"20.49.104.31\",\"ftpUsername\":\"ndowmon1-j1dev-webapp\\\\$ndowmon1-j1dev-webapp\",\"ftpsHostName\":\"ftps://waws-prod-blu-243.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,20.49.104.31\",\"possibleOutboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,52.188.42.23,52.142.18.177,52.142.18.40,52.149.202.179,52.154.66.123,52.154.69.195,52.154.70.71,52.154.70.135,52.186.99.104,52.186.101.205,52.142.16.201,52.186.102.198,52.147.209.102,52.149.204.214,52.186.102.230,52.147.209.166,52.147.210.37,52.147.215.140,52.149.206.164,52.190.40.233,52.188.42.100,52.190.43.22,52.224.24.232,52.224.26.145,20.49.104.31\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-243\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}}],\"nextLink\":null,\"id\":null}"
+            "size": 7565,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T13:57:50.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:51:04.09\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -444,7 +444,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1D74359F1F9328C\""
+              "value": "\"1D7AB0B307AF3B8\""
             },
             {
               "name": "vary",
@@ -456,7 +456,822 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "3847e2cd-db6a-485c-a253-8f6f958765ae"
+              "value": "832a4ea6-b216-4d78-a7cd-ecbdc75668ef"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "825933bc-995c-4a43-b208-def7736a21b0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145801Z:825933bc-995c-4a43-b208-def7736a21b0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:00 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 696,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:00.670Z",
+        "time": 805,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 805
+        }
+      },
+      {
+        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3809d799-e4f7-42ee-b657-bf9dd6ce7a61"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1879,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3387,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3387,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "74203195-15a9-4e36-a90e-f028ed796f8e"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "875287df-048f-4469-bbf5-870e44f2d758"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145802Z:875287df-048f-4469-bbf5-870e44f2d758"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:01 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:01.490Z",
+        "time": 1283,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1283
+        }
+      },
+      {
+        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "fda88dfa-4b9e-4344-913e-9794c0d83453"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1275,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1275,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3ca6a714-0b44-499f-a158-c7ee2495f936"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "44f92059-d794-413d-823b-0350a44fa592"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145804Z:44f92059-d794-413d-823b-0350a44fa592"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:03 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:02.780Z",
+        "time": 1644,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1644
+        }
+      },
+      {
+        "_id": "66df4f2354a07c13123b230a00d098f1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "77ae7718-0c15-4fe8-8d27-b93565a3a087"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1875,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 4215,
+          "content": {
+            "mimeType": "application/json",
+            "size": 4215,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "6e2f610d-a70e-4fee-a092-16b144be6fcf"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "0336fcb3-a387-49b7-8efb-0b3dc1d07ad7"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145805Z:0336fcb3-a387-49b7-8efb-0b3dc1d07ad7"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:04.472Z",
+        "time": 1058,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1058
+        }
+      },
+      {
+        "_id": "45e0e867a19f53e0647b38347759e808",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "db259ed8-d42d-4178-b0a4-144570d624ce"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1909,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"enabled\":true,\"runtimeVersion\":\"~1\",\"httpApiPrefixPath\":\"/.auth\",\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"tokenStoreEnabled\":true,\"allowedExternalRedirectUrls\":[],\"defaultProvider\":null,\"tokenRefreshExtensionHours\":72.0,\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecret\":null,\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\",\"clientSecretCertificateThumbprint\":null,\"issuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"allowedAudiences\":[],\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":\"{\\\"allowed_groups\\\":null,\\\"allowed_client_applications\\\":null}\",\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"isAuthFromFile\":\"False\",\"configVersion\":\"v2\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "aacee9d1-1bdb-4f18-9066-fcee7993ae04"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9754c246-10f1-40b5-8342-03e22fc6d6d1"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145806Z:9754c246-10f1-40b5-8342-03e22fc6d6d1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:05 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:05.540Z",
+        "time": 1155,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1155
+        }
+      },
+      {
+        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ba8de762-2275-4c79-b39f-631eb6410417"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1876,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3347,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3347,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1269aec3-8d45-4321-a2b8-a55cb39621da"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
@@ -476,11 +1291,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "9f9791a1-891f-4be3-967c-e8ffc7b2f0c0"
+              "value": "207028a9-0278-4754-aaec-8e53fa3d0d63"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T180007Z:9f9791a1-891f-4be3-967c-e8ffc7b2f0c0"
+              "value": "GERMANYWESTCENTRAL:20210916T145807Z:207028a9-0278-4754-aaec-8e53fa3d0d63"
             },
             {
               "name": "x-content-type-options",
@@ -488,21 +1303,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:07 GMT"
+              "value": "Thu, 16 Sep 2021 14:58:06 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 687,
+          "headersSize": 671,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:07.346Z",
-        "time": 467,
+        "startedDateTime": "2021-09-16T14:58:06.707Z",
+        "time": 1006,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -510,7 +1325,173 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 467
+          "wait": 1006
+        }
+      },
+      {
+        "_id": "1acc9a3fff82d923ec4342b692df3c30",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "4fecf0d5-58ee-4de8-b07d-1bfaeedba6be"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1910,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1279,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1279,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a5b1c6b1-df6b-4a81-ae6b-c790406ef054"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "cd973ebb-c1dd-4131-aca1-4b64e326a272"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145808Z:cd973ebb-c1dd-4131-aca1-4b64e326a272"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:58:08 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:58:07.722Z",
+        "time": 1094,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1094
         }
       },
       {
@@ -531,7 +1512,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "d53e0bb9-b491-4207-93e4-15ee97505479"
+              "value": "e23a35ea-2a09-47fe-9896-5341064a0648"
             },
             {
               "name": "return-client-request-id",
@@ -547,7 +1528,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -562,7 +1543,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -576,18 +1557,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620414008\",\"not_before\":\"1620410108\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807889\",\"not_before\":\"1631803989\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-06-06T18:00:08.000Z",
+              "expires": "2021-10-16T14:58:09.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -620,10 +1601,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -645,15 +1622,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "d53e0bb9-b491-4207-93e4-15ee97505479"
+              "value": "e23a35ea-2a09-47fe-9896-5341064a0648"
             },
             {
               "name": "x-ms-request-id",
-              "value": "430e768d-f158-4681-8122-0fbcfd0df900"
+              "value": "c2a230ba-11c9-476b-9ffb-f23d66820100"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - EUS ProdSlices"
+              "value": "2.1.12025.15 - WUS2 ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -676,21 +1653,25 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:07 GMT"
+              "value": "Thu, 16 Sep 2021 14:58:09 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             }
           ],
-          "headersSize": 786,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:07.823Z",
-        "time": 273,
+        "startedDateTime": "2021-09-16T14:58:08.840Z",
+        "time": 891,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -698,7 +1679,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 891
         }
       },
       {
@@ -717,7 +1698,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "53242dbc-605a-4077-b0d1-5073bca18c92"
+              "value": "99530652-b66e-412b-9dce-dd07f20af62b"
             },
             {
               "_fromType": "array",
@@ -732,7 +1713,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -759,7 +1740,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -771,11 +1752,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -805,15 +1786,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+              "value": "fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+              "value": "fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T180008Z:0f4a69af-8db2-4cdf-bfa0-5edf604c6ed2"
+              "value": "GERMANYWESTCENTRAL:20210916T145810Z:fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
             },
             {
               "name": "strict-transport-security",
@@ -825,7 +1806,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:07 GMT"
+              "value": "Thu, 16 Sep 2021 14:58:09 GMT"
             },
             {
               "name": "connection",
@@ -833,17 +1814,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:08.100Z",
-        "time": 474,
+        "startedDateTime": "2021-09-16T14:58:09.735Z",
+        "time": 811,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -851,7 +1832,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 474
+          "wait": 811
         }
       },
       {
@@ -875,7 +1856,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "ab25450f-24be-413b-bcf1-766d60b2a98e"
+              "value": "7eb5966a-a4e5-4302-90a2-3cbce603ad15"
             },
             {
               "_fromType": "array",
@@ -885,7 +1866,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -912,7 +1893,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1801,
+          "headersSize": 1810,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -921,14 +1902,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/serverfarms?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/serverfarms?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 1801,
+          "bodySize": 1965,
           "content": {
             "mimeType": "application/json",
-            "size": 1801,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"name\":\"ASP-j1dev-function-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"functionapp\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789047,\"name\":\"ASP-j1dev-function-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":0,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"functionapp\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"Y1\",\"tier\":\"Dynamic\",\"size\":\"Y1\",\"family\":\"Y\",\"capacity\":0}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"name\":\"ASP-j1dev-web-app\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"serverFarmId\":1789048,\"name\":\"ASP-j1dev-web-app\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"j1dev-EastUSwebspace\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":1,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"East US\",\"perSiteScaling\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"app\",\"resourceGroup\":\"j1dev\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"azBalancing\":null},\"sku\":{\"name\":\"F1\",\"tier\":\"Free\",\"size\":\"F1\",\"family\":\"F\",\"capacity\":0}}],\"nextLink\":null,\"id\":null}"
+            "size": 1965,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"name\":\"ASP-StefanAppServicesGroup-99a7\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"serverFarmId\":3381187,\"name\":\"ASP-StefanAppServicesGroup-99a7\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":0,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":0,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"Central US\",\"perSiteScaling\":null,\"elasticScaleEnabled\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":null,\"kind\":\"functionapp\",\"resourceGroup\":\"Stefan_AppServices_Group\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"zoneRedundant\":null},\"sku\":{\"name\":\"Y1\",\"tier\":\"Dynamic\",\"size\":\"Y1\",\"family\":\"Y\",\"capacity\":0}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"name\":\"ExampleAppServicePlan\",\"type\":\"Microsoft.Web/serverfarms\",\"kind\":\"linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"serverFarmId\":3373038,\"name\":\"ExampleAppServicePlan\",\"workerSize\":\"Default\",\"workerSizeId\":0,\"workerTierName\":null,\"numberOfWorkers\":1,\"currentWorkerSize\":null,\"currentWorkerSizeId\":null,\"currentNumberOfWorkers\":null,\"status\":\"Ready\",\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"subscription\":null,\"adminSiteName\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"maximumNumberOfWorkers\":1,\"planName\":\"VirtualDedicatedPlan\",\"adminRuntimeSiteName\":null,\"computeMode\":\"Shared\",\"siteMode\":null,\"geoRegion\":\"Central US\",\"perSiteScaling\":null,\"elasticScaleEnabled\":null,\"maximumElasticWorkerCount\":null,\"numberOfSites\":0,\"hostingEnvironmentId\":null,\"isSpot\":null,\"spotExpirationTime\":null,\"freeOfferExpirationTime\":null,\"tags\":{},\"kind\":\"linux\",\"resourceGroup\":\"Stefan_AppServices_Group\",\"reserved\":null,\"isXenon\":null,\"hyperV\":null,\"mdmId\":null,\"targetWorkerCount\":null,\"targetWorkerSizeId\":null,\"provisioningState\":null,\"webSiteId\":null,\"existingServerFarmIds\":null,\"kubeEnvironmentProfile\":null,\"zoneRedundant\":null},\"sku\":{\"name\":\"F1\",\"tier\":\"Free\",\"size\":\"F1\",\"family\":\"F\",\"capacity\":1}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -958,7 +1939,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "409e1f64-6194-495e-88f2-6333f96b8cd5"
+              "value": "d8e51fda-4474-4de9-b8c4-04d76f1a828c"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
@@ -978,11 +1959,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "fdabfc8a-dd39-420f-957b-fd2440c98c41"
+              "value": "96b13d10-4bcf-4e00-bfa9-5af0f0cbd466"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T180009Z:fdabfc8a-dd39-420f-957b-fd2440c98c41"
+              "value": "GERMANYWESTCENTRAL:20210916T145811Z:96b13d10-4bcf-4e00-bfa9-5af0f0cbd466"
             },
             {
               "name": "x-content-type-options",
@@ -990,21 +1971,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 18:00:08 GMT"
+              "value": "Thu, 16 Sep 2021 14:58:11 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 662,
+          "headersSize": 671,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T18:00:08.580Z",
-        "time": 334,
+        "startedDateTime": "2021-09-16T14:58:10.559Z",
+        "time": 849,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1012,7 +1993,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 334
+          "wait": 849
         }
       }
     ],

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-app-plan-relationships_169005199/recording.har
@@ -12,7 +12,7 @@
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 172,
+          "bodySize": 175,
           "cookies": [],
           "headers": [
             {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "01367650-8bb7-4b7c-9455-cdea39e44fd5"
+              "value": "b071001f-69a0-40d7-a7c5-aa08740e1117"
             },
             {
               "name": "return-client-request-id",
@@ -53,7 +53,7 @@
             },
             {
               "name": "content-length",
-              "value": 172
+              "value": 175
             }
           ],
           "headersSize": 413,
@@ -77,11 +77,11 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807879\",\"not_before\":\"1631803979\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1633530587\",\"not_before\":\"1633526687\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-10-16T14:57:59.000Z",
+              "expires": "2021-11-05T13:29:47.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "01367650-8bb7-4b7c-9455-cdea39e44fd5"
+              "value": "b071001f-69a0-40d7-a7c5-aa08740e1117"
             },
             {
               "name": "x-ms-request-id",
-              "value": "8954c7c5-577e-4870-94a9-e2ff5be34000"
+              "value": "67cdb738-e8f3-481c-87e5-068eacbf3700"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.12025.15 - SCUS ProdSlices"
+              "value": "2.1.12071.28 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:57:59 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:46 GMT"
             },
             {
               "name": "connection",
@@ -183,7 +183,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:57:58.947Z",
+        "startedDateTime": "2021-10-06T13:29:46.690Z",
         "time": 811,
         "timings": {
           "blocked": -1,
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "96e8dcfd-063c-4096-9213-f14c87618535"
+              "value": "57b6ba44-35cc-4e46-95d3-6bdc39a0c1da"
             },
             {
               "_fromType": "array",
@@ -295,19 +295,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "f5a05b0e-c4ad-46b5-b881-85c90388c47e"
+              "value": "fa41c963-d1a5-45e3-8326-a434ac2b73b6"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "f5a05b0e-c4ad-46b5-b881-85c90388c47e"
+              "value": "fa41c963-d1a5-45e3-8326-a434ac2b73b6"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145800Z:f5a05b0e-c4ad-46b5-b881-85c90388c47e"
+              "value": "GERMANYWESTCENTRAL:20211006T132948Z:fa41c963-d1a5-45e3-8326-a434ac2b73b6"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:00 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:47 GMT"
             },
             {
               "name": "connection",
@@ -336,8 +336,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:57:59.826Z",
-        "time": 823,
+        "startedDateTime": "2021-10-06T13:29:47.579Z",
+        "time": 682,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,7 +345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 823
+          "wait": 682
         }
       },
       {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "9df5916b-7ac6-41e5-b9a8-7224d95e242e"
+              "value": "68e2000c-d59a-48ab-ae43-5de43ec6584c"
             },
             {
               "_fromType": "array",
@@ -418,11 +418,11 @@
           "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/sites?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 7565,
+          "bodySize": 7649,
           "content": {
             "mimeType": "application/json",
-            "size": 7565,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T13:57:50.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:51:04.09\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
+            "size": 7649,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-29T07:40:46.91\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"},\"identity\":{\"type\":\"SystemAssigned\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"principalId\":\"b680c0c3-e42a-43a8-94d6-de1c4b16f9ba\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T15:41:39.76\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -444,7 +444,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1D7AB0B307AF3B8\""
+              "value": "\"1D7BAB604D4D25A\""
             },
             {
               "name": "vary",
@@ -456,11 +456,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "832a4ea6-b216-4d78-a7cd-ecbdc75668ef"
+              "value": "58aabb64-0255-40b3-9610-bfd08ef96384"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11997"
+              "value": "11998"
             },
             {
               "name": "server",
@@ -476,11 +476,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "825933bc-995c-4a43-b208-def7736a21b0"
+              "value": "2f543a95-3d06-4619-a5ca-569b6c28e327"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145801Z:825933bc-995c-4a43-b208-def7736a21b0"
+              "value": "GERMANYWESTCENTRAL:20211006T132949Z:2f543a95-3d06-4619-a5ca-569b6c28e327"
             },
             {
               "name": "x-content-type-options",
@@ -488,7 +488,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:00 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:48 GMT"
             },
             {
               "name": "connection",
@@ -501,8 +501,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:00.670Z",
-        "time": 805,
+        "startedDateTime": "2021-10-06T13:29:48.282Z",
+        "time": 764,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -510,168 +510,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 805
-        }
-      },
-      {
-        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "3809d799-e4f7-42ee-b657-bf9dd6ce7a61"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1879,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 3387,
-          "content": {
-            "mimeType": "application/json",
-            "size": 3387,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "74203195-15a9-4e36-a90e-f028ed796f8e"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11997"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "875287df-048f-4469-bbf5-870e44f2d758"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145802Z:875287df-048f-4469-bbf5-870e44f2d758"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:01 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 671,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-09-16T14:58:01.490Z",
-        "time": 1283,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1283
+          "wait": 764
         }
       },
       {
@@ -695,7 +534,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "fda88dfa-4b9e-4344-913e-9794c0d83453"
+              "value": "d424dca6-0d9f-4c31-8dde-da7621f8d8f0"
             },
             {
               "_fromType": "array",
@@ -783,11 +622,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "3ca6a714-0b44-499f-a158-c7ee2495f936"
+              "value": "f41dcadb-2360-4f84-985a-0c440542feb5"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -803,11 +642,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "44f92059-d794-413d-823b-0350a44fa592"
+              "value": "df068bb5-cae2-4f2a-bc86-59733ef60972"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145804Z:44f92059-d794-413d-823b-0350a44fa592"
+              "value": "GERMANYWESTCENTRAL:20211006T132950Z:df068bb5-cae2-4f2a-bc86-59733ef60972"
             },
             {
               "name": "x-content-type-options",
@@ -815,7 +654,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:03 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:50 GMT"
             },
             {
               "name": "connection",
@@ -828,8 +667,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:02.780Z",
-        "time": 1644,
+        "startedDateTime": "2021-10-06T13:29:49.069Z",
+        "time": 1835,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -837,11 +676,177 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1644
+          "wait": 1835
         }
       },
       {
-        "_id": "66df4f2354a07c13123b230a00d098f1",
+        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "95fc9e79-6160-46c9-a6ba-1947ee886d92"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1275,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1275,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "9fa53a7a-bad8-4a62-88c6-d1c0d710dc0a"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "b43c0c67-5229-4fbc-a519-f44e98ea4c3a"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211006T132952Z:b43c0c67-5229-4fbc-a519-f44e98ea4c3a"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 06 Oct 2021 13:29:51 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-06T13:29:50.915Z",
+        "time": 1390,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1390
+        }
+      },
+      {
+        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -861,7 +866,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "77ae7718-0c15-4fe8-8d27-b93565a3a087"
+              "value": "81dc5554-3165-4073-a7b9-b3b7f164272a"
             },
             {
               "_fromType": "array",
@@ -898,7 +903,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1875,
+          "headersSize": 1879,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -907,14 +912,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 4215,
+          "bodySize": 3387,
           "content": {
             "mimeType": "application/json",
-            "size": 4215,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 3387,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -944,11 +949,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "6e2f610d-a70e-4fee-a092-16b144be6fcf"
+              "value": "481ee467-677a-4884-9753-dc1b6c76b153"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11997"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -964,11 +969,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "0336fcb3-a387-49b7-8efb-0b3dc1d07ad7"
+              "value": "df493513-b826-4fee-95b2-a19970fa683b"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145805Z:0336fcb3-a387-49b7-8efb-0b3dc1d07ad7"
+              "value": "GERMANYWESTCENTRAL:20211006T132953Z:df493513-b826-4fee-95b2-a19970fa683b"
             },
             {
               "name": "x-content-type-options",
@@ -976,7 +981,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:05 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:53 GMT"
             },
             {
               "name": "connection",
@@ -989,8 +994,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:04.472Z",
-        "time": 1058,
+        "startedDateTime": "2021-10-06T13:29:52.314Z",
+        "time": 804,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -998,7 +1003,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1058
+          "wait": 804
         }
       },
       {
@@ -1022,7 +1027,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "db259ed8-d42d-4178-b0a4-144570d624ce"
+              "value": "15e071e9-4e3a-4158-b45a-f6c861896069"
             },
             {
               "_fromType": "array",
@@ -1110,11 +1115,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "aacee9d1-1bdb-4f18-9066-fcee7993ae04"
+              "value": "6b16a95f-6d6b-4650-85db-45192db046f9"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11997"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -1130,11 +1135,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "9754c246-10f1-40b5-8342-03e22fc6d6d1"
+              "value": "5c866897-1497-4680-bd23-c2cf00f84bd3"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145806Z:9754c246-10f1-40b5-8342-03e22fc6d6d1"
+              "value": "GERMANYWESTCENTRAL:20211006T132954Z:5c866897-1497-4680-bd23-c2cf00f84bd3"
             },
             {
               "name": "x-content-type-options",
@@ -1142,7 +1147,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:05 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:54 GMT"
             },
             {
               "name": "connection",
@@ -1155,8 +1160,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:05.540Z",
-        "time": 1155,
+        "startedDateTime": "2021-10-06T13:29:53.161Z",
+        "time": 1050,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1164,11 +1169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1155
+          "wait": 1050
         }
       },
       {
-        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_id": "66df4f2354a07c13123b230a00d098f1",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1188,7 +1193,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "ba8de762-2275-4c79-b39f-631eb6410417"
+              "value": "e0cc12a1-9f8c-4476-a329-23b1fbc85ed9"
             },
             {
               "_fromType": "array",
@@ -1225,7 +1230,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1876,
+          "headersSize": 1875,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1234,14 +1239,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 3347,
+          "bodySize": 4231,
           "content": {
             "mimeType": "application/json",
-            "size": 3347,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 4231,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":true,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":3417,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -1271,11 +1276,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "1269aec3-8d45-4321-a2b8-a55cb39621da"
+              "value": "766be65a-739d-41d5-9e46-cc372cc27126"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "server",
@@ -1291,11 +1296,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "207028a9-0278-4754-aaec-8e53fa3d0d63"
+              "value": "97296062-a889-4ba8-8010-623408e25d9d"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145807Z:207028a9-0278-4754-aaec-8e53fa3d0d63"
+              "value": "GERMANYWESTCENTRAL:20211006T132955Z:97296062-a889-4ba8-8010-623408e25d9d"
             },
             {
               "name": "x-content-type-options",
@@ -1303,7 +1308,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:06 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:55 GMT"
             },
             {
               "name": "connection",
@@ -1316,8 +1321,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:06.707Z",
-        "time": 1006,
+        "startedDateTime": "2021-10-06T13:29:54.240Z",
+        "time": 1100,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1325,7 +1330,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1006
+          "wait": 1100
         }
       },
       {
@@ -1349,7 +1354,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "4fecf0d5-58ee-4de8-b07d-1bfaeedba6be"
+              "value": "b7b6d85a-034e-4718-bf1c-cced6df4c181"
             },
             {
               "_fromType": "array",
@@ -1437,10 +1442,171 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "a5b1c6b1-df6b-4a81-ae6b-c790406ef054"
+              "value": "ed796f25-3823-4e48-9af1-929488a7700f"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "2d56c809-4779-4e3d-8e22-1d48f03bfc68"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211006T132956Z:2d56c809-4779-4e3d-8e22-1d48f03bfc68"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 06 Oct 2021 13:29:55 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-06T13:29:55.350Z",
+        "time": 1004,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1004
+        }
+      },
+      {
+        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "306538e0-83ba-4444-bbbf-d0f7da71cdd0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1876,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3347,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3347,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "23007bad-daa6-43d4-afcf-d5e9b3d4a867"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
               "value": "11999"
             },
             {
@@ -1457,11 +1623,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "cd973ebb-c1dd-4131-aca1-4b64e326a272"
+              "value": "f80d8c55-6b7b-4199-99bc-9ec474b91493"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145808Z:cd973ebb-c1dd-4131-aca1-4b64e326a272"
+              "value": "GERMANYWESTCENTRAL:20211006T132958Z:f80d8c55-6b7b-4199-99bc-9ec474b91493"
             },
             {
               "name": "x-content-type-options",
@@ -1469,21 +1635,21 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:08 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:57 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 683,
+          "headersSize": 671,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:07.722Z",
-        "time": 1094,
+        "startedDateTime": "2021-10-06T13:29:56.362Z",
+        "time": 1948,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1491,7 +1657,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1094
+          "wait": 1948
         }
       },
       {
@@ -1499,7 +1665,7 @@
         "_order": 1,
         "cache": {},
         "request": {
-          "bodySize": 172,
+          "bodySize": 175,
           "cookies": [],
           "headers": [
             {
@@ -1512,7 +1678,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "e23a35ea-2a09-47fe-9896-5341064a0648"
+              "value": "4159f967-381a-41a1-8476-a411ffa1fb80"
             },
             {
               "name": "return-client-request-id",
@@ -1540,7 +1706,7 @@
             },
             {
               "name": "content-length",
-              "value": 172
+              "value": 175
             }
           ],
           "headersSize": 413,
@@ -1564,11 +1730,11 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807889\",\"not_before\":\"1631803989\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1633530598\",\"not_before\":\"1633526698\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-10-16T14:58:09.000Z",
+              "expires": "2021-11-05T13:29:59.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1622,15 +1788,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "e23a35ea-2a09-47fe-9896-5341064a0648"
+              "value": "4159f967-381a-41a1-8476-a411ffa1fb80"
             },
             {
               "name": "x-ms-request-id",
-              "value": "c2a230ba-11c9-476b-9ffb-f23d66820100"
+              "value": "d59fc127-3477-41d8-9672-33e0af4b4300"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.12025.15 - WUS2 ProdSlices"
+              "value": "2.1.12071.28 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -1653,7 +1819,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:09 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:58 GMT"
             },
             {
               "name": "connection",
@@ -1670,8 +1836,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:08.840Z",
-        "time": 891,
+        "startedDateTime": "2021-10-06T13:29:58.323Z",
+        "time": 770,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1679,7 +1845,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 891
+          "wait": 770
         }
       },
       {
@@ -1698,7 +1864,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "99530652-b66e-412b-9dce-dd07f20af62b"
+              "value": "12e1ee2b-b970-4f25-8a92-2edf0fb1031a"
             },
             {
               "_fromType": "array",
@@ -1786,15 +1952,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
+              "value": "4796a355-91be-4af9-a0b4-ce9ac4888da9"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
+              "value": "4796a355-91be-4af9-a0b4-ce9ac4888da9"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145810Z:fcbb1d4e-66ed-4e9b-9484-6e52ff0a1f83"
+              "value": "GERMANYWESTCENTRAL:20211006T132959Z:4796a355-91be-4af9-a0b4-ce9ac4888da9"
             },
             {
               "name": "strict-transport-security",
@@ -1806,7 +1972,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:09 GMT"
+              "value": "Wed, 06 Oct 2021 13:29:59 GMT"
             },
             {
               "name": "connection",
@@ -1823,8 +1989,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:09.735Z",
-        "time": 811,
+        "startedDateTime": "2021-10-06T13:29:59.099Z",
+        "time": 820,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1832,7 +1998,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 811
+          "wait": 820
         }
       },
       {
@@ -1856,7 +2022,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "7eb5966a-a4e5-4302-90a2-3cbce603ad15"
+              "value": "276e3025-76ea-48c3-9618-2eaad204a7ef"
             },
             {
               "_fromType": "array",
@@ -1939,7 +2105,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "d8e51fda-4474-4de9-b8c4-04d76f1a828c"
+              "value": "72b037d2-f68f-42e3-9fc4-1c13417b5374"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
@@ -1959,11 +2125,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "96b13d10-4bcf-4e00-bfa9-5af0f0cbd466"
+              "value": "f0555092-43e3-42cf-80ef-28438a118dae"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145811Z:96b13d10-4bcf-4e00-bfa9-5af0f0cbd466"
+              "value": "GERMANYWESTCENTRAL:20211006T133004Z:f0555092-43e3-42cf-80ef-28438a118dae"
             },
             {
               "name": "x-content-type-options",
@@ -1971,7 +2137,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:58:11 GMT"
+              "value": "Wed, 06 Oct 2021 13:30:04 GMT"
             },
             {
               "name": "connection",
@@ -1984,8 +2150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:58:10.559Z",
-        "time": 849,
+        "startedDateTime": "2021-10-06T13:29:59.927Z",
+        "time": 4305,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1993,7 +2159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 849
+          "wait": 4305
         }
       }
     ],

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "a33d6dd4-ebff-4764-a1d4-a54afa3dbb10"
+              "value": "cd296c20-3e6a-4966-8b89-da6e2a7bdbf9"
             },
             {
               "name": "return-client-request-id",
@@ -41,7 +41,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -56,7 +56,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620406793\",\"not_before\":\"1620402893\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807526\",\"not_before\":\"1631803626\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-06-06T15:59:53.000Z",
+              "expires": "2021-10-16T14:52:06.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "a33d6dd4-ebff-4764-a1d4-a54afa3dbb10"
+              "value": "cd296c20-3e6a-4966-8b89-da6e2a7bdbf9"
             },
             {
               "name": "x-ms-request-id",
-              "value": "cf1b9c40-b2de-468e-a7be-27d792862800"
+              "value": "b19b9b20-0160-4cf9-b59b-20cfadf6ce00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - WUS2 ProdSlices"
+              "value": "2.1.12025.15 - EUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 15:59:52 GMT"
+              "value": "Thu, 16 Sep 2021 14:52:06 GMT"
             },
             {
               "name": "connection",
@@ -177,14 +177,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 787,
+          "headersSize": 786,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T15:59:52.716Z",
-        "time": 348,
+        "startedDateTime": "2021-09-16T14:52:05.999Z",
+        "time": 695,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 348
+          "wait": 695
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "01054655-e57c-4ef9-84ed-5966e3b87918"
+              "value": "e25f3751-7893-46c3-a9c2-baaefa747174"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+              "value": "9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+              "value": "9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T155953Z:e5a5ce7a-fb19-42a7-9df7-d0bf32e92d30"
+              "value": "GERMANYWESTCENTRAL:20210916T145208Z:9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 15:59:53 GMT"
+              "value": "Thu, 16 Sep 2021 14:52:07 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T15:59:53.098Z",
-        "time": 780,
+        "startedDateTime": "2021-09-16T14:52:06.783Z",
+        "time": 1427,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,7 +345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 780
+          "wait": 1427
         }
       },
       {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "71f93b21-b759-436b-9559-ba1c162da62d"
+              "value": "deea6ae3-fa34-4b50-b551-f88f8e386d3d"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1795,
+          "headersSize": 1804,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -415,14 +415,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Web/sites?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/sites?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 6379,
+          "bodySize": 7565,
           "content": {
             "mimeType": "application/json",
-            "size": 6379,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev-webapp\",\"name\":\"ndowmon1-j1dev-webapp\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev-webapp\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace\",\"selfLink\":\"https://waws-prod-blu-243.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace/sites/ndowmon1-j1dev-webapp\",\"repositorySiteName\":\"ndowmon1-j1dev-webapp\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev-webapp.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Shared\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-web-app\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:18.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev-webapp\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":true,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"app\",\"inboundIpAddress\":\"20.49.104.31\",\"possibleInboundIpAddresses\":\"20.49.104.31\",\"ftpUsername\":\"ndowmon1-j1dev-webapp\\\\$ndowmon1-j1dev-webapp\",\"ftpsHostName\":\"ftps://waws-prod-blu-243.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,20.49.104.31\",\"possibleOutboundIpAddresses\":\"52.150.53.221,52.154.64.236,52.154.65.178,52.147.212.86,52.154.66.92,52.188.41.146,52.188.42.23,52.142.18.177,52.142.18.40,52.149.202.179,52.154.66.123,52.154.69.195,52.154.70.71,52.154.70.135,52.186.99.104,52.186.101.205,52.142.16.201,52.186.102.198,52.147.209.102,52.149.204.214,52.186.102.230,52.147.209.166,52.147.210.37,52.147.215.140,52.149.206.164,52.190.40.233,52.188.42.100,52.190.43.22,52.224.24.232,52.224.26.145,20.49.104.31\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-243\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev-webapp.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/sites/ndowmon1-j1dev\",\"name\":\"ndowmon1-j1dev\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp,linux\",\"location\":\"East US\",\"tags\":{},\"properties\":{\"name\":\"ndowmon1-j1dev\",\"state\":\"Running\",\"hostNames\":[\"ndowmon1-j1dev.azurewebsites.net\"],\"webSpace\":\"j1dev-EastUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-blu-231.api.azurewebsites.windows.net:454/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/webspaces/j1dev-EastUSwebspace-Linux/sites/ndowmon1-j1dev\",\"repositorySiteName\":\"ndowmon1-j1dev\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"ndowmon1-j1dev.azurewebsites.net\",\"ndowmon1-j1dev.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"ndowmon1-j1dev.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"ndowmon1-j1dev.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Web/serverfarms/ASP-j1dev-function-app\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-05-07T15:59:11.1666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"siteConfig\":{\"numberOfWorkers\":null,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":null,\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"azureStorageAccounts\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":null,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":null,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":null,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0},\"deploymentId\":\"ndowmon1-j1dev\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"EC640CF6487E7BDD973B43ADB08273BF23AC68F21F1A698400901DE5169A0C02\",\"kind\":\"functionapp,linux\",\"inboundIpAddress\":\"20.49.104.23\",\"possibleInboundIpAddresses\":\"20.49.104.23\",\"ftpUsername\":\"ndowmon1-j1dev\\\\$ndowmon1-j1dev\",\"ftpsHostName\":\"ftps://waws-prod-blu-231.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,20.49.104.23\",\"possibleOutboundIpAddresses\":\"52.188.142.126,52.188.143.57,52.188.141.62,40.71.232.88,40.71.233.96,40.71.233.218,40.71.234.29,40.71.234.60,40.71.235.182,40.71.236.158,40.71.237.2,40.71.237.25,40.71.238.120,40.71.238.125,52.151.238.38,40.71.238.146,40.71.238.252,40.71.239.94,20.49.104.23\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-blu-231\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"j1dev\",\"defaultHostName\":\"ndowmon1-j1dev.azurewebsites.net\",\"slotSwapStatus\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\",\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null}}],\"nextLink\":null,\"id\":null}"
+            "size": 7565,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T13:57:50.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:51:04.09\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -444,7 +444,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1D74359F1F9328C\""
+              "value": "\"1D7AB0A45DDB7A0\""
             },
             {
               "name": "vary",
@@ -456,10 +456,337 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "f9b1154b-942b-467b-ba04-0e7f0d16f399"
+              "value": "be89aaa2-0266-4854-87a6-35944fa71498"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5fe0a103-37a8-45a1-b45a-65b4a750f624"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145209Z:5fe0a103-37a8-45a1-b45a-65b4a750f624"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:08 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 696,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:08.245Z",
+        "time": 898,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 898
+        }
+      },
+      {
+        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9ca9dbde-a7cf-4046-93c5-2a3b3225d765"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1879,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3387,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3387,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "b5111df4-1a94-4b7f-8ca3-f01eb43971fb"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "0ce7dd4b-52e1-47f0-a9ed-916e68078174"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145209Z:0ce7dd4b-52e1-47f0-a9ed-916e68078174"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:09 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:09.157Z",
+        "time": 802,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 802
+        }
+      },
+      {
+        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "fd6cec20-05c2-467e-81ba-e7b584d77793"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1275,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1275,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fda08126-31e1-4364-b3bb-440f0718babd"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
               "value": "11999"
             },
             {
@@ -476,11 +803,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "359b9769-1ce2-45b8-bbe6-730ba471b8eb"
+              "value": "0b25babe-8b00-4de4-84f1-69f51f90f413"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210507T155954Z:359b9769-1ce2-45b8-bbe6-730ba471b8eb"
+              "value": "GERMANYWESTCENTRAL:20210916T145211Z:0b25babe-8b00-4de4-84f1-69f51f90f413"
             },
             {
               "name": "x-content-type-options",
@@ -488,21 +815,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 07 May 2021 15:59:53 GMT"
+              "value": "Thu, 16 Sep 2021 14:52:10 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 687,
+          "headersSize": 683,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-07T15:59:53.891Z",
-        "time": 499,
+        "startedDateTime": "2021-09-16T14:52:09.969Z",
+        "time": 1081,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -510,7 +837,661 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 499
+          "wait": 1081
+        }
+      },
+      {
+        "_id": "66df4f2354a07c13123b230a00d098f1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f88db384-2767-46db-92d5-d21785d59a84"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1875,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 4215,
+          "content": {
+            "mimeType": "application/json",
+            "size": 4215,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "53e29181-b74c-4da5-a4bd-1f0e0e854f72"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "166fbfef-f2cf-41b3-8f71-54d1b99e3947"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145216Z:166fbfef-f2cf-41b3-8f71-54d1b99e3947"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:16 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:11.106Z",
+        "time": 5809,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5809
+        }
+      },
+      {
+        "_id": "45e0e867a19f53e0647b38347759e808",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c9d10ab1-c59f-42a8-9eb4-84369cf31b43"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1909,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"enabled\":true,\"runtimeVersion\":\"~1\",\"httpApiPrefixPath\":\"/.auth\",\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"tokenStoreEnabled\":true,\"allowedExternalRedirectUrls\":[],\"defaultProvider\":null,\"tokenRefreshExtensionHours\":72.0,\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecret\":null,\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\",\"clientSecretCertificateThumbprint\":null,\"issuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"allowedAudiences\":[],\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":\"{\\\"allowed_groups\\\":null,\\\"allowed_client_applications\\\":null}\",\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"isAuthFromFile\":\"False\",\"configVersion\":\"v2\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "5beaeef9-7e02-41bc-b50c-0b516ddfab3a"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "8c2c7d90-aa0e-41e7-9c7c-f333fac3c763"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145218Z:8c2c7d90-aa0e-41e7-9c7c-f333fac3c763"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:18 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:16.924Z",
+        "time": 1700,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1700
+        }
+      },
+      {
+        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "fef41857-a8d4-47f5-8bb1-e6b50bfc1afe"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1876,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3347,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3347,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2be43a13-64e8-461f-a0f8-2a61ee28ec6a"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "c38aad54-be77-4ee6-bcbc-0c83613c7aef"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145219Z:c38aad54-be77-4ee6-bcbc-0c83613c7aef"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:18 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:18.644Z",
+        "time": 719,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 719
+        }
+      },
+      {
+        "_id": "1acc9a3fff82d923ec4342b692df3c30",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "edce59bc-7a1e-4552-a172-4525aa8a977e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1910,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1279,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1279,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cc8c3d56-847e-419a-8c95-6c8444ce31d1"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "44239e60-0df5-433c-bf60-416937eed6e6"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210916T145220Z:44239e60-0df5-433c-bf60-416937eed6e6"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Sep 2021 14:52:19 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-16T14:52:19.369Z",
+        "time": 1119,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1119
         }
       }
     ],

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
@@ -12,7 +12,7 @@
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 172,
+          "bodySize": 175,
           "cookies": [],
           "headers": [
             {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "cd296c20-3e6a-4966-8b89-da6e2a7bdbf9"
+              "value": "b2b317e3-cebb-47a1-8460-bd335952f704"
             },
             {
               "name": "return-client-request-id",
@@ -53,7 +53,7 @@
             },
             {
               "name": "content-length",
-              "value": 172
+              "value": 175
             }
           ],
           "headersSize": 413,
@@ -77,11 +77,11 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1631807526\",\"not_before\":\"1631803626\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1633530484\",\"not_before\":\"1633526584\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-10-16T14:52:06.000Z",
+              "expires": "2021-11-05T13:28:04.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "cd296c20-3e6a-4966-8b89-da6e2a7bdbf9"
+              "value": "b2b317e3-cebb-47a1-8460-bd335952f704"
             },
             {
               "name": "x-ms-request-id",
-              "value": "b19b9b20-0160-4cf9-b59b-20cfadf6ce00"
+              "value": "81c19ed7-952e-4542-944b-ca2259233300"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.12025.15 - EUS ProdSlices"
+              "value": "2.1.12071.28 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:06 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:04 GMT"
             },
             {
               "name": "connection",
@@ -177,14 +177,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 786,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:05.999Z",
-        "time": 695,
+        "startedDateTime": "2021-10-06T13:28:03.487Z",
+        "time": 773,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 695
+          "wait": 773
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "e25f3751-7893-46c3-a9c2-baaefa747174"
+              "value": "5798cf3d-8b1c-4062-bd43-f2d94c660e59"
             },
             {
               "_fromType": "array",
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
+              "value": "3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
+              "value": "3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145208Z:9053d84c-7ea9-44f7-9141-7c1c5270c6ca"
+              "value": "GERMANYWESTCENTRAL:20211006T132805Z:3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:07 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:04 GMT"
             },
             {
               "name": "connection",
@@ -336,8 +336,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:06.783Z",
-        "time": 1427,
+        "startedDateTime": "2021-10-06T13:28:04.385Z",
+        "time": 791,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,7 +345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1427
+          "wait": 791
         }
       },
       {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "deea6ae3-fa34-4b50-b551-f88f8e386d3d"
+              "value": "2040f27e-482d-4c81-ac87-83d4550595cd"
             },
             {
               "_fromType": "array",
@@ -418,11 +418,11 @@
           "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/sites?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 7565,
+          "bodySize": 7649,
           "content": {
             "mimeType": "application/json",
-            "size": 7565,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T13:57:50.5966667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:51:04.09\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
+            "size": 7649,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-29T07:40:46.91\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"},\"identity\":{\"type\":\"SystemAssigned\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"principalId\":\"b680c0c3-e42a-43a8-94d6-de1c4b16f9ba\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T15:41:39.76\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -444,7 +444,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1D7AB0A45DDB7A0\""
+              "value": "\"1D7BAB5B406D4C2\""
             },
             {
               "name": "vary",
@@ -456,11 +456,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "be89aaa2-0266-4854-87a6-35944fa71498"
+              "value": "0b74c22e-7bfd-4d78-a276-53f4727f3f91"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -476,11 +476,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "5fe0a103-37a8-45a1-b45a-65b4a750f624"
+              "value": "8b4348b6-3b34-4e41-9945-dc33d478e2e1"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145209Z:5fe0a103-37a8-45a1-b45a-65b4a750f624"
+              "value": "GERMANYWESTCENTRAL:20211006T132805Z:8b4348b6-3b34-4e41-9945-dc33d478e2e1"
             },
             {
               "name": "x-content-type-options",
@@ -488,7 +488,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:08 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:05 GMT"
             },
             {
               "name": "connection",
@@ -501,8 +501,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:08.245Z",
-        "time": 898,
+        "startedDateTime": "2021-10-06T13:28:05.197Z",
+        "time": 801,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -510,168 +510,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 898
-        }
-      },
-      {
-        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "9ca9dbde-a7cf-4046-93c5-2a3b3225d765"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1879,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 3387,
-          "content": {
-            "mimeType": "application/json",
-            "size": 3387,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "b5111df4-1a94-4b7f-8ca3-f01eb43971fb"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11998"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "0ce7dd4b-52e1-47f0-a9ed-916e68078174"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145209Z:0ce7dd4b-52e1-47f0-a9ed-916e68078174"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:09 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 671,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-09-16T14:52:09.157Z",
-        "time": 802,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 802
+          "wait": 801
         }
       },
       {
@@ -695,7 +534,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "fd6cec20-05c2-467e-81ba-e7b584d77793"
+              "value": "f9abff26-a9bd-43ba-a157-4cbab88c21a9"
             },
             {
               "_fromType": "array",
@@ -783,7 +622,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "fda08126-31e1-4364-b3bb-440f0718babd"
+              "value": "a64277f4-ee2f-45b6-9979-808b5f16715d"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
@@ -803,11 +642,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "0b25babe-8b00-4de4-84f1-69f51f90f413"
+              "value": "d3db6065-5ca1-4b38-b77c-4e0967253568"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145211Z:0b25babe-8b00-4de4-84f1-69f51f90f413"
+              "value": "GERMANYWESTCENTRAL:20211006T132807Z:d3db6065-5ca1-4b38-b77c-4e0967253568"
             },
             {
               "name": "x-content-type-options",
@@ -815,7 +654,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:10 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:07 GMT"
             },
             {
               "name": "connection",
@@ -828,8 +667,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:09.969Z",
-        "time": 1081,
+        "startedDateTime": "2021-10-06T13:28:06.017Z",
+        "time": 1763,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -837,11 +676,177 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1081
+          "wait": 1763
         }
       },
       {
-        "_id": "66df4f2354a07c13123b230a00d098f1",
+        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "465ef557-3cac-414f-bf9a-527fdafc9a89"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1275,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1275,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fe8ac5a7-34da-44b7-b1e4-93bc76dbca75"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5f30a6f4-3140-4e6d-80d2-124e1c686765"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211006T132810Z:5f30a6f4-3140-4e6d-80d2-124e1c686765"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 06 Oct 2021 13:28:10 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-06T13:28:07.795Z",
+        "time": 2491,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2491
+        }
+      },
+      {
+        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -861,7 +866,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "f88db384-2767-46db-92d5-d21785d59a84"
+              "value": "afb44525-1346-4b6a-99c5-dc94435274c9"
             },
             {
               "_fromType": "array",
@@ -898,7 +903,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1875,
+          "headersSize": 1879,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -907,14 +912,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 4215,
+          "bodySize": 3387,
           "content": {
             "mimeType": "application/json",
-            "size": 4215,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 3387,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -944,11 +949,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "53e29181-b74c-4da5-a4bd-1f0e0e854f72"
+              "value": "6a47a257-0d9c-4c4f-9ef9-256c62617e50"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -964,11 +969,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "166fbfef-f2cf-41b3-8f71-54d1b99e3947"
+              "value": "4227d565-7acc-4b20-b8b9-af5b020c8783"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145216Z:166fbfef-f2cf-41b3-8f71-54d1b99e3947"
+              "value": "GERMANYWESTCENTRAL:20211006T132812Z:4227d565-7acc-4b20-b8b9-af5b020c8783"
             },
             {
               "name": "x-content-type-options",
@@ -976,7 +981,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:16 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:11 GMT"
             },
             {
               "name": "connection",
@@ -989,8 +994,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:11.106Z",
-        "time": 5809,
+        "startedDateTime": "2021-10-06T13:28:10.297Z",
+        "time": 2072,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -998,7 +1003,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 5809
+          "wait": 2072
         }
       },
       {
@@ -1022,7 +1027,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "c9d10ab1-c59f-42a8-9eb4-84369cf31b43"
+              "value": "a7b94b57-83af-4bc6-834e-41135818eadf"
             },
             {
               "_fromType": "array",
@@ -1110,11 +1115,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "5beaeef9-7e02-41bc-b50c-0b516ddfab3a"
+              "value": "6e99a0a2-c190-4d1e-8a7e-4e925c93859e"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -1130,11 +1135,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "8c2c7d90-aa0e-41e7-9c7c-f333fac3c763"
+              "value": "278aae20-7b16-4403-8907-6ce58e4224cd"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145218Z:8c2c7d90-aa0e-41e7-9c7c-f333fac3c763"
+              "value": "GERMANYWESTCENTRAL:20211006T132814Z:278aae20-7b16-4403-8907-6ce58e4224cd"
             },
             {
               "name": "x-content-type-options",
@@ -1142,7 +1147,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:18 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:13 GMT"
             },
             {
               "name": "connection",
@@ -1155,8 +1160,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:16.924Z",
-        "time": 1700,
+        "startedDateTime": "2021-10-06T13:28:12.425Z",
+        "time": 1715,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1164,11 +1169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1700
+          "wait": 1715
         }
       },
       {
-        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_id": "66df4f2354a07c13123b230a00d098f1",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1188,7 +1193,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "fef41857-a8d4-47f5-8bb1-e6b50bfc1afe"
+              "value": "4b87b88b-b971-4101-bb73-5c5077a7df4b"
             },
             {
               "_fromType": "array",
@@ -1225,7 +1230,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1876,
+          "headersSize": 1875,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1234,14 +1239,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 3347,
+          "bodySize": 4231,
           "content": {
             "mimeType": "application/json",
-            "size": 3347,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 4231,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":true,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":3417,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -1271,11 +1276,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "2be43a13-64e8-461f-a0f8-2a61ee28ec6a"
+              "value": "10b5393a-1cde-4765-88d5-d7b01a2ac8bb"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11997"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -1291,11 +1296,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "c38aad54-be77-4ee6-bcbc-0c83613c7aef"
+              "value": "b04e6e1f-a23e-40bd-bdda-5ad134069d84"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145219Z:c38aad54-be77-4ee6-bcbc-0c83613c7aef"
+              "value": "GERMANYWESTCENTRAL:20211006T132814Z:b04e6e1f-a23e-40bd-bdda-5ad134069d84"
             },
             {
               "name": "x-content-type-options",
@@ -1303,7 +1308,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:18 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:14 GMT"
             },
             {
               "name": "connection",
@@ -1316,8 +1321,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:18.644Z",
-        "time": 719,
+        "startedDateTime": "2021-10-06T13:28:14.152Z",
+        "time": 795,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1325,7 +1330,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 719
+          "wait": 795
         }
       },
       {
@@ -1349,7 +1354,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "edce59bc-7a1e-4552-a172-4525aa8a977e"
+              "value": "dc08f361-f7c7-4f51-9161-c2dce0adec72"
             },
             {
               "_fromType": "array",
@@ -1437,11 +1442,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "cc8c3d56-847e-419a-8c95-6c8444ce31d1"
+              "value": "7e9f72be-40d8-4581-bd8c-bee1d7637e14"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "server",
@@ -1457,11 +1462,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "44239e60-0df5-433c-bf60-416937eed6e6"
+              "value": "acfe37b0-8fd3-42bf-9a95-7c94ed762149"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20210916T145220Z:44239e60-0df5-433c-bf60-416937eed6e6"
+              "value": "GERMANYWESTCENTRAL:20211006T132816Z:acfe37b0-8fd3-42bf-9a95-7c94ed762149"
             },
             {
               "name": "x-content-type-options",
@@ -1469,7 +1474,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 16 Sep 2021 14:52:19 GMT"
+              "value": "Wed, 06 Oct 2021 13:28:15 GMT"
             },
             {
               "name": "connection",
@@ -1482,8 +1487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-09-16T14:52:19.369Z",
-        "time": 1119,
+        "startedDateTime": "2021-10-06T13:28:14.967Z",
+        "time": 1103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1491,7 +1496,168 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1119
+          "wait": 1103
+        }
+      },
+      {
+        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "32b61c83-0ae0-45d3-af12-9639285bc3bb"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1876,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 3347,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3347,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "df1ce858-7208-4245-95e8-b69ab5fd58a7"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "89a52b23-d494-4948-85c7-1173ee97effb"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211006T132816Z:89a52b23-d494-4948-85c7-1173ee97effb"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 06 Oct 2021 13:28:16 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-06T13:28:16.078Z",
+        "time": 785,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 785
         }
       }
     ],

--- a/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
+++ b/src/steps/resource-manager/appservice/__recordings__/rm-appservice-apps_1396228188/recording.har
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "b2b317e3-cebb-47a1-8460-bd335952f704"
+              "value": "e90d7058-b112-428f-b0a3-8b6e63f8c833"
             },
             {
               "name": "return-client-request-id",
@@ -77,11 +77,11 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1633530484\",\"not_before\":\"1633526584\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1634047471\",\"not_before\":\"1634043571\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-11-05T13:28:04.000Z",
+              "expires": "2021-11-11T13:04:31.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,11 +135,11 @@
             },
             {
               "name": "client-request-id",
-              "value": "b2b317e3-cebb-47a1-8460-bd335952f704"
+              "value": "e90d7058-b112-428f-b0a3-8b6e63f8c833"
             },
             {
               "name": "x-ms-request-id",
-              "value": "81c19ed7-952e-4542-944b-ca2259233300"
+              "value": "f34ff484-203f-44ae-bf48-133186ca3202"
             },
             {
               "name": "x-ms-ests-server",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:04 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:31 GMT"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:03.487Z",
-        "time": 773,
+        "startedDateTime": "2021-10-12T13:04:30.926Z",
+        "time": 860,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 773
+          "wait": 860
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5798cf3d-8b1c-4062-bd43-f2d94c660e59"
+              "value": "1e62dfd7-06df-4efd-8fc6-24bf3b0dc3da"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+              "value": "ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -295,19 +295,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
+              "value": "11993"
             },
             {
               "name": "x-ms-request-id",
-              "value": "3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
+              "value": "ac7fb9d2-bb2e-4ccc-9404-6c883551f161"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
+              "value": "ac7fb9d2-bb2e-4ccc-9404-6c883551f161"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132805Z:3c2b0dd4-cdb4-486a-b07b-9b57cb908565"
+              "value": "GERMANYWESTCENTRAL:20211012T130432Z:ac7fb9d2-bb2e-4ccc-9404-6c883551f161"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:04 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:31 GMT"
             },
             {
               "name": "connection",
@@ -336,8 +336,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:04.385Z",
-        "time": 791,
+        "startedDateTime": "2021-10-12T13:04:31.936Z",
+        "time": 799,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,7 +345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 791
+          "wait": 799
         }
       },
       {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "2040f27e-482d-4c81-ac87-83d4550595cd"
+              "value": "a1130a2f-c935-42fe-86d5-051289141f8c"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -418,11 +418,11 @@
           "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Web/sites?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 7649,
+          "bodySize": 7557,
           "content": {
             "mimeType": "application/json",
-            "size": 7649,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-29T07:40:46.91\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"},\"identity\":{\"type\":\"SystemAssigned\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"principalId\":\"b680c0c3-e42a-43a8-94d6-de1c4b16f9ba\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T15:41:39.76\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}}],\"nextLink\":null,\"id\":null}"
+            "size": 7557,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"functionapp\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-function-app\",\"state\":\"Running\",\"hostNames\":[\"example-function-app.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace\",\"selfLink\":\"https://waws-prod-dm1-177.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace/sites/example-function-app\",\"repositorySiteName\":\"example-function-app\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-function-app.azurewebsites.net\",\"example-function-app.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-function-app.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-function-app.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dynamic\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ASP-StefanAppServicesGroup-99a7\",\"reserved\":false,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T15:41:39.76\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-function-app\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Dynamic\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"functionapp\",\"inboundIpAddress\":\"20.40.202.1\",\"possibleInboundIpAddresses\":\"20.40.202.1\",\"ftpUsername\":\"example-function-app\\\\$example-function-app\",\"ftpsHostName\":\"ftps://waws-prod-dm1-177.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,20.40.202.1\",\"possibleOutboundIpAddresses\":\"52.154.218.226,52.154.219.16,52.154.219.40,52.154.219.47,52.154.219.68,52.154.219.148,40.89.247.95,52.143.241.227,52.143.244.158,52.143.244.171,52.143.246.53,52.143.247.85,52.154.219.158,52.154.219.184,52.154.220.10,52.182.208.68,52.182.208.154,52.182.209.61,20.40.202.1\",\"containerSize\":1536,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-177\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-function-app.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"FunctionAppLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"properties\":{\"name\":\"example-php-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-php-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-php-appservices\",\"repositorySiteName\":\"example-php-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-php-appservices.azurewebsites.net\",\"example-php-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-php-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-php-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-16T14:19:58.4666667\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":false,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-php-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-php-appservices\\\\$example-php-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":null,\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-php-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":false,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"}},{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites\",\"kind\":\"app,linux\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"name\":\"example-appservices\",\"state\":\"Running\",\"hostNames\":[\"example-appservices.azurewebsites.net\"],\"webSpace\":\"Stefan_AppServices_Group-CentralUSwebspace-Linux\",\"selfLink\":\"https://waws-prod-dm1-219.api.azurewebsites.windows.net:454/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/webspaces/Stefan_AppServices_Group-CentralUSwebspace-Linux/sites/example-appservices\",\"repositorySiteName\":\"example-appservices\",\"owner\":null,\"usageState\":\"Normal\",\"enabled\":true,\"adminEnabled\":true,\"enabledHostNames\":[\"example-appservices.azurewebsites.net\",\"example-appservices.scm.azurewebsites.net\"],\"siteProperties\":{\"metadata\":null,\"properties\":[{\"name\":\"LinuxFxVersion\",\"value\":\"PHP|8.0\"},{\"name\":\"WindowsFxVersion\",\"value\":null}],\"appSettings\":null},\"availabilityState\":\"Normal\",\"sslCertificates\":[],\"csrs\":[],\"cers\":null,\"siteMode\":\"Limited\",\"hostNameSslStates\":[{\"name\":\"example-appservices.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Standard\"},{\"name\":\"example-appservices.scm.azurewebsites.net\",\"sslState\":\"Disabled\",\"ipBasedSslResult\":null,\"virtualIP\":null,\"thumbprint\":null,\"toUpdate\":null,\"toUpdateIpBasedSsl\":null,\"ipBasedSslState\":\"NotConfigured\",\"hostType\":\"Repository\"}],\"computeMode\":\"Dedicated\",\"serverFarm\":null,\"serverFarmId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/serverfarms/ExampleAppServicePlan\",\"reserved\":true,\"isXenon\":false,\"hyperV\":false,\"lastModifiedTimeUtc\":\"2021-09-29T07:40:46.91\",\"storageRecoveryDefaultState\":\"Running\",\"contentAvailabilityState\":\"Normal\",\"runtimeAvailabilityState\":\"Normal\",\"secretsCollection\":[],\"siteConfig\":{\"numberOfWorkers\":1,\"defaultDocuments\":null,\"netFrameworkVersion\":null,\"phpVersion\":null,\"pythonVersion\":null,\"nodeVersion\":null,\"powerShellVersion\":null,\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":null,\"remoteDebuggingEnabled\":null,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":null,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":null,\"detailedErrorLoggingEnabled\":null,\"publishingUsername\":null,\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":null,\"use32BitWorkerProcess\":null,\"webSocketsEnabled\":null,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":null,\"managedPipelineMode\":null,\"virtualApplications\":null,\"winAuthAdminState\":null,\"winAuthTenantState\":null,\"customAppPoolIdentityAdminState\":null,\"customAppPoolIdentityTenantState\":null,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":null,\"routingRules\":null,\"experiments\":null,\"limits\":null,\"autoHealEnabled\":null,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":null,\"vnetRouteAllEnabled\":null,\"vnetPrivatePortsCount\":null,\"publicNetworkAccess\":null,\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":null,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":null,\"scmIpSecurityRestrictions\":null,\"scmIpSecurityRestrictionsUseMain\":null,\"http20Enabled\":true,\"minTlsVersion\":null,\"scmMinTlsVersion\":null,\"ftpsState\":null,\"preWarmedInstanceCount\":null,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":null,\"functionsRuntimeScaleMonitoringEnabled\":null,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":null,\"sitePort\":null},\"deploymentId\":\"example-appservices\",\"slotName\":null,\"trafficManagerHostNames\":null,\"sku\":\"Free\",\"scmSiteAlsoStopped\":false,\"targetSwapSlot\":null,\"hostingEnvironment\":null,\"hostingEnvironmentProfile\":null,\"clientAffinityEnabled\":false,\"clientCertEnabled\":false,\"clientCertMode\":\"Required\",\"clientCertExclusionPaths\":null,\"hostNamesDisabled\":false,\"domainVerificationIdentifiers\":null,\"customDomainVerificationId\":\"A4B86305F4DAA9B2D3AB9227A7666753B5B757AB72EDB85E73CAC58E84E02CAD\",\"kind\":\"app,linux\",\"inboundIpAddress\":\"20.40.202.21\",\"possibleInboundIpAddresses\":\"20.40.202.21\",\"ftpUsername\":\"example-appservices\\\\$example-appservices\",\"ftpsHostName\":\"ftps://waws-prod-dm1-219.ftp.azurewebsites.windows.net/site/wwwroot\",\"outboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.40.202.21\",\"possibleOutboundIpAddresses\":\"20.84.176.225,20.84.176.244,20.84.176.248,20.84.176.251,20.84.177.117,20.84.177.126,20.84.177.148,20.84.177.193,20.84.177.197,20.84.177.199,20.84.177.200,20.84.177.203,20.84.177.222,20.84.177.233,20.84.177.242,20.84.177.245,20.84.177.246,20.84.178.16,20.84.251.43,20.84.252.44,20.84.252.100,20.84.252.98,20.84.253.1,20.84.253.111,20.40.202.21\",\"containerSize\":0,\"dailyMemoryTimeQuota\":0,\"suspendedTill\":null,\"siteDisabledReason\":0,\"functionExecutionUnitsCache\":null,\"maxNumberOfWorkers\":null,\"homeStamp\":\"waws-prod-dm1-219\",\"cloningInfo\":null,\"hostingEnvironmentId\":null,\"tags\":{},\"resourceGroup\":\"Stefan_AppServices_Group\",\"defaultHostName\":\"example-appservices.azurewebsites.net\",\"slotSwapStatus\":null,\"httpsOnly\":true,\"redundancyMode\":\"None\",\"inProgressOperationId\":null,\"geoDistributions\":null,\"privateEndpointConnections\":null,\"buildVersion\":null,\"targetBuildVersion\":null,\"migrationState\":null,\"eligibleLogCategories\":\"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs\",\"storageAccountRequired\":false,\"virtualNetworkSubnetId\":null,\"keyVaultReferenceIdentity\":\"SystemAssigned\"},\"identity\":{\"type\":\"SystemAssigned\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"principalId\":\"b680c0c3-e42a-43a8-94d6-de1c4b16f9ba\"}}],\"nextLink\":null,\"id\":null}"
           },
           "cookies": [],
           "headers": [
@@ -444,7 +444,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1D7BAB5B406D4C2\""
+              "value": "\"1D7BAB640A68229\""
             },
             {
               "name": "vary",
@@ -456,11 +456,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "0b74c22e-7bfd-4d78-a276-53f4727f3f91"
+              "value": "3968e2db-fad7-4afc-abe1-293a0d91832c"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11994"
             },
             {
               "name": "server",
@@ -476,11 +476,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "8b4348b6-3b34-4e41-9945-dc33d478e2e1"
+              "value": "48949250-9ba8-4611-98cb-128e87002042"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132805Z:8b4348b6-3b34-4e41-9945-dc33d478e2e1"
+              "value": "GERMANYWESTCENTRAL:20211012T130433Z:48949250-9ba8-4611-98cb-128e87002042"
             },
             {
               "name": "x-content-type-options",
@@ -488,7 +488,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:05 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:33 GMT"
             },
             {
               "name": "connection",
@@ -501,8 +501,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:05.197Z",
-        "time": 801,
+        "startedDateTime": "2021-10-12T13:04:32.767Z",
+        "time": 857,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -510,11 +510,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 801
+          "wait": 857
         }
       },
       {
-        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_id": "6289471d43854d042f39bdb6ab93b53f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -534,7 +534,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "f9abff26-a9bd-43ba-a157-4cbab88c21a9"
+              "value": "b08e88eb-e53a-4303-863d-e7e19ab2ecfb"
             },
             {
               "_fromType": "array",
@@ -544,339 +544,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "0"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1913,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 1275,
-          "content": {
-            "mimeType": "application/json",
-            "size": 1275,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a64277f4-ee2f-45b6-9979-808b5f16715d"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "d3db6065-5ca1-4b38-b77c-4e0967253568"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132807Z:d3db6065-5ca1-4b38-b77c-4e0967253568"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:07 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 683,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-10-06T13:28:06.017Z",
-        "time": 1763,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1763
-        }
-      },
-      {
-        "_id": "5d8ba75a51e91759f619d785241638b6",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "465ef557-3cac-414f-bf9a-527fdafc9a89"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "0"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1913,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 1275,
-          "content": {
-            "mimeType": "application/json",
-            "size": 1275,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "fe8ac5a7-34da-44b7-b1e4-93bc76dbca75"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "5f30a6f4-3140-4e6d-80d2-124e1c686765"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132810Z:5f30a6f4-3140-4e6d-80d2-124e1c686765"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:10 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 683,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-10-06T13:28:07.795Z",
-        "time": 2491,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 2491
-        }
-      },
-      {
-        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "afb44525-1346-4b6a-99c5-dc94435274c9"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -903,7 +571,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1879,
+          "headersSize": 1876,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -912,14 +580,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 3387,
+          "bodySize": 3347,
           "content": {
             "mimeType": "application/json",
-            "size": 3387,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 3347,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -949,11 +617,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "6a47a257-0d9c-4c4f-9ef9-256c62617e50"
+              "value": "0f33defa-d071-4d56-90d4-2a86741e3689"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11995"
             },
             {
               "name": "server",
@@ -969,11 +637,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "4227d565-7acc-4b20-b8b9-af5b020c8783"
+              "value": "93d1792c-0f42-4588-9519-0bd8c8cb3546"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132812Z:4227d565-7acc-4b20-b8b9-af5b020c8783"
+              "value": "GERMANYWESTCENTRAL:20211012T130434Z:93d1792c-0f42-4588-9519-0bd8c8cb3546"
             },
             {
               "name": "x-content-type-options",
@@ -981,7 +649,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:11 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:33 GMT"
             },
             {
               "name": "connection",
@@ -994,8 +662,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:10.297Z",
-        "time": 2072,
+        "startedDateTime": "2021-10-12T13:04:33.640Z",
+        "time": 763,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1003,334 +671,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2072
-        }
-      },
-      {
-        "_id": "45e0e867a19f53e0647b38347759e808",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "a7b94b57-83af-4bc6-834e-41135818eadf"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "0"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1909,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings/list?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 1801,
-          "content": {
-            "mimeType": "application/json",
-            "size": 1801,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"enabled\":true,\"runtimeVersion\":\"~1\",\"httpApiPrefixPath\":\"/.auth\",\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"tokenStoreEnabled\":true,\"allowedExternalRedirectUrls\":[],\"defaultProvider\":null,\"tokenRefreshExtensionHours\":72.0,\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecret\":null,\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\",\"clientSecretCertificateThumbprint\":null,\"issuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"allowedAudiences\":[],\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":\"{\\\"allowed_groups\\\":null,\\\"allowed_client_applications\\\":null}\",\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"isAuthFromFile\":\"False\",\"configVersion\":\"v2\"}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "6e99a0a2-c190-4d1e-8a7e-4e925c93859e"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "278aae20-7b16-4403-8907-6ce58e4224cd"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132814Z:278aae20-7b16-4403-8907-6ce58e4224cd"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:13 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 683,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-10-06T13:28:12.425Z",
-        "time": 1715,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1715
-        }
-      },
-      {
-        "_id": "66df4f2354a07c13123b230a00d098f1",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "4b87b88b-b971-4101-bb73-5c5077a7df4b"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1875,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2020-09-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
-        },
-        "response": {
-          "bodySize": 4231,
-          "content": {
-            "mimeType": "application/json",
-            "size": 4231,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":true,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":3417,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "10b5393a-1cde-4765-88d5-d7b01a2ac8bb"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-IIS/10.0"
-            },
-            {
-              "name": "x-aspnet-version",
-              "value": "4.0.30319"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "ASP.NET"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "b04e6e1f-a23e-40bd-bdda-5ad134069d84"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132814Z:b04e6e1f-a23e-40bd-bdda-5ad134069d84"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:14 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 671,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-10-06T13:28:14.152Z",
-        "time": 795,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 795
+          "wait": 763
         }
       },
       {
@@ -1354,7 +695,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "dc08f361-f7c7-4f51-9161-c2dce0adec72"
+              "value": "3f725e51-a220-4b56-a967-dbe2c308de2f"
             },
             {
               "_fromType": "array",
@@ -1364,7 +705,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -1442,7 +783,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "7e9f72be-40d8-4581-bd8c-bee1d7637e14"
+              "value": "bb33fee3-8770-4719-9889-a2a24104316b"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
@@ -1462,11 +803,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "acfe37b0-8fd3-42bf-9a95-7c94ed762149"
+              "value": "7b8ee7c9-1ab7-44ec-aca6-5c8a4d2d8b10"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132816Z:acfe37b0-8fd3-42bf-9a95-7c94ed762149"
+              "value": "GERMANYWESTCENTRAL:20211012T130435Z:7b8ee7c9-1ab7-44ec-aca6-5c8a4d2d8b10"
             },
             {
               "name": "x-content-type-options",
@@ -1474,7 +815,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:15 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:34 GMT"
             },
             {
               "name": "connection",
@@ -1487,8 +828,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:14.967Z",
-        "time": 1103,
+        "startedDateTime": "2021-10-12T13:04:34.415Z",
+        "time": 1111,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1496,11 +837,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1103
+          "wait": 1111
         }
       },
       {
-        "_id": "6289471d43854d042f39bdb6ab93b53f",
+        "_id": "0d3e45954f2182468d5639a11ea3f2d5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1520,7 +861,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "32b61c83-0ae0-45d3-af12-9639285bc3bb"
+              "value": "b4333421-06e0-4df6-a9b3-81ff40cba4ad"
             },
             {
               "_fromType": "array",
@@ -1530,7 +871,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -1557,7 +898,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1876,
+          "headersSize": 1879,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1566,14 +907,14 @@
               "value": "2020-09-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web?api-version=2020-09-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web?api-version=2020-09-01"
         },
         "response": {
-          "bodySize": 3347,
+          "bodySize": 3387,
           "content": {
             "mimeType": "application/json",
-            "size": 3347,
-            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-function-app/config/web\",\"name\":\"example-function-app\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"5.6\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":null,\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-function-app\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":200,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":0,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+            "size": 3387,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/web\",\"name\":\"example-php-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-php-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":false,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":false,\"siteAuthSettings\":{\"enabled\":null,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":null},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":null,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":false,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"Disabled\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
           },
           "cookies": [],
           "headers": [
@@ -1603,10 +944,176 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "df1ce858-7208-4245-95e8-b69ab5fd58a7"
+              "value": "f529f7ec-85a8-4542-90d5-59a4c9892f66"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11992"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "cc3d740d-1c5f-4726-9918-b69018077df6"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211012T130436Z:cc3d740d-1c5f-4726-9918-b69018077df6"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 12 Oct 2021 13:04:35 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-12T13:04:35.595Z",
+        "time": 766,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 766
+        }
+      },
+      {
+        "_id": "5d8ba75a51e91759f619d785241638b6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "66e7a55a-1f49-4c93-ba94-0491b09abd25"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1275,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1275,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-php-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"properties\":{\"enabled\":false,\"unauthenticatedClientAction\":null,\"tokenStoreEnabled\":null,\"allowedExternalRedirectUrls\":null,\"defaultProvider\":null,\"clientId\":null,\"clientSecret\":null,\"clientSecretSettingName\":null,\"clientSecretCertificateThumbprint\":null,\"issuer\":null,\"allowedAudiences\":null,\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":null,\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"configVersion\":\"v1\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f657ad34-215e-4053-8dac-c3f4619b91df"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
               "value": "11999"
             },
             {
@@ -1623,11 +1130,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "89a52b23-d494-4948-85c7-1173ee97effb"
+              "value": "24573ffb-7b8a-433d-b4e3-f5a03022768d"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "GERMANYWESTCENTRAL:20211006T132816Z:89a52b23-d494-4948-85c7-1173ee97effb"
+              "value": "GERMANYWESTCENTRAL:20211012T130437Z:24573ffb-7b8a-433d-b4e3-f5a03022768d"
             },
             {
               "name": "x-content-type-options",
@@ -1635,7 +1142,168 @@
             },
             {
               "name": "date",
-              "value": "Wed, 06 Oct 2021 13:28:16 GMT"
+              "value": "Tue, 12 Oct 2021 13:04:36 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-12T13:04:36.374Z",
+        "time": 1423,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1423
+        }
+      },
+      {
+        "_id": "66df4f2354a07c13123b230a00d098f1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "33a93d55-a739-4d9d-afcd-38d37401b939"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1875,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 4231,
+          "content": {
+            "mimeType": "application/json",
+            "size": 4231,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/web\",\"name\":\"example-appservices\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"numberOfWorkers\":1,\"defaultDocuments\":[\"Default.htm\",\"Default.html\",\"Default.asp\",\"index.htm\",\"index.html\",\"iisstart.htm\",\"default.aspx\",\"index.php\",\"hostingstart.html\"],\"netFrameworkVersion\":\"v4.0\",\"phpVersion\":\"\",\"pythonVersion\":\"\",\"nodeVersion\":\"\",\"powerShellVersion\":\"\",\"linuxFxVersion\":\"PHP|8.0\",\"windowsFxVersion\":null,\"requestTracingEnabled\":false,\"remoteDebuggingEnabled\":false,\"remoteDebuggingVersion\":\"VS2019\",\"httpLoggingEnabled\":false,\"azureMonitorLogCategories\":null,\"acrUseManagedIdentityCreds\":false,\"acrUserManagedIdentityID\":null,\"logsDirectorySizeLimit\":35,\"detailedErrorLoggingEnabled\":false,\"publishingUsername\":\"$example-appservices\",\"publishingPassword\":null,\"appSettings\":null,\"metadata\":null,\"connectionStrings\":null,\"machineKey\":null,\"handlerMappings\":null,\"documentRoot\":null,\"scmType\":\"None\",\"use32BitWorkerProcess\":true,\"webSocketsEnabled\":false,\"alwaysOn\":false,\"javaVersion\":null,\"javaContainer\":null,\"javaContainerVersion\":null,\"appCommandLine\":\"\",\"managedPipelineMode\":\"Integrated\",\"virtualApplications\":[{\"virtualPath\":\"/\",\"physicalPath\":\"site\\\\wwwroot\",\"preloadEnabled\":false,\"virtualDirectories\":null}],\"winAuthAdminState\":0,\"winAuthTenantState\":0,\"customAppPoolIdentityAdminState\":false,\"customAppPoolIdentityTenantState\":false,\"runtimeADUser\":null,\"runtimeADUserPassword\":null,\"loadBalancing\":\"LeastRequests\",\"routingRules\":[],\"experiments\":{\"rampUpRules\":[]},\"limits\":null,\"autoHealEnabled\":false,\"autoHealRules\":null,\"tracingOptions\":null,\"vnetName\":\"\",\"vnetRouteAllEnabled\":true,\"vnetPrivatePortsCount\":0,\"publicNetworkAccess\":null,\"siteAuthEnabled\":true,\"siteAuthSettingsV2\":{\"platform\":{\"enabled\":true,\"runtimeVersion\":\"~1\"},\"globalValidation\":{\"requireAuthentication\":true,\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"redirectToProvider\":\"azureactivedirectory\"},\"identityProviders\":{\"azureActiveDirectory\":{\"enabled\":true,\"registration\":{\"openIdIssuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\"},\"login\":{\"disableWWWAuthenticate\":false},\"validation\":{\"jwtClaimChecks\":{},\"allowedAudiences\":[],\"defaultAuthorizationPolicy\":{\"allowedPrincipals\":{}}}},\"facebook\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"gitHub\":{\"enabled\":true,\"registration\":{},\"login\":{}},\"google\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"twitter\":{\"enabled\":true,\"registration\":{}},\"legacyMicrosoftAccount\":{\"enabled\":true,\"registration\":{},\"login\":{},\"validation\":{}},\"apple\":{\"enabled\":true,\"registration\":{},\"login\":{}}},\"login\":{\"routes\":{},\"tokenStore\":{\"enabled\":true,\"tokenRefreshExtensionHours\":72.0,\"fileSystem\":{},\"azureBlobStorage\":{}},\"preserveUrlFragmentsForLogins\":false,\"allowedExternalRedirectUrls\":[],\"cookieExpiration\":{\"convention\":\"FixedTime\",\"timeToExpiration\":\"08:00:00\"},\"nonce\":{\"validateNonce\":true,\"nonceExpirationInterval\":\"00:05:00\"}},\"httpSettings\":{\"requireHttps\":true,\"routes\":{\"apiPrefix\":\"/.auth\"},\"forwardProxy\":{\"convention\":\"NoProxy\"}}},\"cors\":null,\"push\":null,\"apiDefinition\":null,\"apiManagementConfig\":null,\"autoSwapSlotName\":null,\"localMySqlEnabled\":false,\"managedServiceIdentityId\":3417,\"xManagedServiceIdentityId\":null,\"keyVaultReferenceIdentity\":null,\"ipSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictions\":[{\"ipAddress\":\"Any\",\"action\":\"Allow\",\"priority\":1,\"name\":\"Allow all\",\"description\":\"Allow all access\"}],\"scmIpSecurityRestrictionsUseMain\":false,\"http20Enabled\":true,\"minTlsVersion\":\"1.2\",\"scmMinTlsVersion\":\"1.0\",\"ftpsState\":\"AllAllowed\",\"preWarmedInstanceCount\":0,\"functionAppScaleLimit\":0,\"healthCheckPath\":null,\"fileChangeAuditEnabled\":false,\"functionsRuntimeScaleMonitoringEnabled\":false,\"websiteTimeZone\":null,\"minimumElasticInstanceCount\":1,\"azureStorageAccounts\":{},\"sitePort\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "b1ea8aed-448f-4c17-9169-822025efb40f"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11996"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5016eadd-99c2-451d-a59f-23aeb071c704"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211012T130438Z:5016eadd-99c2-451d-a59f-23aeb071c704"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 12 Oct 2021 13:04:38 GMT"
             },
             {
               "name": "connection",
@@ -1648,8 +1316,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-10-06T13:28:16.078Z",
-        "time": 785,
+        "startedDateTime": "2021-10-12T13:04:37.851Z",
+        "time": 749,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1657,7 +1325,173 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 785
+          "wait": 749
+        }
+      },
+      {
+        "_id": "45e0e867a19f53e0647b38347759e808",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ea256559-7c68-4708-8b00-b15a68fc802c"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-appservice/7.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1909,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2020-09-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings/list?api-version=2020-09-01"
+        },
+        "response": {
+          "bodySize": 1801,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1801,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Web/sites/example-appservices/config/authsettings\",\"name\":\"authsettings\",\"type\":\"Microsoft.Web/sites/config\",\"location\":\"Central US\",\"tags\":{},\"properties\":{\"enabled\":true,\"runtimeVersion\":\"~1\",\"httpApiPrefixPath\":\"/.auth\",\"unauthenticatedClientAction\":\"RedirectToLoginPage\",\"tokenStoreEnabled\":true,\"allowedExternalRedirectUrls\":[],\"defaultProvider\":null,\"tokenRefreshExtensionHours\":72.0,\"clientId\":\"d6c4ffcd-4127-4812-bdc6-2808c28b2c3e\",\"clientSecret\":null,\"clientSecretSettingName\":\"MICROSOFT_PROVIDER_AUTHENTICATION_SECRET\",\"clientSecretCertificateThumbprint\":null,\"issuer\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/v2.0\",\"allowedAudiences\":[],\"additionalLoginParams\":null,\"isAadAutoProvisioned\":false,\"aadClaimsAuthorization\":\"{\\\"allowed_groups\\\":null,\\\"allowed_client_applications\\\":null}\",\"googleClientId\":null,\"googleClientSecret\":null,\"googleClientSecretSettingName\":null,\"googleOAuthScopes\":null,\"facebookAppId\":null,\"facebookAppSecret\":null,\"facebookAppSecretSettingName\":null,\"facebookOAuthScopes\":null,\"gitHubClientId\":null,\"gitHubClientSecret\":null,\"gitHubClientSecretSettingName\":null,\"gitHubOAuthScopes\":null,\"twitterConsumerKey\":null,\"twitterConsumerSecret\":null,\"twitterConsumerSecretSettingName\":null,\"microsoftAccountClientId\":null,\"microsoftAccountClientSecret\":null,\"microsoftAccountClientSecretSettingName\":null,\"microsoftAccountOAuthScopes\":null,\"isAuthFromFile\":\"False\",\"configVersion\":\"v2\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f61f8493-5573-41a1-8b42-59afeddeda40"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-resource-requests",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-aspnet-version",
+              "value": "4.0.30319"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "3358b303-f041-44eb-9f1f-9fb289e1acb7"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20211012T130439Z:3358b303-f041-44eb-9f1f-9fb289e1acb7"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 12 Oct 2021 13:04:38 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 683,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-12T13:04:38.627Z",
+        "time": 894,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 894
         }
       }
     ],

--- a/src/steps/resource-manager/appservice/client.ts
+++ b/src/steps/resource-manager/appservice/client.ts
@@ -1,5 +1,10 @@
 import { WebSiteManagementClient } from '@azure/arm-appservice';
-import { AppServicePlan, Site } from '@azure/arm-appservice/esm/models';
+import {
+  AppServicePlan,
+  Site,
+  WebAppsGetAuthSettingsResponse,
+  WebAppsGetConfigurationResponse,
+} from '@azure/arm-appservice/esm/models';
 import {
   Client,
   iterateAllResources,
@@ -36,5 +41,35 @@ export class AppServiceClient extends Client {
       resourceDescription: 'appService.appServicePlans',
       callback,
     });
+  }
+
+  public async fetchAppConfiguration(
+    name: string | undefined,
+    resourceGroup: string | undefined,
+  ): Promise<WebAppsGetConfigurationResponse | null> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      WebSiteManagementClient,
+    );
+
+    if (!name || !resourceGroup) {
+      return null;
+    }
+
+    return serviceClient.webApps.getConfiguration(resourceGroup, name);
+  }
+
+  public async fetchAppAuthSettings(
+    name: string | undefined,
+    resourceGroup: string | undefined,
+  ): Promise<WebAppsGetAuthSettingsResponse | null> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      WebSiteManagementClient,
+    );
+
+    if (!name || !resourceGroup) {
+      return null;
+    }
+
+    return serviceClient.webApps.getAuthSettings(resourceGroup, name);
   }
 }

--- a/src/steps/resource-manager/appservice/client.ts
+++ b/src/steps/resource-manager/appservice/client.ts
@@ -43,16 +43,80 @@ export class AppServiceClient extends Client {
     });
   }
 
-  public async fetchAppConfiguration(
+  public async createAppAuthConfigurationContext(): Promise<
+    (
+      name?: string,
+      resourceGroup?: string,
+    ) => Promise<WebAppsGetAuthSettingsResponse | undefined>
+  > {
+    let canGetAuthSettings: boolean | undefined = undefined;
+
+    return async (
+      name?: string,
+      resourceGroup?: string,
+    ): Promise<WebAppsGetAuthSettingsResponse | undefined> => {
+      if (typeof canGetAuthSettings === 'undefined') {
+        canGetAuthSettings = await this.canFetchAppAuthSettings(
+          name,
+          resourceGroup,
+        );
+      }
+
+      if (!canGetAuthSettings) {
+        return;
+      }
+
+      const serviceClient = await this.getAuthenticatedServiceClient(
+        WebSiteManagementClient,
+      );
+
+      if (!name || !resourceGroup) {
+        return;
+      }
+
+      return serviceClient.webApps.getAuthSettings(resourceGroup, name);
+    };
+  }
+
+  public async canFetchAppAuthSettings(
     name: string | undefined,
     resourceGroup: string | undefined,
-  ): Promise<WebAppsGetConfigurationResponse | null> {
+  ): Promise<boolean | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       WebSiteManagementClient,
     );
 
     if (!name || !resourceGroup) {
-      return null;
+      return;
+    }
+
+    try {
+      await serviceClient.webApps.getAuthSettings(resourceGroup, name);
+      return true;
+    } catch (err) {
+      this.logger.warn({ err }, 'Warning: unable to fetch app configuration.');
+      if (err.statusCode === 403 && err.code === 'AuthorizationFailed') {
+        this.logger.publishEvent({
+          name: 'MISSING_PERMISSION',
+          description:
+            'Missing permission "Microsoft.Web/sites/config/list/action", which is used to fetch WebApp Auth Settings. Please update the `JupiterOne Reader` Role in your Azure environment in order to fetch these settings for your WebApp.',
+        });
+        return false;
+      }
+      return;
+    }
+  }
+
+  public async fetchAppConfiguration(
+    name: string | undefined,
+    resourceGroup: string | undefined,
+  ): Promise<WebAppsGetConfigurationResponse | undefined> {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      WebSiteManagementClient,
+    );
+
+    if (!name || !resourceGroup) {
+      return;
     }
 
     return serviceClient.webApps.getConfiguration(resourceGroup, name);
@@ -61,13 +125,13 @@ export class AppServiceClient extends Client {
   public async fetchAppAuthSettings(
     name: string | undefined,
     resourceGroup: string | undefined,
-  ): Promise<WebAppsGetAuthSettingsResponse | null> {
+  ): Promise<WebAppsGetAuthSettingsResponse | undefined> {
     const serviceClient = await this.getAuthenticatedServiceClient(
       WebSiteManagementClient,
     );
 
     if (!name || !resourceGroup) {
-      return null;
+      return;
     }
 
     return serviceClient.webApps.getAuthSettings(resourceGroup, name);

--- a/src/steps/resource-manager/appservice/client.ts
+++ b/src/steps/resource-manager/appservice/client.ts
@@ -43,12 +43,10 @@ export class AppServiceClient extends Client {
     });
   }
 
-  public async createAppAuthConfigurationContext(): Promise<
-    (
-      name?: string,
-      resourceGroup?: string,
-    ) => Promise<WebAppsGetAuthSettingsResponse | undefined>
-  > {
+  public createAppAuthConfigurationContext(): (
+    name?: string,
+    resourceGroup?: string,
+  ) => Promise<WebAppsGetAuthSettingsResponse | undefined> {
     let canGetAuthSettings: boolean | undefined = undefined;
 
     return async (

--- a/src/steps/resource-manager/appservice/converters.ts
+++ b/src/steps/resource-manager/appservice/converters.ts
@@ -5,14 +5,27 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker } from '../../../azure';
-import { AppServicePlan, Site } from '@azure/arm-appservice/esm/models';
+import {
+  AppServicePlan,
+  Site,
+  WebAppsGetAuthSettingsResponse,
+  WebAppsGetConfigurationResponse,
+} from '@azure/arm-appservice/esm/models';
 import { AppServiceEntities } from './constants';
 
-export function createAppEntity(
-  webLinker: AzureWebLinker,
-  data: Site,
-  metadata: StepEntityMetadata,
-): Entity {
+export function createAppEntity({
+  webLinker,
+  data,
+  metadata,
+  appConfig,
+  appAuthSettings,
+}: {
+  webLinker: AzureWebLinker;
+  data: Site;
+  metadata: StepEntityMetadata;
+  appConfig: WebAppsGetConfigurationResponse | null;
+  appAuthSettings: WebAppsGetAuthSettingsResponse | null;
+}): Entity {
   return createIntegrationEntity({
     entityData: {
       source: data,
@@ -25,6 +38,28 @@ export function createAppEntity(
         type: data.type,
         kind: data.kind?.split(','),
         location: data.location,
+        // 9.1 Ensure App Service Authentication is set on Azure App Service (Automated)
+        authEnabled: appAuthSettings?.enabled,
+        // 9.2 Ensure web app redirects all HTTP traffic to HTTPS in Azure App Service (Automated)
+        httpsOnly: data.httpsOnly,
+        // 9.3 Ensure web app is using the latest version of TLS encryption (Automated)
+        minTlsVersion: appConfig?.minTlsVersion,
+        // 9.4 Ensure the web app has 'Client Certificates (Incoming client certificates)' set to 'On' (Automated)
+        clientCertEnabled: data.clientCertEnabled,
+        // 9.5 Ensure that Register with Azure Active Directory is enabled on App Service (Automated)
+        principalId: data.identity?.principalId,
+        // 9.6 Ensure that 'PHP version' is the latest, if used to run the web app (Manual)
+        phpVersion: appConfig?.phpVersion,
+        // 9.7 Ensure that 'Python version' is the latest, if used to run the web app (Manual)
+        pythonVersion: appConfig?.pythonVersion,
+        // 9.8 Ensure that 'Java version' is the latest, if used to run the web app (Manual)
+        javaVersion: appConfig?.javaVersion,
+        // Not CIS benchmark, but useful property
+        nodeVersion: appConfig?.nodeVersion,
+        // 9.9 Ensure that 'HTTP Version' is the latest, if used to run the web app (Manual)
+        http20Enabled: appConfig?.http20Enabled,
+        // 9.10 Ensure FTP deployments are disabled (Automated)
+        ftpsState: appConfig?.ftpsState,
         webLink: webLinker.portalResourceUrl(data.id),
       },
     },

--- a/src/steps/resource-manager/appservice/converters.ts
+++ b/src/steps/resource-manager/appservice/converters.ts
@@ -2,6 +2,7 @@ import {
   Entity,
   createIntegrationEntity,
   StepEntityMetadata,
+  setRawData,
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker } from '../../../azure';
@@ -23,10 +24,10 @@ export function createAppEntity({
   webLinker: AzureWebLinker;
   data: Site;
   metadata: StepEntityMetadata;
-  appConfig: WebAppsGetConfigurationResponse | null;
-  appAuthSettings: WebAppsGetAuthSettingsResponse | null;
+  appConfig: WebAppsGetConfigurationResponse | undefined;
+  appAuthSettings: WebAppsGetAuthSettingsResponse | undefined;
 }): Entity {
-  return createIntegrationEntity({
+  const appServiceEntity = createIntegrationEntity({
     entityData: {
       source: data,
       assign: {
@@ -64,6 +65,22 @@ export function createAppEntity({
       },
     },
   });
+
+  if (appConfig) {
+    setRawData(appServiceEntity, {
+      name: 'appConfig',
+      rawData: appConfig,
+    });
+  }
+
+  if (appAuthSettings) {
+    setRawData(appServiceEntity, {
+      name: 'appAuthSettings',
+      rawData: appAuthSettings,
+    });
+  }
+
+  return appServiceEntity;
 }
 
 export function createAppServicePlanEntity(

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -31,9 +31,23 @@ export async function fetchApps(
   const client = new AppServiceClient(instance.config, logger);
 
   await client.iterateApps(async (app) => {
+    const appConfig = await client.fetchAppConfiguration(
+      app.name,
+      app.resourceGroup,
+    );
+    const appAuthSettings = await client.fetchAppAuthSettings(
+      app.name,
+      app.resourceGroup,
+    );
     const metadata = getMetadataForApp(logger, app);
     const appEntity = await jobState.addEntity(
-      createAppEntity(webLinker, app, metadata),
+      createAppEntity({
+        webLinker,
+        data: app,
+        metadata,
+        appConfig,
+        appAuthSettings,
+      }),
     );
     await createResourceGroupResourceRelationship(executionContext, appEntity);
   });

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -30,7 +30,7 @@ export async function fetchApps(
   const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
   const client = new AppServiceClient(instance.config, logger);
 
-  const fetchAppAuthConfiguration = await client.createAppAuthConfigurationContext();
+  const fetchAppAuthConfiguration = client.createAppAuthConfigurationContext();
 
   await client.iterateApps(async (app) => {
     const appAuthSettings = await fetchAppAuthConfiguration(

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -18,7 +18,10 @@ import {
   AppServiceSteps,
 } from './constants';
 import { createAppEntity, createAppServicePlanEntity } from './converters';
-import { Site } from '@azure/arm-appservice/esm/models';
+import {
+  Site,
+  WebAppsGetAuthSettingsResponse,
+} from '@azure/arm-appservice/esm/models';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources';
 
@@ -30,17 +33,37 @@ export async function fetchApps(
   const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
   const client = new AppServiceClient(instance.config, logger);
 
-  const fetchAppAuthConfiguration = client.createAppAuthConfigurationContext();
+  let canFetchAppAuthConfiguration = true;
 
   await client.iterateApps(async (app) => {
-    const appAuthSettings = await fetchAppAuthConfiguration(
-      app.name,
-      app.resourceGroup,
-    );
+    let appAuthSettings: WebAppsGetAuthSettingsResponse | undefined;
+
     const appConfig = await client.fetchAppConfiguration(
       app.name,
       app.resourceGroup,
     );
+
+    if (canFetchAppAuthConfiguration) {
+      try {
+        appAuthSettings = await client.fetchAppAuthSettings(
+          app.name,
+          app.resourceGroup,
+        );
+      } catch (err) {
+        logger.warn(
+          { err, name: app.name, resourceGroup: app.resourceGroup },
+          'Warning: unable to fetch app configuration.',
+        );
+        if (err.statusCode === 403 && err.code === 'AuthorizationFailed') {
+          logger.publishEvent({
+            name: 'missing_permission',
+            description:
+              'Missing permission "Microsoft.Web/sites/config/list/action", which is used to fetch WebApp Auth Settings. Please update the `JupiterOne Reader` Role in your Azure environment in order to fetch these settings for your WebApp.',
+          });
+          canFetchAppAuthConfiguration = false;
+        }
+      }
+    }
 
     const metadata = getMetadataForApp(logger, app);
     const appEntity = await jobState.addEntity(

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -30,15 +30,18 @@ export async function fetchApps(
   const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
   const client = new AppServiceClient(instance.config, logger);
 
+  const fetchAppAuthConfiguration = await client.createAppAuthConfigurationContext();
+
   await client.iterateApps(async (app) => {
+    const appAuthSettings = await fetchAppAuthConfiguration(
+      app.name,
+      app.resourceGroup,
+    );
     const appConfig = await client.fetchAppConfiguration(
       app.name,
       app.resourceGroup,
     );
-    const appAuthSettings = await client.fetchAppAuthSettings(
-      app.name,
-      app.resourceGroup,
-    );
+
     const metadata = getMetadataForApp(logger, app);
     const appEntity = await jobState.addEntity(
       createAppEntity({

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -40,7 +40,7 @@ it('auth error', async () => {
   };
 
   await expect(exec).rejects.toThrow(
-    "AADSTS90002: Tenant 'invalid' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator.",
+    "Error: AADSTS90002: Tenant 'invalid' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.",
   );
 });
 


### PR DESCRIPTION
This PR adds the following (new) benchmarks:

- 9.1 Ensure App Service Authentication is set on Azure App Service (Automated)
- 9.2 Ensure web app redirects all HTTP traffic to HTTPS in Azure App Service (Automated)
- 9.3 Ensure web app is using the latest version of TLS encryption (Automated)
- 9.4 Ensure the web app has 'Client Certificates (Incoming client certificates)' set to 'On' (Automated)
- 9.5 Ensure that Register with Azure Active Directory is enabled on App Service (Automated)
- 9.6 Ensure that 'PHP version' is the latest, if used to run the web app (Manual)
- 9.7 Ensure that 'Python version' is the latest, if used to run the web app (Manual)
- 9.8 Ensure that 'Java version' is the latest, if used to run the web app (Manual)
- 9.9 Ensure that 'HTTP Version' is the latest, if used to run the web app (Manual)
- 9.10 Ensure FTP deployments are disabled (Automated)

### Some notes:
1) Types for `app.name` and `app.resourceGroup` are defined as `string | undefined` :monocle_face: . That's the reason why the entire `| undefined` part got weaved through the additional methods. My goal was, even in the unlikely event that these are indeed undefined, that nothing breaks/causes the step to error out, but for those additional properties to just be `undefined` as well.
2) The CIS benchmark didn't include an entry for `nodeVersion`, I've added it - feels useful but let me know if that property should be removed.
3) I've left some comments inside of the converter to help make sense of what's what, I can delete them before this gets merged if we don't want to have them be there.
4) For some reason Azure won't return the values of the versions (9.6-9.8). I'm confident I'm doing the correct thing with the code and furthermore even using `az` CLI tool (as shown in the CIS benchmarks examples) isn't returning those values back (we get back empty strings ""). I decided to still keep this in the code so that we still have this functionality in place if/once this gets resolved, but let me know if we want to simply ignore these benchmarks for now and delete those properties.
5) `fetchAppAuthSettings()` necessary for resolving benchmark 9.1 required required some authorization/scope modification. Without any changes, this resulted in the following error:

> Error: The client 'xxxxxxxxxxxxxxxx' with object id 'xxxxxxxxxxxxxxxx' does not have authorization to perform action 'Microsoft.Web/sites/config/list/action' over scope '/subscriptions/yyyyyyyyyy/resourceGroups/zzzzzzzzzzzzzzzz/providers/Microsoft.Web/sites/example-appservices/config/authsettings' or the scope is invalid. If access was recently granted, please refresh your credentials.

This makes me think of the following ideas:
1) We may want to note this somewhere for customers - e.g. they need to make that modification in order for this property to be successfully ingested.
2) We probably need to add some error handling for this - so that the entire step doesn't error out if this is not the case.

###  CHANGELOG.md
(to be added when this gets merged)
```
### Added

- New properties added to resources:

  | Entity                                | Properties          |
  | ------------------------------------- | ------------------- |
  | `azure_web_app`, `azure_function_app` | `authEnabled`       |
  | `azure_web_app`, `azure_function_app` | `httpsOnly`         |
  | `azure_web_app`, `azure_function_app` | `minTlsVersion`     |
  | `azure_web_app`, `azure_function_app` | `clientCertEnabled` |
  | `azure_web_app`, `azure_function_app` | `principalId`       |
  | `azure_web_app`, `azure_function_app` | `phpVersion`        |
  | `azure_web_app`, `azure_function_app` | `pythonVersion`     |
  | `azure_web_app`, `azure_function_app` | `javaVersion`       |
  | `azure_web_app`, `azure_function_app` | `nodeVersion`       |
  | `azure_web_app`, `azure_function_app` | `http20Enabled`     |
  | `azure_web_app`, `azure_function_app` | `ftpsState`         |
  
  Note: fetching app auth settings requires additional permission to be added to the custom role:
     `Microsoft.Web/sites/config/list/Action`
```

### J1QL Queries
- 9.1 Ensure App Service Authentication is set on Azure App Service (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with authEnabled = true
   
# BAD CASE
Find (azure_function_app | azure_web_app) with authEnabled = false
```
- 9.2 Ensure web app redirects all HTTP traffic to HTTPS in Azure App Service (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with httpsOnly = true
   
# BAD CASE
Find (azure_function_app | azure_web_app) with httpsOnly = false
```

- 9.3 Ensure web app is using the latest version of TLS encryption (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with minTlsVersion = "1.2"
   
# BAD CASE
Find (azure_function_app | azure_web_app) with minTlsVersion != "1.2"
```

- 9.4 Ensure the web app has 'Client Certificates (Incoming client certificates)' set to 'On' (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with clientCertEnabled = true
   
# BAD CASE
Find (azure_function_app | azure_web_app) with clientCertEnabled = false
```

- 9.5 Ensure that Register with Azure Active Directory is enabled on App Service (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with principalId != undefined
   
# BAD CASE
Find (azure_function_app | azure_web_app) with principalId = undefined
```

- 9.6 Ensure that 'PHP version' is the latest, if used to run the web app (Manual)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with phpVersion = <latest version, string>
   
# BAD CASE
Find (azure_function_app | azure_web_app) with phpVersion != <latest version, string>
```

- 9.7 Ensure that 'Python version' is the latest, if used to run the web app (Manual)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with pythonVersion = <latest version, string>
   
# BAD CASE
Find (azure_function_app | azure_web_app) with pythonVersion != <latest version, string>
```

- 9.8 Ensure that 'Java version' is the latest, if used to run the web app (Manual)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with javaVersion = <latest version, string>
   
# BAD CASE
Find (azure_function_app | azure_web_app) with javaVersion != <latest version, string>
```

- 9.9 Ensure that 'HTTP Version' is the latest, if used to run the web app (Manual)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with http20Enabled = true
   
# BAD CASE
Find (azure_function_app | azure_web_app) with http20Enabled = false
```

- 9.10 Ensure FTP deployments are disabled (Automated)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with ftpsState != "AllAllowed"
   
# BAD CASE
Find (azure_function_app | azure_web_app) with ftpsState = "AllAllowed"
```

- [Bonus, not CIS benchmark] Ensure that 'Node version' is the latest, if used to run the web app (Manual)
```
# GOOD CASE
Find (azure_function_app | azure_web_app) with nodeVersion = <latest version, string>
   
# BAD CASE
Find (azure_function_app | azure_web_app) with nodeVersion != <latest version, string>
```

Pinging @ndowmon @aiwilliams (I'm not sure if I need to tag someone else for Azure related PRs :slightly_smiling_face: )