### PR TITLE
INT-1776 - Add Key Vault Keys (8.1) and Secrets (8.2) (Section 8) CIS benchmarks

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -173,7 +173,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 ********************************************************************************
 -->
 
@@ -219,6 +219,8 @@ The following entities are created:
 | [RM] Gallery                                   | `azure_gallery`                                   | `Repository`                       |
 | [RM] Image                                     | `azure_image`                                     | `Image`                            |
 | [RM] Key Vault                                 | `azure_keyvault_service`                          | `Service`                          |
+| [RM] Key Vault Key                             | `azure_keyvault_key`                              | `Key`                              |
+| [RM] Key Vault Secret                          | `azure_keyvault_secret`                           | `Secret`                           |
 | [RM] Load Balancer                             | `azure_lb`                                        | `Gateway`                          |
 | [RM] Location                                  | `azure_location`                                  | `Site`                             |
 | [RM] Management Group                          | `azure_management_group`                          | `Group`                            |
@@ -279,7 +281,7 @@ The following entities are created:
 
 ### Relationships
 
-The following relationships are created/mapped:
+The following relationships are created:
 
 | Source Entity `_type`              | Relationship `_class` | Target Entity `_type`                             |
 | ---------------------------------- | --------------------- | ------------------------------------------------- |
@@ -311,6 +313,8 @@ The following relationships are created/mapped:
 | `azure_user_group`                 | **HAS**               | `azure_group_member`                              |
 | `azure_user_group`                 | **HAS**               | `azure_user`                                      |
 | `azure_keyvault_service`           | **ALLOWS**            | `ANY_PRINCIPAL`                                   |
+| `azure_keyvault_service`           | **CONTAINS**          | `azure_keyvault_key`                              |
+| `azure_keyvault_service`           | **CONTAINS**          | `azure_keyvault_secret`                           |
 | `azure_lb`                         | **CONNECTS**          | `azure_nic`                                       |
 | `azure_location`                   | **HAS**               | `azure_network_watcher`                           |
 | `azure_management_group`           | **CONTAINS**          | `azure_management_group`                          |

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@azure/arm-subscriptions": "^2.0.0",
     "@azure/identity": "^1.0.2",
     "@azure/keyvault-keys": "^4.0.2",
+    "@azure/keyvault-secrets": "^4.3.0",
     "@azure/ms-rest-nodeauth": "^2.0.5",
     "@azure/storage-blob": "^12.5.0",
     "@azure/storage-queue": "^12.4.0",

--- a/src/azure/createAzureWebLinker.ts
+++ b/src/azure/createAzureWebLinker.ts
@@ -31,6 +31,11 @@ export default function createAzureWebLinker(
         }
       }
     },
+    assetResourceUrl: (path): string | undefined => {
+      if (defaultDomain && path) {
+        return `https://portal.azure.com/#@${defaultDomain}/asset${path}`;
+      }
+    },
   };
 }
 

--- a/src/azure/types.ts
+++ b/src/azure/types.ts
@@ -18,4 +18,5 @@ export interface AzureWebLinker {
    * determined
    */
   portalResourceUrl: (path: string | undefined) => string | undefined;
+  assetResourceUrl: (path: string | undefined) => string | undefined;
 }

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -32,6 +32,8 @@ import { steps as sqlDatabaseSteps } from './steps/resource-manager/databases/sq
 import { STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS } from './steps/resource-manager/interservice';
 import {
   STEP_RM_KEYVAULT_VAULTS,
+  STEP_RM_KEYVAULT_KEYS,
+  STEP_RM_KEYVAULT_SECRETS,
   KeyVaultStepIds,
 } from './steps/resource-manager/key-vault';
 import {
@@ -128,6 +130,8 @@ describe('getStepStartStates', () => {
       [STEP_AD_USERS]: { disabled: true },
       [STEP_AD_SERVICE_PRINCIPALS]: { disabled: true },
       [STEP_RM_KEYVAULT_VAULTS]: { disabled: true },
+      [STEP_RM_KEYVAULT_KEYS]: { disabled: true },
+      [STEP_RM_KEYVAULT_SECRETS]: { disabled: true },
       [KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS]: { disabled: true },
       [STEP_RM_NETWORK_VIRTUAL_NETWORKS]: { disabled: true },
       [STEP_RM_NETWORK_SECURITY_GROUPS]: { disabled: true },
@@ -264,6 +268,8 @@ describe('getStepStartStates', () => {
       [STEP_AD_USERS]: { disabled: false },
       [STEP_AD_SERVICE_PRINCIPALS]: { disabled: false },
       [STEP_RM_KEYVAULT_VAULTS]: { disabled: true },
+      [STEP_RM_KEYVAULT_KEYS]: { disabled: true },
+      [STEP_RM_KEYVAULT_SECRETS]: { disabled: true },
       [KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS]: { disabled: true },
       [STEP_RM_NETWORK_VIRTUAL_NETWORKS]: { disabled: true },
       [STEP_RM_NETWORK_SECURITY_GROUPS]: { disabled: true },
@@ -400,6 +406,8 @@ describe('getStepStartStates', () => {
       [STEP_AD_USERS]: { disabled: true },
       [STEP_AD_SERVICE_PRINCIPALS]: { disabled: true },
       [STEP_RM_KEYVAULT_VAULTS]: { disabled: false },
+      [STEP_RM_KEYVAULT_KEYS]: { disabled: false },
+      [STEP_RM_KEYVAULT_SECRETS]: { disabled: false },
       [KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS]: { disabled: false },
       [STEP_RM_NETWORK_VIRTUAL_NETWORKS]: { disabled: false },
       [STEP_RM_NETWORK_SECURITY_GROUPS]: { disabled: false },
@@ -538,6 +546,8 @@ describe('getStepStartStates', () => {
       [STEP_AD_USERS]: { disabled: true },
       [STEP_AD_SERVICE_PRINCIPALS]: { disabled: true },
       [STEP_RM_KEYVAULT_VAULTS]: { disabled: true },
+      [STEP_RM_KEYVAULT_KEYS]: { disabled: true },
+      [STEP_RM_KEYVAULT_SECRETS]: { disabled: true },
       [KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS]: { disabled: true },
       [STEP_RM_NETWORK_VIRTUAL_NETWORKS]: { disabled: true },
       [STEP_RM_NETWORK_SECURITY_GROUPS]: { disabled: true },

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -32,6 +32,8 @@ import { steps as sqlDatabaseSteps } from './steps/resource-manager/databases/sq
 import { STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS } from './steps/resource-manager/interservice/constants';
 import {
   STEP_RM_KEYVAULT_VAULTS,
+  STEP_RM_KEYVAULT_KEYS,
+  STEP_RM_KEYVAULT_SECRETS,
   KeyVaultStepIds,
 } from './steps/resource-manager/key-vault/constants';
 import {
@@ -146,6 +148,8 @@ export function getResourceManagerSteps(): GetApiSteps {
   return {
     executeFirstSteps: [
       STEP_RM_KEYVAULT_VAULTS,
+      STEP_RM_KEYVAULT_KEYS,
+      STEP_RM_KEYVAULT_SECRETS,
       KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS,
       STEP_RM_NETWORK_VIRTUAL_NETWORKS,
       STEP_RM_NETWORK_SECURITY_GROUPS,

--- a/src/steps/resource-manager/key-vault/__recordings__/resource-manager-step-key-vaults_311334852/recording.har
+++ b/src/steps/resource-manager/key-vault/__recordings__/resource-manager-step-key-vaults_311334852/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "9d62ae571eb541c135fae72616ae365c",
+        "_id": "7c7c773cc880bad25db8c30df19394dc",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "cd65cf4c-9119-49a4-8afb-3af30151c0cf"
+              "value": "065b43c0-617b-4185-abfc-04bd019ca516"
             },
             {
               "name": "return-client-request-id",
@@ -41,7 +41,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -56,7 +56,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/4a17becb-fb42-4633-b5c8-5ab66f28d195/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1613171563\",\"not_before\":\"1613167663\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632782311\",\"not_before\":\"1632778411\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-03-14T22:12:43.000Z",
+              "expires": "2021-10-27T21:38:31.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "cd65cf4c-9119-49a4-8afb-3af30151c0cf"
+              "value": "065b43c0-617b-4185-abfc-04bd019ca516"
             },
             {
               "name": "x-ms-request-id",
-              "value": "f1d00e63-40c0-47b3-ab31-26650bd67000"
+              "value": "83571b6a-3b90-4dfe-9428-7fbc6e048d00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11459.16 - CHI ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:43 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:31 GMT"
             },
             {
               "name": "connection",
@@ -177,14 +177,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 786,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:43.114Z",
-        "time": 350,
+        "startedDateTime": "2021-09-27T21:38:31.242Z",
+        "time": 721,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 350
+          "wait": 721
         }
       },
       {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5d40f63d-d2fe-4cb8-afec-ea049ccb6a9c"
+              "value": "fc24149f-f0d6-4088-9985-15899ce197b0"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 337,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 337,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"87f62f44-9dad-4284-a08f-f2fb3d8b528a\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "9041571e-953c-4f08-b43b-a429a366cd08"
+              "value": "da0e7dbf-10f2-4f11-a6e7-4bbeec369786"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "9041571e-953c-4f08-b43b-a429a366cd08"
+              "value": "da0e7dbf-10f2-4f11-a6e7-4bbeec369786"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTCENTRALUS:20210212T221243Z:9041571e-953c-4f08-b43b-a429a366cd08"
+              "value": "GERMANYWESTCENTRAL:20210927T213832Z:da0e7dbf-10f2-4f11-a6e7-4bbeec369786"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:43 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:32 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "337"
+              "value": "349"
             }
           ],
-          "headersSize": 588,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:43.493Z",
-        "time": 232,
+        "startedDateTime": "2021-09-27T21:38:32.043Z",
+        "time": 788,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,11 +345,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 788
         }
       },
       {
-        "_id": "889027fa70d2ad3e867d9230ddc86682",
+        "_id": "7db72387127f09493f5629c8cbeb45ba",
         "_order": 0,
         "cache": {},
         "request": {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "b1027a19-6c7a-46c5-b000-85be2f7441ae"
+              "value": "026c717e-0781-439d-a422-69f4fe4b2095"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1837,
+          "headersSize": 1846,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -419,14 +419,14 @@
               "value": "2015-11-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resources?%24filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resources?%24filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01"
         },
         "response": {
-          "bodySize": 305,
+          "bodySize": 304,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 305,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/keionned1-j1dev\",\"name\":\"keionned1-j1dev\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"}}]}"
+            "size": 304,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1\",\"name\":\"example-key-vault-1\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{}}]}"
           },
           "cookies": [],
           "headers": [
@@ -452,19 +452,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "887ddf1e-d5cd-4ce4-8a3f-c763aa529726"
+              "value": "79770c1d-e49b-4a5b-b2d2-3fb00379e43d"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "887ddf1e-d5cd-4ce4-8a3f-c763aa529726"
+              "value": "79770c1d-e49b-4a5b-b2d2-3fb00379e43d"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTCENTRALUS:20210212T221244Z:887ddf1e-d5cd-4ce4-8a3f-c763aa529726"
+              "value": "GERMANYWESTCENTRAL:20210927T213833Z:79770c1d-e49b-4a5b-b2d2-3fb00379e43d"
             },
             {
               "name": "strict-transport-security",
@@ -476,7 +476,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:43 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:32 GMT"
             },
             {
               "name": "connection",
@@ -484,17 +484,17 @@
             },
             {
               "name": "content-length",
-              "value": "305"
+              "value": "304"
             }
           ],
-          "headersSize": 594,
+          "headersSize": 599,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:43.741Z",
-        "time": 372,
+        "startedDateTime": "2021-09-27T21:38:32.871Z",
+        "time": 492,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -502,11 +502,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 372
+          "wait": 492
         }
       },
       {
-        "_id": "082e5c537b0eddea4ff4488a326af6d7",
+        "_id": "fe5425e40a33ad34c06ec78fa00148c0",
         "_order": 0,
         "cache": {},
         "request": {
@@ -526,7 +526,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "6d623a10-9f2b-48e7-bac2-9d126c05c3f1"
+              "value": "c758d36b-c978-49e9-b4a3-0bac40118074"
             },
             {
               "_fromType": "array",
@@ -536,7 +536,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -563,7 +563,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1836,
+          "headersSize": 1866,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -572,14 +572,14 @@
               "value": "2018-02-14"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/keionned1-j1dev?api-version=2018-02-14"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/stefan_keyvaults_group/providers/Microsoft.KeyVault/vaults/example-key-vault-1?api-version=2018-02-14"
         },
         "response": {
-          "bodySize": 1375,
+          "bodySize": 1429,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1375,
-            "text": "{\"id\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/keionned1-j1dev\",\"name\":\"keionned1-j1dev\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"sku\":{\"family\":\"A\",\"name\":\"standard\"},\"tenantId\":\"4a17becb-fb42-4633-b5c8-5ab66f28d195\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"defaultAction\":\"Deny\",\"ipRules\":[],\"virtualNetworkRules\":[]},\"accessPolicies\":[{\"tenantId\":\"4a17becb-fb42-4633-b5c8-5ab66f28d195\",\"objectId\":\"1c709f89-4d15-458d-b3b2-2943ccb22d80\",\"permissions\":{\"keys\":[\"get\"],\"secrets\":[\"get\"],\"certificates\":[],\"storage\":[]}}],\"enabledForDeployment\":false,\"enabledForDiskEncryption\":true,\"enabledForTemplateDeployment\":false,\"enableSoftDelete\":true,\"softDeleteRetentionInDays\":7,\"enableRbacAuthorization\":false,\"vaultUri\":\"https://keionned1-j1dev.vault.azure.net/\",\"provisioningState\":\"Succeeded\"}}"
+            "size": 1429,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1\",\"name\":\"example-key-vault-1\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"sku\":{\"family\":\"A\",\"name\":\"Standard\"},\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"accessPolicies\":[{\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"objectId\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"permissions\":{\"keys\":[\"Get\",\"List\",\"Update\",\"Create\",\"Import\",\"Delete\",\"Recover\",\"Backup\",\"Restore\"],\"secrets\":[\"Get\",\"List\",\"Set\",\"Delete\",\"Recover\",\"Backup\",\"Restore\"],\"certificates\":[\"Get\",\"List\",\"Update\",\"Create\",\"Import\",\"Delete\",\"Recover\",\"Backup\",\"Restore\",\"ManageContacts\",\"ManageIssuers\",\"GetIssuers\",\"ListIssuers\",\"SetIssuers\",\"DeleteIssuers\"]}}],\"enabledForDeployment\":false,\"enabledForDiskEncryption\":false,\"enabledForTemplateDeployment\":false,\"enableSoftDelete\":true,\"softDeleteRetentionInDays\":90,\"enableRbacAuthorization\":false,\"vaultUri\":\"https://example-key-vault-1.vault.azure.net/\",\"provisioningState\":\"Succeeded\"}}"
           },
           "cookies": [],
           "headers": [
@@ -604,12 +604,16 @@
               "value": "Accept-Encoding"
             },
             {
+              "name": "x-ms-client-request-id",
+              "value": "c758d36b-c978-49e9-b4a3-0bac40118074"
+            },
+            {
               "name": "x-ms-keyvault-service-version",
-              "value": "1.0.104.232"
+              "value": "1.5.99.5"
             },
             {
               "name": "x-ms-request-id",
-              "value": "a7b129c8-bd39-4090-bb83-a0aaf22b3edf"
+              "value": "7e059025-ac56-44a6-81c3-078667f74141"
             },
             {
               "name": "strict-transport-security",
@@ -637,29 +641,29 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "bc95bdcf-0c04-42b4-a413-fdecb7f1ef23"
+              "value": "59a6f21a-fec0-4877-b69c-7c24f1e725d0"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTCENTRALUS:20210212T221244Z:bc95bdcf-0c04-42b4-a413-fdecb7f1ef23"
+              "value": "GERMANYWESTCENTRAL:20210927T213834Z:59a6f21a-fec0-4877-b69c-7c24f1e725d0"
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:44 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:34 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 725,
+          "headersSize": 789,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:44.122Z",
-        "time": 443,
+        "startedDateTime": "2021-09-27T21:38:33.374Z",
+        "time": 1084,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -667,11 +671,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 443
+          "wait": 1084
         }
       },
       {
-        "_id": "9d62ae571eb541c135fae72616ae365c",
+        "_id": "7c7c773cc880bad25db8c30df19394dc",
         "_order": 1,
         "cache": {},
         "request": {
@@ -688,7 +692,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "98c7dd50-6945-4a34-bbf1-0f7d070e2421"
+              "value": "36518248-cf27-4a10-bc0e-e65e617f569d"
             },
             {
               "name": "return-client-request-id",
@@ -704,7 +708,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -719,7 +723,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -733,18 +737,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/4a17becb-fb42-4633-b5c8-5ab66f28d195/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1613171565\",\"not_before\":\"1613167665\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632782315\",\"not_before\":\"1632778415\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-03-14T22:12:45.000Z",
+              "expires": "2021-10-27T21:38:35.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -777,10 +781,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -802,15 +802,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "98c7dd50-6945-4a34-bbf1-0f7d070e2421"
+              "value": "36518248-cf27-4a10-bc0e-e65e617f569d"
             },
             {
               "name": "x-ms-request-id",
-              "value": "de44ddd4-1a4f-439e-be9d-7bd28be27200"
+              "value": "4c811bbd-0258-452e-af21-82fa45a32d00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11459.16 - CHI ProdSlices"
+              "value": "2.1.12071.16 - NCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -833,21 +833,25 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:44 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:35 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:44.576Z",
-        "time": 393,
+        "startedDateTime": "2021-09-27T21:38:34.556Z",
+        "time": 722,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -855,7 +859,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 393
+          "wait": 722
         }
       },
       {
@@ -874,7 +878,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "46797015-eef2-4e9b-b85a-2d6ed9426f64"
+              "value": "7b829c9f-f6d6-4e33-8011-1d7e4c88c09f"
             },
             {
               "_fromType": "array",
@@ -889,7 +893,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -916,7 +920,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -928,11 +932,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 337,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 337,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"87f62f44-9dad-4284-a08f-f2fb3d8b528a\",\"displayName\":\"Azure subscription 1\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -958,19 +962,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11998"
+              "value": "11999"
             },
             {
               "name": "x-ms-request-id",
-              "value": "949beee0-b9ab-493e-b6e9-0c3fc9c52f95"
+              "value": "c503d3a5-dc2b-43cb-b4f9-784bfddb7b13"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "949beee0-b9ab-493e-b6e9-0c3fc9c52f95"
+              "value": "c503d3a5-dc2b-43cb-b4f9-784bfddb7b13"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTCENTRALUS:20210212T221245Z:949beee0-b9ab-493e-b6e9-0c3fc9c52f95"
+              "value": "GERMANYWESTCENTRAL:20210927T213836Z:c503d3a5-dc2b-43cb-b4f9-784bfddb7b13"
             },
             {
               "name": "strict-transport-security",
@@ -982,7 +986,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:45 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:35 GMT"
             },
             {
               "name": "connection",
@@ -990,17 +994,17 @@
             },
             {
               "name": "content-length",
-              "value": "337"
+              "value": "349"
             }
           ],
-          "headersSize": 588,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:44.974Z",
-        "time": 280,
+        "startedDateTime": "2021-09-27T21:38:35.283Z",
+        "time": 772,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1008,11 +1012,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 280
+          "wait": 772
         }
       },
       {
-        "_id": "f22d0d0858f9cc6fbf911c9623e41476",
+        "_id": "62431131ffb8d397d24540ab2ac3482b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1032,7 +1036,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "642c3349-2546-466c-aabd-da3d7b567bbb"
+              "value": "9ef3cad4-0116-4dec-970d-babf24b747fd"
             },
             {
               "_fromType": "array",
@@ -1042,7 +1046,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.0 OS/(x64-Darwin-20.1.0)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -1069,7 +1073,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1892,
+          "headersSize": 1922,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1078,14 +1082,14 @@
               "value": "2017-05-01-preview"
             }
           ],
-          "url": "https://management.azure.com//subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/keionned1-j1dev/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+          "url": "https://management.azure.com//subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
         },
         "response": {
-          "bodySize": 1063,
+          "bodySize": 273,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1063,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourcegroups/j1dev/providers/microsoft.keyvault/vaults/keionned1-j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_key_vault_diag_set\",\"type\":\"Microsoft.Insights/diagnosticSettings\",\"name\":\"j1dev_key_vault_diag_set\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/87f62f44-9dad-4284-a08f-f2fb3d8b528a/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/keionnedj1dev\",\"serviceBusRuleId\":null,\"workspaceId\":null,\"eventHubAuthorizationRuleId\":null,\"eventHubName\":null,\"metrics\":[{\"category\":\"AllMetrics\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logs\":[{\"category\":\"AuditEvent\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logAnalyticsDestinationType\":null},\"identity\":null}]}"
+            "size": 273,
+            "text": "{\"value\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -1115,7 +1119,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "12874d4a-8beb-4035-84d4-c1c9e4780e08"
+              "value": "2da166a7-bef8-4a6b-a2ed-3f745290132f"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
@@ -1127,11 +1131,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "8e187717-7449-496e-b7bd-b4212d4d584b"
+              "value": "31138a70-a4e2-4348-b25c-b124f3595573"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "WESTCENTRALUS:20210212T221246Z:8e187717-7449-496e-b7bd-b4212d4d584b"
+              "value": "GERMANYWESTCENTRAL:20210927T213837Z:31138a70-a4e2-4348-b25c-b124f3595573"
             },
             {
               "name": "x-content-type-options",
@@ -1139,21 +1143,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 12 Feb 2021 22:12:45 GMT"
+              "value": "Mon, 27 Sep 2021 21:38:36 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 629,
+          "headersSize": 634,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-02-12T22:12:45.260Z",
-        "time": 730,
+        "startedDateTime": "2021-09-27T21:38:36.063Z",
+        "time": 1147,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1161,7 +1165,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 730
+          "wait": 1147
         }
       }
     ],

--- a/src/steps/resource-manager/key-vault/client.test.ts
+++ b/src/steps/resource-manager/key-vault/client.test.ts
@@ -66,7 +66,7 @@ describe('iterateKeys', () => {
     );
 
     const callback = jest.fn();
-    await client.iterateKeys(vault, callback);
+    await client.iterateKeys(vault.properties.vaultUri as string, callback);
 
     expect(callback).not.toHaveBeenCalled();
   });

--- a/src/steps/resource-manager/key-vault/client.ts
+++ b/src/steps/resource-manager/key-vault/client.ts
@@ -1,7 +1,7 @@
 import { KeyVaultManagementClient } from '@azure/arm-keyvault';
 import { Vault } from '@azure/arm-keyvault/esm/models';
 import { KeyClient, KeyProperties } from '@azure/keyvault-keys';
-
+import { SecretClient, SecretProperties } from '@azure/keyvault-secrets';
 import {
   Client,
   iterateAllResources,
@@ -35,22 +35,46 @@ export class KeyVaultClient extends Client {
   }
 
   public async iterateKeys(
-    vault: Vault,
+    vaultUri: string,
     callback: (resource: KeyProperties) => void | Promise<void>,
   ): Promise<void> {
-    const vaultUri = vault.properties.vaultUri;
-    if (!vaultUri) {
-      throw new Error('Vault does not include vaultUri, cannot iterate keys');
-    } else {
-      const client = new KeyClient(vaultUri, this.getClientSecretCredentials());
-      try {
-        for await (const properties of client.listPropertiesOfKeys()) {
-          await callback(properties);
-        }
-      } catch (err) {
-        if (err.statusCode !== 403) {
-          throw err;
-        }
+    const client = new KeyClient(vaultUri, this.getClientSecretCredentials());
+    try {
+      for await (const properties of client.listPropertiesOfKeys()) {
+        await callback(properties);
+      }
+    } catch (err) {
+      // Idea: we still want fetchKeyVaultKeys step to succeed (the below ones will just get skipped)
+      // For those KeyVaults where the permission for listing keys is missing
+      // a warn message will be shown indicating that
+      if (err.statusCode === 403) {
+        this.logger.warn({ err }, err.message);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  public async iterateSecrets(
+    vaultUri: string,
+    callback: (resource: SecretProperties) => void | Promise<void>,
+  ): Promise<void> {
+    const client = new SecretClient(
+      vaultUri,
+      this.getClientSecretCredentials(),
+    );
+    try {
+      for await (const properties of client.listPropertiesOfSecrets()) {
+        await callback(properties);
+      }
+    } catch (err) {
+      // Idea: we still want fetchKeyVaultSecrets step to succeed (the below ones will just get skipped)
+      // For those KeyVaults where the permission for listing secrets is missing
+      // a warn message will be shown indicating that
+      if (err.statusCode === 403) {
+        this.logger.warn({ err }, err.message);
+      } else {
+        throw err;
       }
     }
   }

--- a/src/steps/resource-manager/key-vault/constants.ts
+++ b/src/steps/resource-manager/key-vault/constants.ts
@@ -13,15 +13,37 @@ export const KeyVaultStepIds = {
   KEY_VAULT_PRINCIPAL_RELATIONSHIPS: 'rm-keyvault-principal-relationships',
 };
 
+export const STEP_RM_KEYVAULT_KEYS = 'rm-keyvault-keys';
+
+export const STEP_RM_KEYVAULT_SECRETS = 'rm-keyvault-secrets';
+
 // Graph objects
 export const KEY_VAULT_SERVICE_ENTITY_TYPE = 'azure_keyvault_service';
 export const KEY_VAULT_SERVICE_ENTITY_CLASS = ['Service'];
+
+export const KEY_VAULT_KEY_ENTITY_TYPE = 'azure_keyvault_key';
+export const KEY_VAULT_KEY_ENTITY_CLASS = ['Key'];
+
+export const KEY_VAULT_SECRET_ENTITY_TYPE = 'azure_keyvault_secret';
+export const KEY_VAULT_SECRET_ENTITY_CLASS = ['Secret'];
 
 export const KeyVaultEntities = {
   KEY_VAULT: {
     _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
     _class: KEY_VAULT_SERVICE_ENTITY_CLASS,
     resourceName: '[RM] Key Vault',
+    diagnosticLogCategories: ['AuditEvent'],
+  },
+  KEY_VAULT_KEY: {
+    _type: KEY_VAULT_KEY_ENTITY_TYPE,
+    _class: KEY_VAULT_KEY_ENTITY_CLASS,
+    resourceName: '[RM] Key Vault Key',
+    diagnosticLogCategories: ['AuditEvent'],
+  },
+  KEY_VAULT_SECRET: {
+    _type: KEY_VAULT_SECRET_ENTITY_TYPE,
+    _class: KEY_VAULT_SECRET_ENTITY_CLASS,
+    resourceName: '[RM] Key Vault Secret',
     diagnosticLogCategories: ['AuditEvent'],
   },
 };
@@ -33,11 +55,35 @@ export const ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE = generateRelationshipType(
   KEY_VAULT_SERVICE_ENTITY_TYPE,
 );
 
+export const KEY_VAULT_KEY_RELATIONSHIP_TYPE = generateRelationshipType(
+  RelationshipClass.CONTAINS,
+  KEY_VAULT_SERVICE_ENTITY_TYPE,
+  KEY_VAULT_KEY_ENTITY_TYPE,
+);
+
+export const KEY_VAULT_SECRET_RELATIONSHIP_TYPE = generateRelationshipType(
+  RelationshipClass.CONTAINS,
+  KEY_VAULT_SERVICE_ENTITY_TYPE,
+  KEY_VAULT_SECRET_ENTITY_TYPE,
+);
+
 export const KeyVaultRelationships = {
   KEY_VAULT_ALLOWS_PRINCIPAL: {
     _type: 'azure_keyvault_service_allows_principal',
     sourceType: KeyVaultEntities.KEY_VAULT._type,
     _class: RelationshipClass.ALLOWS,
     targetType: ANY_PRINCIPAL,
+  },
+  KEY_VAULT_CONTAINS_KEY: {
+    _type: KEY_VAULT_KEY_RELATIONSHIP_TYPE,
+    sourceType: KeyVaultEntities.KEY_VAULT._type,
+    _class: RelationshipClass.CONTAINS,
+    targetType: KeyVaultEntities.KEY_VAULT_KEY._type,
+  },
+  KEY_VAULT_CONTAINS_SECRET: {
+    _type: KEY_VAULT_SECRET_RELATIONSHIP_TYPE,
+    sourceType: KeyVaultEntities.KEY_VAULT._type,
+    _class: RelationshipClass.CONTAINS,
+    targetType: KeyVaultEntities.KEY_VAULT_SECRET._type,
   },
 };

--- a/src/steps/resource-manager/key-vault/converters.test.ts
+++ b/src/steps/resource-manager/key-vault/converters.test.ts
@@ -1,6 +1,13 @@
 import { createAzureWebLinker } from '../../../azure';
-import { createKeyVaultEntity } from './converters';
+import {
+  createKeyVaultEntity,
+  createKeyVaultKeyEntity,
+  createKeyVaultSecretEntity,
+} from './converters';
 import { Vault } from '@azure/arm-keyvault/esm/models';
+import { KeyProperties } from '@azure/keyvault-keys';
+import { SecretProperties } from '@azure/keyvault-secrets';
+import { parseTimePropertyValue } from '@jupiterone/integration-sdk-core';
 
 const webLinker = createAzureWebLinker('something.onmicrosoft.com');
 
@@ -69,11 +76,105 @@ describe('createKeyVaultEntity', () => {
       'tag.environment': 'j1dev',
       'tag.classification': 'production',
       environment: 'j1dev',
+      function: ['key-vault'],
       classification: 'production',
       webLink:
         'https://portal.azure.com/#@something.onmicrosoft.com/resource/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/j1dev',
       category: ['infrastructure'],
-      endpoints: ['https://j1dev.vault.azure.net/'],
+      vaultUrl: 'https://j1dev.vault.azure.net/',
+    });
+  });
+});
+
+describe('createKeyVaultKeyEntity', () => {
+  const data: KeyProperties = {
+    name: 'j1-key',
+    vaultUrl: 'https://j1dev.vault.azure.net/',
+    enabled: true,
+    expiresOn: new Date('2021-09-20T08:57:43.971Z'),
+  };
+
+  test('properties', () => {
+    const date = new Date('2021-09-20T08:57:43.971Z');
+
+    expect(
+      createKeyVaultKeyEntity({
+        webLinker,
+        data,
+        vaultUrl: 'https://j1dev.vault.azure.net/',
+      }),
+    ).toEqual({
+      _class: ['Key'],
+      _key: 'https://j1dev.vault.azure.net/keys/j1-key',
+      _rawData: [
+        {
+          name: 'default',
+          rawData: data,
+        },
+      ],
+      _type: 'azure_keyvault_key',
+      webLink:
+        'https://portal.azure.com/#@something.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/key/https://j1dev.vault.azure.net/keys/j1-key',
+      name: 'j1-key',
+      enabled: true,
+      expiresOn: parseTimePropertyValue(date),
+      notBefore: undefined,
+      recoveryLevel: undefined,
+      updatedOn: undefined,
+      createdOn: undefined,
+      displayName: 'j1-key',
+      vaultUrl: 'https://j1dev.vault.azure.net/',
+      version: undefined,
+    });
+  });
+});
+
+describe('createKeyVaultSecretEntity', () => {
+  const data: SecretProperties = {
+    id:
+      '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/j1dev/secrets/j1-secret',
+    name: 'j1-secret',
+    vaultUrl: 'https://j1dev.vault.azure.net/',
+    enabled: true,
+    expiresOn: new Date('2021-09-20T08:57:43.971Z'),
+  };
+
+  test('properties', () => {
+    const date = new Date('2021-09-20T08:57:43.971Z');
+
+    expect(
+      createKeyVaultSecretEntity({
+        webLinker,
+        data,
+        vaultUrl: 'https://j1dev.vault.azure.net/',
+      }),
+    ).toEqual({
+      _class: ['Secret'],
+      _key:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/j1dev/secrets/j1-secret',
+      _rawData: [
+        {
+          name: 'default',
+          rawData: data,
+        },
+      ],
+      _type: 'azure_keyvault_secret',
+      webLink:
+        'https://portal.azure.com/#@something.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/Secret/https://j1dev.vault.azure.net/keys/j1-secret',
+      name: 'j1-secret',
+      certificateKeyId: undefined,
+      contentType: undefined,
+      enabled: true,
+      expiresOn: parseTimePropertyValue(date),
+      createdOn: undefined,
+      managed: undefined,
+      notBefore: undefined,
+      recoveryLevel: undefined,
+      vaultUrl: 'https://j1dev.vault.azure.net/',
+      displayName: 'j1-secret',
+      version: undefined,
+      id:
+        '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/j1dev/secrets/j1-secret',
     });
   });
 });

--- a/src/steps/resource-manager/key-vault/converters.ts
+++ b/src/steps/resource-manager/key-vault/converters.ts
@@ -1,7 +1,10 @@
 import { Vault } from '@azure/arm-keyvault/esm/models';
+import { KeyProperties } from '@azure/keyvault-keys';
+import { SecretProperties } from '@azure/keyvault-secrets';
 import {
   createIntegrationEntity,
   Entity,
+  parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker } from '../../../azure';
@@ -9,6 +12,10 @@ import { normalizeLocation, resourceGroupName } from '../../../azure/utils';
 import {
   KEY_VAULT_SERVICE_ENTITY_TYPE,
   KEY_VAULT_SERVICE_ENTITY_CLASS,
+  KEY_VAULT_KEY_ENTITY_CLASS,
+  KEY_VAULT_KEY_ENTITY_TYPE,
+  KEY_VAULT_SECRET_ENTITY_TYPE,
+  KEY_VAULT_SECRET_ENTITY_CLASS,
 } from './constants';
 
 export function createKeyVaultEntity(
@@ -25,10 +32,82 @@ export function createKeyVaultEntity(
         webLink: webLinker.portalResourceUrl(data.id),
         region: normalizeLocation(data.location),
         resourceGroup: resourceGroupName(data.id),
-        endpoints: data.properties.vaultUri && [data.properties.vaultUri],
+        vaultUrl: data.properties.vaultUri,
         category: ['infrastructure'],
+        function: ['key-vault'],
       },
       tagProperties: ['environment'],
+    },
+  });
+}
+
+export function createKeyVaultKeyEntity({
+  webLinker,
+  data,
+  vaultUrl,
+}: {
+  webLinker: AzureWebLinker;
+  data: KeyProperties;
+  vaultUrl: string;
+}): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: `${vaultUrl}keys/${data.name}`,
+        _type: KEY_VAULT_KEY_ENTITY_TYPE,
+        _class: KEY_VAULT_KEY_ENTITY_CLASS,
+        vaultUrl: data.vaultUrl,
+        recoveryLevel: data.recoveryLevel,
+        webLink: webLinker.assetResourceUrl(
+          `/Microsoft_Azure_KeyVault/key/${vaultUrl}keys/${data.name}`,
+        ),
+        name: data.name,
+        version: data.version,
+        enabled: data.enabled,
+        notBefore: parseTimePropertyValue(data.notBefore),
+        createdOn: parseTimePropertyValue(data.createdOn),
+        updatedOn: parseTimePropertyValue(data.updatedOn),
+        // 8.1 Ensure that expiration date is set on all keys (automated)
+        expiresOn: parseTimePropertyValue(data.expiresOn),
+      },
+    },
+  });
+}
+
+export function createKeyVaultSecretEntity({
+  webLinker,
+  data,
+  vaultUrl,
+}: {
+  webLinker: AzureWebLinker;
+  data: SecretProperties;
+  vaultUrl: string;
+}): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: data.id,
+        _type: KEY_VAULT_SECRET_ENTITY_TYPE,
+        _class: KEY_VAULT_SECRET_ENTITY_CLASS,
+        vaultUrl: data.vaultUrl,
+        contentType: data.contentType,
+        certificateKeyId: data.certificateKeyId,
+        managed: data.managed,
+        recoveryLevel: data.recoveryLevel,
+        webLink: webLinker.assetResourceUrl(
+          `/Microsoft_Azure_KeyVault/Secret/${vaultUrl}keys/${data.name}`,
+        ),
+        name: data.name,
+        version: data.version,
+        enabled: data.enabled,
+        notBefore: parseTimePropertyValue(data.notBefore),
+        createdOn: parseTimePropertyValue(data.createdOn),
+        updatedOn: parseTimePropertyValue(data.updatedOn),
+        // 8.2 Ensure that the expiration date is set on all Secrets (Automated)
+        expiresOn: parseTimePropertyValue(data.expiresOn),
+      },
     },
   });
 }

--- a/src/steps/resource-manager/key-vault/index.test.ts
+++ b/src/steps/resource-manager/key-vault/index.test.ts
@@ -1,7 +1,4 @@
-import {
-  MockIntegrationStepExecutionContext,
-  Recording,
-} from '@jupiterone/integration-sdk-testing';
+import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import {
   getMatchRequestsBy,
@@ -19,116 +16,133 @@ import {
 } from '../../active-directory';
 import { buildKeyVaultAccessPolicyRelationships, fetchKeyVaults } from '.';
 import {
+  ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE,
   KeyVaultEntities,
   KEY_VAULT_SERVICE_ENTITY_CLASS,
-  KEY_VAULT_SERVICE_ENTITY_TYPE,
 } from './constants';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
 import { getMockAccountEntity } from '../../../../test/helpers/getMockEntity';
+import { RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS } from '../utils/createResourceGroupResourceRelationship';
 
 let recording: Recording;
-let context: MockIntegrationStepExecutionContext<IntegrationConfig>;
-let instanceConfig: IntegrationConfig;
 
 describe('step = key vaults', () => {
-  beforeAll(async () => {
-    instanceConfig = {
-      clientId: process.env.CLIENT_ID || 'clientId',
-      clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
-      directoryId: '4a17becb-fb42-4633-b5c8-5ab66f28d195',
-      subscriptionId: '87f62f44-9dad-4284-a08f-f2fb3d8b528a',
-      developerId: 'keionned',
-    };
-
-    context = createMockAzureStepExecutionContext({
-      instanceConfig,
-      entities: [
-        {
-          _key: `/subscriptions/${instanceConfig.subscriptionId}`,
-          _class: ['Account'],
-          _type: 'azure_subscription',
-          id: `/subscriptions/${instanceConfig.subscriptionId}`,
-        },
-        {
-          _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
-          _type: 'azure_resource_group',
-          _class: ['Group'],
-          name: 'j1dev',
-          location: 'eastus',
-          id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
-        },
-      ],
-      setData: {
-        [ACCOUNT_ENTITY_TYPE]: {
-          defaultDomain: 'www.fake-domain.com',
-          _type: ACCOUNT_ENTITY_TYPE,
-          _key: 'azure_account_id',
-          id: 'azure_account_id',
-        },
-      },
-    });
-
-    recording = setupAzureRecording({
-      directory: __dirname,
-      name: 'resource-manager-step-key-vaults',
-    });
-
-    await fetchKeyVaults(context);
-  });
-
   afterAll(async () => {
     if (recording) {
       await recording.stop();
     }
   });
 
-  it('should collect an Azure Key Vault entity', () => {
-    const { collectedEntities } = context.jobState;
-
-    expect(collectedEntities).toContainEqual(
-      expect.objectContaining({
-        _class: KEY_VAULT_SERVICE_ENTITY_CLASS,
-        _type: KEY_VAULT_SERVICE_ENTITY_TYPE,
-        category: ['infrastructure'],
-        displayName: `${instanceConfig.developerId}1-j1dev`,
-        region: 'eastus',
-        resourceGroup: 'j1dev',
-        endpoints: [
-          `https://${instanceConfig.developerId}1-j1dev.vault.azure.net/`,
-        ],
-        _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-        id: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-        webLink: `https://portal.azure.com/#@www.fake-domain.com/resource/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-      }),
-    );
-  });
-
-  it('should collect an Azure Account has Azure Key Vault relationship', () => {
-    const { collectedRelationships } = context.jobState;
-
-    expect(collectedRelationships).toContainEqual({
-      _class: 'HAS',
-      _fromEntityKey: 'azure_account_id',
-      _key: `azure_account_id|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-      _type: 'azure_account_has_keyvault_service',
-      displayName: 'HAS',
+  it('should collect an Azure Key Vault entity', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'resource-manager-step-key-vaults',
     });
-  });
 
-  it('should collect an Azure Resource Group has Azure Key Vault relationship', () => {
-    const { collectedRelationships } = context.jobState;
+    const instanceConfig = {
+      ...configFromEnv,
+      directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+      subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+    };
 
-    expect(collectedRelationships).toContainEqual({
-      _class: 'HAS',
-      _fromEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev`,
-      _key: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev|has|/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-      _toEntityKey: `/subscriptions/${instanceConfig.subscriptionId}/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/${instanceConfig.developerId}1-j1dev`,
-      _type: 'azure_resource_group_has_keyvault_service',
-      displayName: 'HAS',
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: instanceConfig,
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: getMockAccountEntity(instanceConfig),
+      },
+    });
+
+    await fetchKeyVaults(context);
+
+    expect(context.jobState.collectedEntities.length).toBeGreaterThan(0);
+    expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
+      _class: KEY_VAULT_SERVICE_ENTITY_CLASS,
+    });
+
+    expect(
+      context.jobState.collectedRelationships.filter(
+        (e) => e._type === ACCOUNT_KEY_VAULT_RELATIONSHIP_TYPE,
+      ),
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _class: { const: 'HAS' },
+          _type: { const: 'azure_account_has_keyvault_service' },
+        },
+      },
+    });
+
+    expect(
+      context.jobState.collectedRelationships.filter(
+        (e) => e._type === RESOURCE_GROUP_RESOURCE_RELATIONSHIP_CLASS,
+      ),
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _class: { const: 'HAS' },
+          _type: { const: 'azure_resource_group_has_keyvault_service' },
+        },
+      },
     });
   });
 });
+
+/*
+describe('step = key vaults keys', () => {
+  afterAll(async () => {
+    if (recording) {
+      await recording.stop();
+    }
+  });
+
+  it('should collect an Azure Key Vault Key entity and relationships', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'resource-manager-step-key-vaults-keys',
+    });
+
+    const instanceConfig = {
+      ...configFromEnv,
+      directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+      subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+    }
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: instanceConfig,
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: getMockAccountEntity(instanceConfig),
+      },
+    });
+
+    await fetchKeyVaults(context);
+    await fetchKeyVaultKeys(context);
+
+    const keyVaultEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === KEY_VAULT_SERVICE_ENTITY_TYPE,
+    );
+    expect(keyVaultEntities.length).toBeGreaterThan(0);
+
+    const keyVaultKeyEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === KEY_VAULT_KEY_ENTITY_TYPE,
+    );
+    expect(keyVaultKeyEntities.length).toBeGreaterThan(0);
+
+    expect(
+      context.jobState.collectedRelationships.filter(
+        (e) =>
+          e._type === KeyVaultRelationships.KEY_VAULT_CONTAINS_KEY._type,
+      ),
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _class: { const: 'CONTAINS' },
+          _type: { const: 'azure_keyvault_service_contains_key' },
+        },
+      },
+    });
+  });
+});
+*/
 
 describe('rm-keyvault-principal-relationships', () => {
   afterEach(async () => {
@@ -211,3 +225,60 @@ describe('rm-keyvault-principal-relationships', () => {
     ]);
   }, 10_000);
 });
+
+/*
+describe('step = key vaults secrets', () => {
+  afterAll(async () => {
+    if (recording) {
+      await recording.stop();
+    }
+  });
+
+  it('should collect an Azure Key Vault Secret entity and relationships', async () => {
+    recording = setupAzureRecording({
+      directory: __dirname,
+      name: 'resource-manager-step-key-vaults-secrets',
+    });
+
+    const instanceConfig = {
+      ...configFromEnv,
+      directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+      subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+    }
+
+    const context = createMockAzureStepExecutionContext({
+      instanceConfig: instanceConfig,
+      setData: {
+        [ACCOUNT_ENTITY_TYPE]: getMockAccountEntity(instanceConfig),
+      },
+    });
+
+    await fetchKeyVaults(context);
+    await fetchKeyVaultSecrets(context);
+
+    const keyVaultEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === KEY_VAULT_SERVICE_ENTITY_TYPE,
+    );
+    expect(keyVaultEntities.length).toBeGreaterThan(0);
+
+    const keyVaultSecretEntities = context.jobState.collectedEntities.filter(
+      (e) => e._type === KEY_VAULT_SECRET_ENTITY_TYPE,
+    );
+    expect(keyVaultSecretEntities.length).toBeGreaterThan(0);
+
+    expect(
+      context.jobState.collectedRelationships.filter(
+        (e) =>
+          e._type === KeyVaultRelationships.KEY_VAULT_CONTAINS_SECRET._type,
+      ),
+    ).toMatchDirectRelationshipSchema({
+      schema: {
+        properties: {
+          _class: { const: 'CONTAINS' },
+          _type: { const: 'azure_keyvault_service_contains_secret' },
+        },
+      },
+    });
+  });
+});
+*/

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -22,8 +22,14 @@ import {
   KeyVaultEntities,
   KeyVaultRelationships,
   KeyVaultStepIds,
+  STEP_RM_KEYVAULT_KEYS,
+  STEP_RM_KEYVAULT_SECRETS,
 } from './constants';
-import { createKeyVaultEntity } from './converters';
+import {
+  createKeyVaultEntity,
+  createKeyVaultKeyEntity,
+  createKeyVaultSecretEntity,
+} from './converters';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
 import createResourceGroupResourceRelationship, {
   createResourceGroupResourceRelationshipMetadata,
@@ -69,6 +75,42 @@ export async function fetchKeyVaults(
   });
 }
 
+export async function fetchKeyVaultKeys(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await getAccountEntity(jobState);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new KeyVaultClient(instance.config, logger);
+
+  await jobState.iterateEntities(
+    { _type: KEY_VAULT_SERVICE_ENTITY_TYPE },
+    async (vaultEntity) => {
+      if (vaultEntity.vaultUrl) {
+        await client.iterateKeys(
+          vaultEntity.vaultUrl as string,
+          async (key) => {
+            const keyEntity = createKeyVaultKeyEntity({
+              webLinker,
+              data: key,
+              vaultUrl: vaultEntity.vaultUrl as string,
+            });
+            await jobState.addEntity(keyEntity);
+
+            await jobState.addRelationship(
+              createDirectRelationship({
+                _class: RelationshipClass.CONTAINS,
+                from: vaultEntity,
+                to: keyEntity,
+              }),
+            );
+          },
+        );
+      }
+    },
+  );
+}
+
 export async function buildKeyVaultAccessPolicyRelationships(
   executionContext: IntegrationStepContext,
 ): Promise<void> {
@@ -99,6 +141,42 @@ export async function buildKeyVaultAccessPolicyRelationships(
               'permissions.certificates': permissions.certificates?.join(','),
             },
           }),
+        );
+      }
+    },
+  );
+}
+
+export async function fetchKeyVaultSecrets(
+  executionContext: IntegrationStepContext,
+): Promise<void> {
+  const { instance, logger, jobState } = executionContext;
+  const accountEntity = await getAccountEntity(jobState);
+  const webLinker = createAzureWebLinker(accountEntity.defaultDomain as string);
+  const client = new KeyVaultClient(instance.config, logger);
+
+  await jobState.iterateEntities(
+    { _type: KEY_VAULT_SERVICE_ENTITY_TYPE },
+    async (vaultEntity) => {
+      if (vaultEntity.vaultUrl) {
+        await client.iterateSecrets(
+          vaultEntity.vaultUrl as string,
+          async (secret) => {
+            const secretEntity = createKeyVaultSecretEntity({
+              webLinker,
+              data: secret,
+              vaultUrl: vaultEntity.vaultUrl as string,
+            });
+            await jobState.addEntity(secretEntity);
+
+            await jobState.addRelationship(
+              createDirectRelationship({
+                _class: RelationshipClass.CONTAINS,
+                from: vaultEntity,
+                to: secretEntity,
+              }),
+            );
+          },
         );
       }
     },
@@ -139,5 +217,21 @@ export const keyvaultSteps: Step<
     relationships: [KeyVaultRelationships.KEY_VAULT_ALLOWS_PRINCIPAL],
     dependsOn: [STEP_RM_KEYVAULT_VAULTS],
     executionHandler: buildKeyVaultAccessPolicyRelationships,
+  },
+  {
+    id: STEP_RM_KEYVAULT_KEYS,
+    name: 'Key Vault Keys',
+    entities: [KeyVaultEntities.KEY_VAULT_KEY],
+    relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_KEY],
+    dependsOn: [STEP_RM_KEYVAULT_VAULTS],
+    executionHandler: fetchKeyVaultKeys,
+  },
+  {
+    id: STEP_RM_KEYVAULT_SECRETS,
+    name: 'Key Vault Secrets',
+    entities: [KeyVaultEntities.KEY_VAULT_SECRET],
+    relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_SECRET],
+    dependsOn: [STEP_RM_KEYVAULT_VAULTS],
+    executionHandler: fetchKeyVaultSecrets,
   },
 ];

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -40,7 +40,7 @@ it('auth error', async () => {
   };
 
   await expect(exec).rejects.toThrow(
-    "AADSTS90002: Tenant 'invalid' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator.",
+    "Error: AADSTS90002: Tenant 'invalid' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.",
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,6 +293,14 @@
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.0.0"
 
+"@azure/core-auth@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
+  integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
 "@azure/core-http@^1.0.0", "@azure/core-http@^1.1.0", "@azure/core-http@^1.1.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-1.1.3.tgz#8cdff20e3ce65dbe726bfdd46889c30fc2e07c6d"
@@ -335,6 +343,27 @@
     uuid "^8.3.0"
     xml2js "^0.4.19"
 
+"@azure/core-http@^2.0.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-2.2.0.tgz#a8edfeb31bbd65172e2455fde3e607fd9300c064"
+  integrity sha512-DCXm8OTNhPxErNvwuNgd9r/W+LjMrHHNc9/q4QgIOpCaoBvpJd1O5Nl2gbAhrwfiwmEBNWHMeGoe5+g3Lx2H/A==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-asynciterator-polyfill" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    "@types/node-fetch" "^2.5.0"
+    "@types/tunnel" "^0.0.3"
+    form-data "^4.0.0"
+    node-fetch "^2.6.0"
+    process "^0.11.10"
+    tough-cookie "^4.0.0"
+    tslib "^2.2.0"
+    tunnel "^0.0.6"
+    uuid "^8.3.0"
+    xml2js "^0.4.19"
+
 "@azure/core-lro@^1.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-1.0.2.tgz#b7b51ff7b84910b7eb152a706b0531d020864f31"
@@ -354,6 +383,16 @@
     "@azure/core-http" "^1.2.0"
     events "^3.0.0"
     tslib "^2.0.0"
+
+"@azure/core-lro@^2.0.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.2.0.tgz#82252566b811c255989f90e639f00f177f02ec55"
+  integrity sha512-TJo95eNT1dwYOPCb0m1C2zyxVlHuRRkKGeg9TKu8XMF2qh4v6c1weD63r9RVIrLdHdnSqS0n6PTXBpWoB8NqMw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.2.0"
 
 "@azure/core-paging@^1.0.0":
   version "1.1.1"
@@ -377,6 +416,14 @@
     "@opencensus/web-types" "0.0.7"
     "@opentelemetry/api" "^0.10.2"
     tslib "^2.0.0"
+
+"@azure/core-tracing@1.0.0-preview.13":
+  version "1.0.0-preview.13"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz#55883d40ae2042f6f1e12b17dd0c0d34c536d644"
+  integrity sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==
+  dependencies:
+    "@opentelemetry/api" "^1.0.1"
+    tslib "^2.2.0"
 
 "@azure/core-tracing@1.0.0-preview.7":
   version "1.0.0-preview.7"
@@ -433,6 +480,19 @@
     "@azure/logger" "^1.0.0"
     "@opentelemetry/api" "^0.6.1"
     tslib "^1.9.3"
+
+"@azure/keyvault-secrets@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@azure/keyvault-secrets/-/keyvault-secrets-4.3.0.tgz#e0ea4730a2ad8874b80909ce0e9a54b837fed4ab"
+  integrity sha512-bhdAr2Yjx+XpgfkClOufpTxcnKqDIwyOSKrbI9mJ2q5wQNb7Z1WPnPnIhjdsw1on/NRXzMaarYFNkf/MdS73FA==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-http" "^2.0.0"
+    "@azure/core-lro" "^2.0.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.2.0"
 
 "@azure/logger@^1.0.0":
   version "1.0.0"
@@ -1180,6 +1240,11 @@
   dependencies:
     "@opentelemetry/context-base" "^0.6.1"
 
+"@opentelemetry/api@^1.0.1":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.3.tgz#13a12ae9e05c2a782f7b5e84c3cbfda4225eaf80"
+  integrity sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==
+
 "@opentelemetry/context-base@^0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.10.2.tgz#55bea904b2b91aa8a8675df9eaba5961bddb1def"
@@ -1475,6 +1540,13 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.1.tgz#0d72774768b73df26f25df9184273a42da72b19c"
   integrity sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/tunnel@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.3.tgz#f109e730b072b3136347561fc558c9358bb8c6e9"
+  integrity sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
   dependencies:
     "@types/node" "*"
 
@@ -3143,6 +3215,15 @@ form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -6079,6 +6160,11 @@ tslib@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
This PR adds the following (new) benchmarks:

- 8.1 Ensure that the expiration date is set on all keys (Automated)
- 8.2 Ensure that the expiration date is set on all Secrets (Automated)

### Some notes:
1) The tests for 8.1 (-t="step = key vaults keys") and 8.2 (-t="step = key vaults secrets") are included and setup/working properly, however we had some issue while trying to get recording.har to be saved. What's happening is that `iterateKeys` and `iterateSecrets` are returning `symbol.asyncIterator` and us doing `for await (const x of something) {}` apparently prevents Polly.js from storing/saving the recording file. If we comment out that loop part, the .har files get saved successfully. Did anyone experience something similar?
2) Iterating keys requires app registration to have a correct policy (e.g. "can LIST the particular KeyVault keys") and likewise for the secrets. We've applied those changes to J1 current Azure environment and the warn logging statement has been put in place to inform if that's the case (our idea was that even then nothing fails, but instead we notify about that and step otherwise completed). Relevant code can be found [here](https://github.com/JupiterOne/graph-azure/compare/main...Creativice-Oy:feat/azure-cis-8#diff-44a7dbc335fb472e9486bc541b63038f66272b7091bf7d35c9ffcdd5dc51ff66R71). Example of warn statement:

> 11:16:12.532Z  WARN Local: The user, group or application 'appid=d6c4ffcd-4....8b2c3e;oid=c4248787-....89f5;iss=https://sts.windows.net/19a...4efc66ad/' does not have keys list permission on key vault 'example-key-vault-1;location=eastus'. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125287 (stepId=rm-keyvault-keys)

3) Keys and secrets have different types of webLink structures, therefore we added `assetResourceUrl` variant and are using it for this.

###  CHANGELOG.md
(to be added when this gets merged)
```
### Added

- Added support for ingesting the following **new** resources:

  | Service          | Resource / Entity       |
  | ---------------- | ----------------------- |
  | Key Vault Key    | `azure_keyvault_key`    |
  | Key Vault Secret | `azure_keyvault_secret` |
  
- With the following properties:

  | Entity                  | Properties         |
  | ----------------------- | ------------------ |
  | `azure_keyvault_key`    | `name`             |
  | `azure_keyvault_key`    | `recoveryLevel`    |
  | `azure_keyvault_key`    | `vaultUrl`         |
  | `azure_keyvault_key`    | `version`          |
  | `azure_keyvault_key`    | `enabled`          |
  | `azure_keyvault_key`    | `notBefore`        |
  | `azure_keyvault_key`    | `createdOn`        |
  | `azure_keyvault_key`    | `updatedOn`        |
  | `azure_keyvault_key`    | `expiresOn`        |
  | `azure_keyvault_secret` | `name`             |
  | `azure_keyvault_secret` | `recoveryLevel`    |
  | `azure_keyvault_secret` | `vaultUrl`         |
  | `azure_keyvault_secret` | `version`          |
  | `azure_keyvault_secret` | `contentType`      |
  | `azure_keyvault_secret` | `certificateKeyId` |
  | `azure_keyvault_secret` | `managed`          |
  | `azure_keyvault_secret` | `enabled`          |
  | `azure_keyvault_secret` | `notBefore`        |
  | `azure_keyvault_secret` | `createdOn`        |
  | `azure_keyvault_secret` | `updatedOn`        |
  | `azure_keyvault_secret` | `expiresOn`        |
```

### J1QL Queries
- 8.1 Ensure that the expiration date is set on all keys (Automated)
```
# GOOD CASE
find azure_keyvault_key with enabled = true && expiresOn != undefined
   
# BAD CASE
find azure_keyvault_key with enabled = true && expiresOn = undefined
```
- 8.2 Ensure that the expiration date is set on all Secrets (Automated)
```
# GOOD CASE
find azure_keyvault_secret with enabled = true && expiresOn != undefined

# BAD CASE
find azure_keyvault_secret with enabled = true && expiresOn = undefined
```

Pinging @ndowmon @aiwilliams