### PR TITLE
INT-1766 - Add 3.2 CIS benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "@microsoft/microsoft-graph-types": "^1.10.0",
     "cross-fetch": "^3.0.4",
+    "date-fns": "^2.24.0",
     "lodash.map": "^4.6.0",
     "lodash.snakecase": "^4.1.1"
   },

--- a/src/steps/resource-manager/compute/index.test.ts
+++ b/src/steps/resource-manager/compute/index.test.ts
@@ -466,6 +466,7 @@ describe('rm-compute-virtual-machine-disk-relationships', () => {
           webLinker,
           storageAccount,
           { blob: {} },
+          false,
         );
 
         const context = createMockAzureStepExecutionContext({
@@ -550,6 +551,7 @@ describe('rm-compute-virtual-machine-disk-relationships', () => {
           webLinker,
           storageAccount,
           { blob: {} },
+          false,
         );
 
         const context = createMockAzureStepExecutionContext({
@@ -628,6 +630,7 @@ describe('rm-compute-virtual-machine-disk-relationships', () => {
           webLinker,
           storageAccount,
           { blob: {} },
+          false,
         );
 
         const context = createMockAzureStepExecutionContext({

--- a/src/steps/resource-manager/monitor/client.ts
+++ b/src/steps/resource-manager/monitor/client.ts
@@ -3,10 +3,12 @@ import {
   iterateAllResources,
 } from '../../../azure/resource-manager/client';
 import { MonitorManagementClient } from '@azure/arm-monitor';
+import { formatISO, subDays } from 'date-fns';
 import {
   ActivityLogAlertResource,
   DiagnosticSettingsResource,
   LogProfileResource,
+  EventData,
 } from '@azure/arm-monitor/esm/models';
 
 export class MonitorClient extends Client {
@@ -91,6 +93,32 @@ export class MonitorClient extends Client {
           ),
       },
       resourceDescription: 'monitor.activityLogAlerts',
+      callback,
+    });
+  }
+
+  public async iterateActivityLogs(
+    resourceId: string,
+    callback: (e: EventData) => void | Promise<void>,
+    dayRange?: number,
+  ) {
+    const serviceClient = await this.getAuthenticatedServiceClient(
+      MonitorManagementClient,
+    );
+
+    const startDate = formatISO(subDays(new Date(), dayRange || 90));
+    const endDate = formatISO(new Date());
+
+    return iterateAllResources({
+      logger: this.logger,
+      serviceClient,
+      resourceEndpoint: {
+        list: async () =>
+          serviceClient.activityLogs.list(
+            `eventTimestamp ge '${startDate}' and eventTimestamp le '${endDate}' and resourceUri eq '${resourceId}'`,
+          ),
+      },
+      resourceDescription: 'monitor.activityLogs',
       callback,
     });
   }

--- a/src/steps/resource-manager/network/__recordings__/rm-network-flow-logs_1050087510/recording.har
+++ b/src/steps/resource-manager/network/__recordings__/rm-network-flow-logs_1050087510/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "44d6275b-c48b-423a-8447-73a9bcc817f3"
+              "value": "4e567c29-3618-476f-8ed7-a92140e6e020"
             },
             {
               "name": "return-client-request-id",
@@ -41,7 +41,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "linux"
+              "value": "darwin"
             },
             {
               "name": "x-client-cpu",
@@ -56,7 +56,7 @@
               "value": 172
             }
           ],
-          "headersSize": 413,
+          "headersSize": 414,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1616117241\",\"not_before\":\"1616113341\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718693\",\"not_before\":\"1632714793\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-18T00:27:21.000Z",
+              "expires": "2021-10-27T03:58:14.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "44d6275b-c48b-423a-8447-73a9bcc817f3"
+              "value": "4e567c29-3618-476f-8ed7-a92140e6e020"
             },
             {
               "name": "x-ms-request-id",
-              "value": "742eaa71-eb6d-41ee-8e38-b10155b90400"
+              "value": "eb638669-9222-4b42-9e46-6c02b0ae2100"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:21 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:13 GMT"
             },
             {
               "name": "connection",
@@ -177,14 +177,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 781,
+          "headersSize": 786,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:20.140Z",
-        "time": 248,
+        "startedDateTime": "2021-09-27T03:58:13.561Z",
+        "time": 589,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,11 +192,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 248
+          "wait": 589
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 0,
         "cache": {},
         "request": {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "977c0ac3-e1b3-4324-a6dc-65dae6975811"
+              "value": "c7c9af83-039e-4d73-b097-9816cce206e5"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1686,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "a13dbc6c-01a1-4411-aa83-ae0ed602d6c2"
+              "value": "0a5b1537-a322-419e-8da7-027fc7efb80e"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "a13dbc6c-01a1-4411-aa83-ae0ed602d6c2"
+              "value": "0a5b1537-a322-419e-8da7-027fc7efb80e"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002721Z:a13dbc6c-01a1-4411-aa83-ae0ed602d6c2"
+              "value": "EASTASIA:20210927T035815Z:0a5b1537-a322-419e-8da7-027fc7efb80e"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:20 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:15 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 588,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:20.405Z",
-        "time": 304,
+        "startedDateTime": "2021-09-27T03:58:14.207Z",
+        "time": 826,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,11 +345,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 304
+          "wait": 826
         }
       },
       {
-        "_id": "d8b24d6495b59dc19d46e5f79a412772",
+        "_id": "aafb18b26d49cfd5d93d49a01bbaabc9",
         "_order": 0,
         "cache": {},
         "request": {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "709d73bd-c31b-42ce-9764-94c8e4dbb7e5"
+              "value": "1999af9d-0d8c-4969-a943-4bce1e55f402"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1848,
+          "headersSize": 1839,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -415,14 +415,1504 @@
               "value": "2019-12-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers?api-version=2019-12-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers?api-version=2019-12-01"
         },
         "response": {
-          "bodySize": 443,
+          "bodySize": 811,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 443,
-            "text": "{\"value\":[{\"name\":\"NetworkWatcher_westus\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_westus\",\"etag\":\"W/\\\"6f418993-f615-49c4-b3c1-ffd84e69184a\\\"\",\"type\":\"Microsoft.Network/networkWatchers\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\",\"runningOperationIds\":[]}},{\"name\":\"NetworkWatcher_eastus\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus\",\"etag\":\"W/\\\"5fe8be0c-0d9a-450b-913f-2e1896a9ab43\\\"\",\"type\":\"Microsoft.Network/networkWatchers\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\",\"runningOperationIds\":[]}}]}"
+            "size": 811,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"NetworkWatcher_centralus\",\r\n      \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_centralus\",\r\n      \"etag\": \"W/\\\"e15f95ac-9572-448a-b157-5097c6051440\\\"\",\r\n      \"type\": \"Microsoft.Network/networkWatchers\",\r\n      \"location\": \"centralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"runningOperationIds\": []\r\n      }\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "48529edb-9b7e-4c6d-abef-e3d15acc2cca"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "b5a6b1c8-b6fa-40af-b274-97992e559e59"
+            },
+            {
+              "name": "x-ms-arm-service-request-id",
+              "value": "31f0152d-b82c-4b22-a421-df6bb75143e8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035816Z:b5a6b1c8-b6fa-40af-b274-97992e559e59"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:16 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 694,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:15.053Z",
+        "time": 1354,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1354
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "742e5f02-b794-4dfd-a025-48d535e03f54"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718697\",\"not_before\":\"1632714797\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:17.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "742e5f02-b794-4dfd-a025-48d535e03f54"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cfdc11cf-2a47-4e83-82e7-d61223a52700"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:16.425Z",
+        "time": 1373,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1373
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "48ef3a98-fa90-40e8-8738-459b1eb34c8c"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11998"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3560351c-a605-4fac-bd4f-2ae4c582c60a"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "3560351c-a605-4fac-bd4f-2ae4c582c60a"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035818Z:3560351c-a605-4fac-bd4f-2ae4c582c60a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:18 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 583,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:17.806Z",
+        "time": 516,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 516
+        }
+      },
+      {
+        "_id": "225e50f30d4a040b89be8b0ed2c6c693",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "7753b76f-e8c2-4685-b13e-203431126732"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1813,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-12-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Network/networkSecurityGroups?api-version=2019-12-01"
+        },
+        "response": {
+          "bodySize": 2193,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2193,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"NSG\",\r\n      \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG\",\r\n      \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"centralus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"0e112a13-93cf-4ab0-9fce-3c502c55f89d\",\r\n        \"securityRules\": [],\r\n        \"defaultSecurityRules\": [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/AllowVnetInBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/DenyAllInBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/AllowVnetOutBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/AllowInternetOutBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/defaultSecurityRules/DenyAllOutBound\",\r\n            \"etag\": \"W/\\\"d80a06f1-cbab-40a9-963a-8ac584c44ff0\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"flowLogs\": [\r\n          {\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_centralus/flowLogs/NSG-DefaultResourceGroup-CUS-flowlog\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "91c84306-d1a3-49c6-ac8f-0185b7965fbb"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f3442a66-3980-4be7-b6dd-39e3f296a6b1"
+            },
+            {
+              "name": "x-ms-arm-service-request-id",
+              "value": "265caf4a-f3e0-4869-a4d5-f05915cfe47f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035818Z:f3442a66-3980-4be7-b6dd-39e3f296a6b1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:18 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 694,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:18.332Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "fd45bd2a-f620-467d-8672-789ad3ab0e7e"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718699\",\"not_before\":\"1632714799\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:19.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "fd45bd2a-f620-467d-8672-789ad3ab0e7e"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "15e761f4-4265-46e6-ac53-bad5dde45b00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:18 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:18.969Z",
+        "time": 820,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 820
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e109a9fd-29f9-4c66-9384-409d7dcc0b4b"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "f060de8b-c736-4b7e-88d7-462d1b1a7a33"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f060de8b-c736-4b7e-88d7-462d1b1a7a33"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035820Z:f060de8b-c736-4b7e-88d7-462d1b1a7a33"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:19 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 583,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:19.798Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      },
+      {
+        "_id": "361e4bb6319d8ec0d4a0357e2a955adf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "1ff4c2fd-a044-4f43-b94d-d6399d326500"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2017-05-01-preview"
+            }
+          ],
+          "url": "https://management.azure.com//subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 273,
+            "text": "{\"value\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fb10327e-9aff-45db-8aee-5365807d26c5"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "297b66a1-0186-4126-9a9d-e72a8f12ea0e"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035822Z:297b66a1-0186-4126-9a9d-e72a8f12ea0e"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:21 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 624,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:20.085Z",
+        "time": 2049,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2049
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "2afa657a-5002-4135-ad6a-1a6a01dcb73c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718703\",\"not_before\":\"1632714803\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:23.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "2afa657a-5002-4135-ad6a-1a6a01dcb73c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "b8fb684d-b93b-4568-88d0-102a1ed72500"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:23 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:22.148Z",
+        "time": 1137,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1137
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "96855fcf-31a7-4dc0-8f7e-678683eeb159"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11997"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "89d0854d-9cc4-4803-b639-2aa50e8a5e47"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "89d0854d-9cc4-4803-b639-2aa50e8a5e47"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035823Z:89d0854d-9cc4-4803-b639-2aa50e8a5e47"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:23 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 583,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:23.293Z",
+        "time": 330,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 330
+        }
+      },
+      {
+        "_id": "65b39ca75483f0ca33c5ac4a87ec1aa8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d9267a56-90d0-410b-bce3-51fe3cee9f4e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1807,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2019-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+        },
+        "response": {
+          "bodySize": 1304,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1304,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"name\":\"regenerateaccesskeytest\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-20T15:02:41.5642636Z\",\"primaryEndpoints\":{\"web\":\"https://regenerateaccesskeytest.z13.web.core.windows.net/\",\"blob\":\"https://regenerateaccesskeytest.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"name\":\"sqlvab7pt3ww5qhmdw\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-23T11:32:50.8155392Z\",\"primaryEndpoints\":{\"dfs\":\"https://sqlvab7pt3ww5qhmdw.dfs.core.windows.net/\",\"web\":\"https://sqlvab7pt3ww5qhmdw.z13.web.core.windows.net/\",\"blob\":\"https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/\",\"queue\":\"https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/\",\"table\":\"https://sqlvab7pt3ww5qhmdw.table.core.windows.net/\",\"file\":\"https://sqlvab7pt3ww5qhmdw.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"name\":\"stefanexamplestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-07T13:14:18.4460771Z\",\"primaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage.table.core.windows.net/\",\"file\":\"https://stefanexamplestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage-secondary.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage-secondary.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage-secondary.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage-secondary.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"name\":\"storageaccountstefaafb8\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"centralus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-16T14:50:27.0370951Z\",\"primaryEndpoints\":{\"blob\":\"https://storageaccountstefaafb8.blob.core.windows.net/\",\"queue\":\"https://storageaccountstefaafb8.queue.core.windows.net/\",\"table\":\"https://storageaccountstefaafb8.table.core.windows.net/\",\"file\":\"https://storageaccountstefaafb8.file.core.windows.net/\"},\"primaryLocation\":\"centralus\",\"statusOfPrimary\":\"available\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -448,23 +1938,23 @@
             },
             {
               "name": "x-ms-original-request-ids",
-              "value": "ee51728a-fea7-4224-b62c-2e68a696cec5, a6e6c34f-28d9-4a88-9715-f5eac2751e9b"
+              "value": "287f01e6-cee2-4bd6-bfd6-1dfe74be8eec, c8f28f5e-36e5-4703-95e4-467c3ff72816"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "bf2227a1-d903-426e-82de-0527832d3894"
+              "value": "d2e81e05-fe61-44f5-8bfa-bc424dcff555"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "bf2227a1-d903-426e-82de-0527832d3894"
+              "value": "d2e81e05-fe61-44f5-8bfa-bc424dcff555"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002722Z:bf2227a1-d903-426e-82de-0527832d3894"
+              "value": "EASTASIA:20210927T035824Z:d2e81e05-fe61-44f5-8bfa-bc424dcff555"
             },
             {
               "name": "strict-transport-security",
@@ -476,7 +1966,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:21 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:23 GMT"
             },
             {
               "name": "connection",
@@ -484,17 +1974,17 @@
             },
             {
               "name": "content-length",
-              "value": "443"
+              "value": "1304"
             }
           ],
-          "headersSize": 697,
+          "headersSize": 693,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:20.722Z",
-        "time": 696,
+        "startedDateTime": "2021-09-27T03:58:23.635Z",
+        "time": 646,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -502,12 +1992,12 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 696
+          "wait": 646
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 1,
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 172,
@@ -523,7 +2013,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "d267174d-4f88-4034-9022-18255279e5a7"
+              "value": "5be08b50-beae-4178-87a8-3ea12a5da19f"
             },
             {
               "name": "return-client-request-id",
@@ -539,7 +2029,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "linux"
+              "value": "darwin"
             },
             {
               "name": "x-client-cpu",
@@ -554,7 +2044,7 @@
               "value": 172
             }
           ],
-          "headersSize": 413,
+          "headersSize": 414,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -568,516 +2058,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1616117242\",\"not_before\":\"1616113342\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718705\",\"not_before\":\"1632714805\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-18T00:27:22.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "d267174d-4f88-4034-9022-18255279e5a7"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "6684fcbc-c22d-4949-bfba-f7309af40400"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:22 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:21.423Z",
-        "time": 221,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 221
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "6a321058-642d-42dc-acd1-866a02598beb"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1686,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 358,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "179cd96c-34ba-4c64-b830-a09039bd9b41"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "179cd96c-34ba-4c64-b830-a09039bd9b41"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002722Z:179cd96c-34ba-4c64-b830-a09039bd9b41"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:22 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "358"
-            }
-          ],
-          "headersSize": 588,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:21.648Z",
-        "time": 285,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 285
-        }
-      },
-      {
-        "_id": "7150c0743cc36637f4d34bd98872b108",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "30609ce3-7cae-4f94-93dd-19da5f5e1955"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1822,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-12-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Network/networkSecurityGroups?api-version=2019-12-01"
-        },
-        "response": {
-          "bodySize": 2599,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 2599,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\",\r\n      \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {\r\n        \"environment\": \"j1dev\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"e68eafb0-f091-4701-82ff-0978bc014a8d\",\r\n        \"securityRules\": [\r\n          {\r\n            \"name\": \"SSH\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/SSH\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"priv_one\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/securityRules/priv_one\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\": \"10.0.3.0/24\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 1002,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\": [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetInBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllInBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Inbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowVnetOutBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/AllowInternetOutBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/defaultSecurityRules/DenyAllOutBound\",\r\n            \"etag\": \"W/\\\"f40dd9d4-471b-454c-b4f3-1c399466e695\\\"\",\r\n            \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Outbound\",\r\n              \"sourcePortRanges\": [],\r\n              \"destinationPortRanges\": [],\r\n              \"sourceAddressPrefixes\": [],\r\n              \"destinationAddressPrefixes\": []\r\n            }\r\n          }\r\n        ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev\"\r\n          }\r\n        ],\r\n        \"subnets\": [\r\n          {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n          }\r\n        ],\r\n        \"flowLogs\": [\r\n          {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus/flowLogs/j1dev-j1dev-flowlog\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "4f4319fb-613e-4a00-9399-fea610050e61"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "d802a951-6160-4891-a75d-94b8393451fe"
-            },
-            {
-              "name": "x-ms-arm-service-request-id",
-              "value": "9ed0448f-ddb0-43a9-a673-50d39571f76f"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002723Z:d802a951-6160-4891-a75d-94b8393451fe"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:23 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 699,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:21.948Z",
-        "time": 494,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 494
-        }
-      },
-      {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "e32b61f4-80da-4818-9a10-e69fa57fbe6b"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "linux"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 413,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1616117243\",\"not_before\":\"1616113343\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-18T00:27:23.000Z",
+              "expires": "2021-10-27T03:58:25.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1131,15 +2123,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "e32b61f4-80da-4818-9a10-e69fa57fbe6b"
+              "value": "5be08b50-beae-4178-87a8-3ea12a5da19f"
             },
             {
               "name": "x-ms-request-id",
-              "value": "2ac12027-311a-4e8d-9c6b-2735850b0500"
+              "value": "83571b6a-3b90-4dfe-9428-7fbc9ce42100"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -1162,7 +2154,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:23 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:24 GMT"
             },
             {
               "name": "connection",
@@ -1173,14 +2165,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 781,
+          "headersSize": 786,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:22.478Z",
-        "time": 212,
+        "startedDateTime": "2021-09-27T03:58:24.292Z",
+        "time": 1116,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1188,12 +2180,12 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 212
+          "wait": 1116
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 2,
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 4,
         "cache": {},
         "request": {
           "bodySize": 0,
@@ -1207,7 +2199,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "b62474f1-f3c2-4fd3-bd61-86349950283f"
+              "value": "e97611c3-721a-4bfa-8b0b-f5e187e52ae0"
             },
             {
               "_fromType": "array",
@@ -1222,7 +2214,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1249,7 +2241,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1686,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1261,11 +2253,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -1295,15 +2287,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "5ef1e5bf-bc41-4a5a-a779-77b00bdf4cac"
+              "value": "33e3305f-458c-4518-a126-f25c27b80192"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "5ef1e5bf-bc41-4a5a-a779-77b00bdf4cac"
+              "value": "33e3305f-458c-4518-a126-f25c27b80192"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002724Z:5ef1e5bf-bc41-4a5a-a779-77b00bdf4cac"
+              "value": "EASTASIA:20210927T035825Z:33e3305f-458c-4518-a126-f25c27b80192"
             },
             {
               "name": "strict-transport-security",
@@ -1315,7 +2307,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:23 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:24 GMT"
             },
             {
               "name": "connection",
@@ -1323,17 +2315,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 588,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:22.700Z",
-        "time": 299,
+        "startedDateTime": "2021-09-27T03:58:25.413Z",
+        "time": 269,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1341,11 +2333,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 299
+          "wait": 269
         }
       },
       {
-        "_id": "0efbd72001560a2dbee5179d4924566f",
+        "_id": "63c1e91a3010d051bad1523d9486f161",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1365,7 +2357,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "cec041c9-17f1-414b-8288-3b94a29d7e84"
+              "value": "f1f83c3c-680a-471e-90ed-0a9330966718"
             },
             {
               "_fromType": "array",
@@ -1375,7 +2367,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1402,23 +2394,27 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1905,
+          "headersSize": 2171,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
             {
               "name": "api-version",
-              "value": "2017-05-01-preview"
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T11:58:25+08:00' and eventTimestamp le '2021-09-27T11:58:25+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest'"
             }
           ],
-          "url": "https://management.azure.com//subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T11%3A58%3A25%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T11%3A58%3A25%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FDefaultResourceGroup-CUS%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fregenerateaccesskeytest%27"
         },
         "response": {
-          "bodySize": 1085,
+          "bodySize": 22567,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1085,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.network/networksecuritygroups/j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_net_sec_grp_set\",\"type\":\"Microsoft.Insights/diagnosticSettings\",\"name\":\"j1dev_net_sec_grp_set\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"serviceBusRuleId\":null,\"workspaceId\":null,\"eventHubAuthorizationRuleId\":null,\"eventHubName\":null,\"metrics\":[],\"logs\":[{\"category\":\"NetworkSecurityGroupEvent\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}},{\"category\":\"NetworkSecurityGroupRuleCounter\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logAnalyticsDestinationType\":null},\"identity\":null}]}"
+            "size": 22567,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"a704a2cb-eb4d-4a35-805e-ead94ad19f43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/a704a2cb-eb4d-4a35-805e-ead94ad19f43/ticks/637680001929101036\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"0225ea72-f781-4f6e-9fe5-d6a0c2474557\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:23:12.9101036Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"ee04b008-d832-4d27-a31d-d6477b7c56bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ee04b008-d832-4d27-a31d-d6477b7c56bb/ticks/637680001926901032\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:23:12.6901032Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"47870c69-2372-4d1a-9917-44ee82af3d43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/47870c69-2372-4d1a-9917-44ee82af3d43/ticks/637679999082738446\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"31101762-006a-4ed7-89d9-49ca3036ab80\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:18:28.2738446Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"0bb50929-cabd-4f23-9f59-230d8444fdc2\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/0bb50929-cabd-4f23-9f59-230d8444fdc2/ticks/637679999074987777\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:18:27.4987777Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"9f03ce09-20a6-4d06-95d4-ef9682fe9dcb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9f03ce09-20a6-4d06-95d4-ef9682fe9dcb/ticks/637679990444693037\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4e305746-c740-4588-b06a-7d6040286b8a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:04:04.4693037Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"cafd852a-38ab-43de-9c4e-8ae9d2e0aa39\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cafd852a-38ab-43de-9c4e-8ae9d2e0aa39/ticks/637679990442442997\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:04:04.2442997Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"70e4e7f2-a8fb-42fe-8940-2777f9f0d373\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/70e4e7f2-a8fb-42fe-8940-2777f9f0d373/ticks/637679185425534061\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8d275523-3648-4cb1-9685-2170c4968840\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:42:22.5534061Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"8777e717-fee0-422a-ae58-7e871fdf0394\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/8777e717-fee0-422a-ae58-7e871fdf0394/ticks/637679185423183513\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:22.3183513Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"28e8a43f-d061-4b3d-b13c-ae0cc610de21\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/28e8a43f-d061-4b3d-b13c-ae0cc610de21/ticks/637679185357882256\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1d0fc11b-5f8a-414e-b58f-a17cf1e90f0f\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:42:15.7882256Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"d1f38226-b5fc-4ff8-9a00-3093b11f81c0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d1f38226-b5fc-4ff8-9a00-3093b11f81c0/ticks/637679185355782736\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:15.5782736Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac/ticks/637679179809610416\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"47695443-19d5-493e-a4e8-7789b0e60377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:33:00.9610416Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"d0717133-9bd8-40f6-9771-8b3f656b9068\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d0717133-9bd8-40f6-9771-8b3f656b9068/ticks/637679179807409713\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:33:00.7409713Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"62f1c7a0-52d0-47e8-831e-52bb6a043101\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/62f1c7a0-52d0-47e8-831e-52bb6a043101/ticks/637677475939857920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1cc9b1d1-3ad3-4be5-804d-107cff738cd4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:13:13.985792Z\",\"submissionTimestamp\":\"2021-09-20T15:14:24.1932217Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"f0381753-4ff1-45ed-99df-0a0f74f21bb7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/f0381753-4ff1-45ed-99df-0a0f74f21bb7/ticks/637677475660997035\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"446855e9-2947-4f06-9ddb-4249a30ad8e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:12:46.0997035Z\",\"submissionTimestamp\":\"2021-09-20T15:14:11.1254588Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"1813f4e7-9bf6-4710-ac12-489b32de7fd6\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1813f4e7-9bf6-4710-ac12-489b32de7fd6/ticks/637677474240400287\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1608dd41-cc4f-471b-8c4d-3a4393333377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:10:24.0400287Z\",\"submissionTimestamp\":\"2021-09-20T15:13:05.4897023Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"e0f6b157-a5ea-4c30-948d-5f3b5b30f14a\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e0f6b157-a5ea-4c30-948d-5f3b5b30f14a/ticks/637677474232600486\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:23.2600486Z\",\"submissionTimestamp\":\"2021-09-20T15:12:05.1607741Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"848862b2-56a3-4837-9562-bbd64dad53cc\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/848862b2-56a3-4837-9562-bbd64dad53cc/ticks/637677474228858674\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"90c74ebf-f83f-4196-8840-c20aa40bc0ca\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:10:22.8858674Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"83c32961-cc44-4648-9186-5d672cf75d83\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/83c32961-cc44-4648-9186-5d672cf75d83/ticks/637677474226509192\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:22.6509192Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"e4c18ff5-a195-41b8-89b0-cab13faa6f27\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e4c18ff5-a195-41b8-89b0-cab13faa6f27/ticks/637677471861822795\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"a40adc80-7e2f-4c2b-9621-5cc901366e2a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:26.1822795Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556/ticks/637677471859722688\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.9722688Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"cf6386d9-e6ab-42bd-9e5a-83cefa4c8199\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cf6386d9-e6ab-42bd-9e5a-83cefa4c8199/ticks/637677471856711620\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ea0187af-8198-4c98-97bd-4220a5bcd942\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:25.671162Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"b0e07419-dc8f-414f-82cd-53f01df6a401\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b0e07419-dc8f-414f-82cd-53f01df6a401/ticks/637677471854611536\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.4611536Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"d8243a16-ab46-4322-8dea-d563d7f88d39\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d8243a16-ab46-4322-8dea-d563d7f88d39/ticks/637677471851671673\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Regenerate Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fb259f93-8cbf-4974-83a9-6862b96eb049\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:25.1671673Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"6154366b-4323-45a8-b328-4d746d69a1d9\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6154366b-4323-45a8-b328-4d746d69a1d9/ticks/637677471847621619\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Regenerate Storage Account Keys\"},\"properties\":{\"requestbody\":\"{\\\"keyName\\\":\\\"key1\\\"}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:24.7621619Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"2fa63062-2f22-4759-90af-464f8be3b5c3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/2fa63062-2f22-4759-90af-464f8be3b5c3/ticks/637677471779112974\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4b5c0812-a756-4dda-97af-8ba7463e5d4c\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:17.9112974Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"6bd2ac81-1521-409d-ab9f-62a24b0ffd2d\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6bd2ac81-1521-409d-ab9f-62a24b0ffd2d/ticks/637677471777013163\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:17.7013163Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"6f2ead07-65c7-4527-8729-88a168ace6e9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/6f2ead07-65c7-4527-8729-88a168ace6e9/ticks/637677469905184323\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"5095ece2-d23b-4405-9663-0319f48b0234\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:03:10.5184323Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"85385ce4-5123-480f-b5ca-93ad14251b67\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/85385ce4-5123-480f-b5ca-93ad14251b67/ticks/637677469895868920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"257770ea-c767-43e6-8175-a296a4200be4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.586892Z\",\"submissionTimestamp\":\"2021-09-20T15:04:47.0753231Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1eed7870-0320-420b-ba7a-9c8a375031d0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/1eed7870-0320-420b-ba7a-9c8a375031d0/ticks/637677469894434112\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.4434112Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"9e8ec575-53e1-4cdf-aac6-1b6fe831f315\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9e8ec575-53e1-4cdf-aac6-1b6fe831f315/ticks/637677469636227096\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"57dc2ec8-7845-4db5-b514-99690b6a867b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6227096Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"ff1449dd-10cf-4a75-bbfc-f243cc8c63da\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ff1449dd-10cf-4a75-bbfc-f243cc8c63da/ticks/637677469636177088\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"5adc31a9-0f71-4dc9-b0d6-b2b7a3ef6cf0\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6177088Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1fd27944-0a26-4bb1-a0e3-fba30c720db0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1fd27944-0a26-4bb1-a0e3-fba30c720db0/ticks/637677469575072028\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Premium_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":false,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:37.5072028Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -1440,7 +2436,7 @@
             },
             {
               "name": "vary",
-              "value": "Accept-Encoding"
+              "value": "Accept-Encoding,Accept-Encoding"
             },
             {
               "name": "strict-transport-security",
@@ -1448,7 +2444,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "c685631b-4553-40fb-8b82-fa93ed3b9043"
+              "value": "EastAsia_99e2f94705cb4d2abbde7ee7c59f601a_637683119063562461"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
@@ -1460,11 +2456,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "1acde36b-75b3-4ed4-811c-415c5950d64b"
+              "value": "c2781849-f91b-439a-947d-f7775836fdeb"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002725Z:1acde36b-75b3-4ed4-811c-415c5950d64b"
+              "value": "EASTASIA:20210927T035826Z:c2781849-f91b-439a-947d-f7775836fdeb"
             },
             {
               "name": "x-content-type-options",
@@ -1472,21 +2468,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:24 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:26 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 629,
+          "headersSize": 664,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:23.009Z",
-        "time": 1173,
+        "startedDateTime": "2021-09-27T03:58:25.695Z",
+        "time": 707,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1494,505 +2490,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1173
+          "wait": 707
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "817ffb4f-173a-4636-a079-ee80c1558bae"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "linux"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 413,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1616117245\",\"not_before\":\"1616113345\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-18T00:27:25.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "817ffb4f-173a-4636-a079-ee80c1558bae"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "dc87bf06-5c2e-404a-b4c3-188e6a860500"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:24 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:24.188Z",
-        "time": 212,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 212
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "c34a85b7-1688-4b8b-94ef-b29c6fdb64e4"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1686,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2016-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
-        },
-        "response": {
-          "bodySize": 358,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "67adc084-260c-4c67-85e4-7dcc244b7cff"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "67adc084-260c-4c67-85e4-7dcc244b7cff"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002725Z:67adc084-260c-4c67-85e4-7dcc244b7cff"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:25 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "358"
-            }
-          ],
-          "headersSize": 588,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:24.404Z",
-        "time": 276,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 276
-        }
-      },
-      {
-        "_id": "c9d6dbee91365ea9a6e208a3dd1605c4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "28107715-8d5f-470d-998f-dd90e0303337"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1816,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-06-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
-        },
-        "response": {
-          "bodySize": 2459,
-          "content": {
-            "mimeType": "application/json",
-            "size": 2459,
-            "text": "{\"value\":[{\"identity\":{\"principalId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"SystemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"resourceAccessRules\":[],\"bypass\":\"Logging, Metrics, AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[{\"value\":\"76.182.33.160\",\"action\":\"Allow\"}],\"defaultAction\":\"Deny\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://ndowmon11-j1dev.vault.azure.net/keys/j1dev/325432ed4deb46bebe09d39dc071f090\",\"lastKeyRotationTimestamp\":\"2021-03-09T16:48:13.3984368Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"keyname\":\"j1dev\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.2628136Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1dev.dfs.core.windows.net/\",\"web\":\"https://ndowmon1j1dev.z13.web.core.windows.net/\",\"blob\":\"https://ndowmon1j1dev.blob.core.windows.net/\",\"queue\":\"https://ndowmon1j1dev.queue.core.windows.net/\",\"table\":\"https://ndowmon1j1dev.table.core.windows.net/\",\"file\":\"https://ndowmon1j1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1devblobstorage\",\"name\":\"ndowmon1j1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.3721528Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://ndowmon1j1devblobstorage.blob.core.windows.net/\",\"table\":\"https://ndowmon1j1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a812d2f1-2a55-4ae9-aa4d-6f1b85791e0a"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "1301a84f-ef09-4f03-8ef6-28c762533d36"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002726Z:1301a84f-ef09-4f03-8ef6-28c762533d36"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:25 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 685,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:24.686Z",
-        "time": 418,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 418
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2017,12 +2519,12 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "dc6ad0b8-fa44-4c65-a675-c736df635eef"
+              "value": "e50b843a-77ef-4960-9d1c-31cdda2bc234"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -2044,7 +2546,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 437,
+          "headersSize": 428,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2053,7 +2555,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -2064,7 +2566,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-18T00:27:26.000Z",
+              "expires": "2021-10-27T03:58:27.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -2099,8 +2601,448 @@
               "value": "no-cache"
             },
             {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "358762aa-6108-4b57-a0d9-83a518042a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:26 GMT"
+            },
+            {
               "name": "content-length",
               "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:26.442Z",
+        "time": 1122,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1122
+        }
+      },
+      {
+        "_id": "12ec0509765fac63d7064f131c7b3918",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "a675c24a-9f60-4728-8a49-f28393b1e081"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "regenerateaccesskeytest.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1606,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://regenerateaccesskeytest.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 236,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 236,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "236"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "de194674-f01c-0027-6453-b378fb000000"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "a675c24a-9f60-4728-8a49-f28393b1e081"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:28 GMT"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:27.582Z",
+        "time": 1360,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1360
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "0dc24022-9b05-4a43-9081-12e8c82a6076"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2162,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T11:58:28+08:00' and eventTimestamp le '2021-09-27T11:58:28+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T11%3A58%3A28%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T11%3A58%3A28%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_SQL_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fsqlvab7pt3ww5qhmdw%27"
+        },
+        "response": {
+          "bodySize": 13185,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 13185,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"1bf92f9b-047b-4228-84df-7c2ed64bacdf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/1bf92f9b-047b-4228-84df-7c2ed64bacdf/ticks/637679941964644382\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46f46d72-c836-4fb5-81df-39d87ee35361\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:43:16.4644382Z\",\"submissionTimestamp\":\"2021-09-23T11:45:03.183974Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0/ticks/637679941750596914\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"e4bbfd9b-2399-4547-bc1b-72028b20383d\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/e4bbfd9b-2399-4547-bc1b-72028b20383d/ticks/637679941750596914\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"5e859926-06ba-422b-b976-128ae719d9c5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/5e859926-06ba-422b-b976-128ae719d9c5/ticks/637679941731506587\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"3d667eff-b604-4b94-9aa0-f6ae6b20cd2e\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:53.1506587Z\",\"submissionTimestamp\":\"2021-09-23T11:43:29.1239763Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44a7cc1c-09a5-408a-bb6d-7159bd091493\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/44a7cc1c-09a5-408a-bb6d-7159bd091493/ticks/637679936036356606\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"57d231f9-c955-4a39-81a7-e0ca1179c7c3\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T11:33:23.6356606Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1880622Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"c997130c-e08c-4218-8c43-b292200e4d82\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/c997130c-e08c-4218-8c43-b292200e4d82/ticks/637679936001153487\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"scope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:20.1153487Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1860603Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"db28785d-d234-4156-85d1-f93663a89aa7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/db28785d-d234-4156-85d1-f93663a89aa7/ticks/637679935941633332\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1645c04a-9f69-472c-8224-c5be3334796c\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:14.1633332Z\",\"submissionTimestamp\":\"2021-09-23T11:34:50.1441225Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"685222b6-8e45-4a6f-9116-77895f3c68eb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/685222b6-8e45-4a6f-9116-77895f3c68eb/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"5f9205a3-3c45-4db5-abf6-4cbba8b09865\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d4290f0f-f81f-48ff-8d26-686074ca277a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d4290f0f-f81f-48ff-8d26-686074ca277a/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"463cb640-befe-45af-b4d7-b5470a837a59\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"b821643d-9081-4a4b-a57c-2f8ca07b7002\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/b821643d-9081-4a4b-a57c-2f8ca07b7002/ticks/637679935726410258\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:52.6410258Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"dab4de05-9d1d-41af-bda7-78b884be52d5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/dab4de05-9d1d-41af-bda7-78b884be52d5/ticks/637679935680160357\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/2a1a9cdf-e04d-429a-8416-3bfb72a1b26f/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountsShouldRestrictNetworkAccessUsingVirtualNetworkRulesMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\\\",\\\"policyDefinitionEffect\\\":\\\"Audit\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:48.0160357Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d5d150f2-829f-42ea-8a70-cb7aead80689\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d5d150f2-829f-42ea-8a70-cb7aead80689/ticks/637679935679959308\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":\\\"true\\\",\\\"allowBlobPublicAccess\\\":\\\"false\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:47.9959308Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_e2224077aa614d658de20feb3bf66a3a_637683119095993536"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f39407be-52c6-461d-be8b-43110462fbc0"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035829Z:f39407be-52c6-461d-be8b-43110462fbc0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:29 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:28.972Z",
+        "time": 740,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 740
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "2a36e483-dd0b-463d-b694-e269879212ad"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:30.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
             },
             {
               "name": "content-type",
@@ -2124,11 +3066,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "9c5cb5f1-925b-4777-81a3-7a751e6f0500"
+              "value": "ee0d95b4-dd71-4680-ac7c-a3f4f9572a00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
+              "value": "2.1.12071.16 - SCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -2147,17 +3089,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:25 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:30 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
             }
           ],
-          "headersSize": 711,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:25.136Z",
-        "time": 277,
+        "startedDateTime": "2021-09-27T03:58:29.731Z",
+        "time": 1106,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2165,11 +3111,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 1106
         }
       },
       {
-        "_id": "5dbc34c006894f7ce143f08803d3acba",
+        "_id": "155a15bd9bc9daa4c43589a03bdf5d4b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2184,12 +3130,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Linux 5.4.0-67-generic)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "b222093c-239a-4ef8-88fb-7ba978fcc94f"
+              "value": "b9e6b0ba-5b27-4be9-80c5-29d76d1aaf1f"
             },
             {
               "_fromType": "array",
@@ -2208,10 +3154,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.blob.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.blob.core.windows.net"
             }
           ],
-          "headersSize": 1595,
+          "headersSize": 1596,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2224,14 +3170,14 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1dev.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 805,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/xml",
-            "size": 805,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+            "size": 749,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
@@ -2249,11 +3195,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "dca469bb-a01e-004a-1256-1cefb0000000"
+              "value": "05fcadd9-b01e-0039-5a53-b36c7a000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "b222093c-239a-4ef8-88fb-7ba978fcc94f"
+              "value": "b9e6b0ba-5b27-4be9-80c5-29d76d1aaf1f"
             },
             {
               "name": "x-ms-version",
@@ -2261,7 +3207,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:26 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:31 GMT"
             }
           ],
           "headersSize": 295,
@@ -2270,8 +3216,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:25.438Z",
-        "time": 528,
+        "startedDateTime": "2021-09-27T03:58:30.849Z",
+        "time": 1103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2279,12 +3225,12 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 528
+          "wait": 1103
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 1,
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 194,
@@ -2308,17 +3254,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "855950ba-4322-4ce4-baea-3ee8f26880f5"
+              "value": "22cfb68c-7201-41bf-a98a-2f291ad12ddb"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": "fpc=AlIw6m0tsE9GlXcst_gqU4ERsITIAQAAAO3m5dcOAAAA"
+              "value": "fpc=AtwsgiMpo-pChVbRqLQmFcg-ExxYAQAAAGY449gOAAAA"
             },
             {
               "_fromType": "array",
@@ -2335,7 +3281,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 485,
+          "headersSize": 476,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2344,7 +3290,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -2355,7 +3301,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-18T00:27:27.000Z",
+              "expires": "2021-10-27T03:58:32.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -2411,11 +3357,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "6684fcbc-c22d-4949-bfba-f73002f50400"
+              "value": "358762aa-6108-4b57-a0d9-83a58b052a00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
+              "value": "2.1.12071.16 - SCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -2434,21 +3380,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:26 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:32 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 711,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:25.989Z",
-        "time": 87,
+        "startedDateTime": "2021-09-27T03:58:31.991Z",
+        "time": 733,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2456,11 +3402,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 733
         }
       },
       {
-        "_id": "af6a01d1852c557b688492da54e4f9fe",
+        "_id": "8bb93cbc2d87e49d3993a0fdc741e834",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2480,12 +3426,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v12.21.0; Linux 5.4.0-67-generic)"
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "1a752fac-922e-455d-9112-6cffaf53d4b4"
+              "value": "829be269-34fe-4fb0-bdc0-c6b93337cca9"
             },
             {
               "_fromType": "array",
@@ -2504,10 +3450,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.queue.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.queue.core.windows.net"
             }
           ],
-          "headersSize": 1652,
+          "headersSize": 1653,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2524,14 +3470,14 @@
               "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1dev.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+          "url": "https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
         },
         "response": {
-          "bodySize": 626,
+          "bodySize": 573,
           "content": {
             "mimeType": "application/xml",
-            "size": 626,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
@@ -2553,11 +3499,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "42d0df37-1003-0002-5f56-1cf287000000"
+              "value": "a114ae68-e003-0034-6753-b3a4ae000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "1a752fac-922e-455d-9112-6cffaf53d4b4"
+              "value": "829be269-34fe-4fb0-bdc0-c6b93337cca9"
             },
             {
               "name": "x-ms-version",
@@ -2565,7 +3511,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:26 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:33 GMT"
             }
           ],
           "headersSize": 321,
@@ -2574,8 +3520,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:26.084Z",
-        "time": 201,
+        "startedDateTime": "2021-09-27T03:58:32.733Z",
+        "time": 1102,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2583,26 +3529,21 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 201
+          "wait": 1102
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "63c1e91a3010d051bad1523d9486f161",
         "_order": 2,
         "cache": {},
         "request": {
-          "bodySize": 194,
+          "bodySize": 0,
           "cookies": [],
           "headers": [
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
               "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
@@ -2612,481 +3553,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "a8c66df4-3502-420e-b6c2-5411e594d845"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 437,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-18T00:27:27.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "3d5e91e3-3d61-403c-901b-cbf146fb0500"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:27 GMT"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            }
-          ],
-          "headersSize": 711,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:26.302Z",
-        "time": 198,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 198
-        }
-      },
-      {
-        "_id": "ee4f6ed8f5c33ad8b5cafac8001e69f6",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Linux 5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "cac3d218-d20b-4625-b892-547d16035da9"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmon1j1devblobstorage.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1617,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmon1j1devblobstorage.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 651,
-          "content": {
-            "mimeType": "application/xml",
-            "size": 651,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a8ad7d60-901e-003e-1256-1cf9d9000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "cac3d218-d20b-4625-b892-547d16035da9"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:28 GMT"
-            }
-          ],
-          "headersSize": 295,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:26.506Z",
-        "time": 491,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 491
-        }
-      },
-      {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "4ce76f0d-e16d-474e-b376-1e34a3d0fc5c"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "linux"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 413,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1616117248\",\"not_before\":\"1616113348\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-18T00:27:28.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "4ce76f0d-e16d-474e-b376-1e34a3d0fc5c"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a4f26f2f-1fc9-44d5-93f0-2ad080c40400"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11562.8 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:27 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 781,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:27.003Z",
-        "time": 176,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 176
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "f5f70fea-132f-4f10-a416-1bcacebf17b7"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
+              "value": "51c1f99b-31fe-49b6-95c9-e4ea63eaaa6d"
             },
             {
               "_fromType": "array",
@@ -3096,7 +3563,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -3123,7 +3590,1699 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1686,
+          "headersSize": 2168,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T11:58:33+08:00' and eventTimestamp le '2021-09-27T11:58:33+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T11%3A58%3A33%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T11%3A58%3A33%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_Storage_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstefanexamplestorage%27"
+        },
+        "response": {
+          "bodySize": 16343,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16343,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713/ticks/637680751208063831\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"9f9c4957-cbe0-4829-8e91-6ef594969333\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-24T10:12:00.8063831Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"8903f8d4-7a4c-456d-be34-33660212b2bd\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/8903f8d4-7a4c-456d-be34-33660212b2bd/ticks/637680751206863840\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T10:12:00.686384Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"927daf50-bb12-4bb1-960e-005dd0196385\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/927daf50-bb12-4bb1-960e-005dd0196385/ticks/637680036884982412\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"2fbc6389-ef5b-43c4-8771-5500d31026d5\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T14:21:28.4982412Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"f60bee7d-a7ea-4f59-9d88-658fafc85b1f\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/f60bee7d-a7ea-4f59-9d88-658fafc85b1f/ticks/637680036855632564\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T14:21:25.5632564Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0dde252b-5665-4e8a-a936-4daba0d8a575\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0dde252b-5665-4e8a-a936-4daba0d8a575/ticks/637677468635548611\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"b1001d0c-e882-4506-b8ab-9163d906f654\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:01:03.5548611Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0842ad8b-0a70-4ce5-8652-a7f2114e8000\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0842ad8b-0a70-4ce5-8652-a7f2114e8000/ticks/637677468633347789\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:01:03.3347789Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a/ticks/637666178855994320\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"2bc25043-553e-48b1-ad9b-ce9926416ca9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:45.599432Z\",\"submissionTimestamp\":\"2021-09-07T13:26:18.0982287Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b1dc8c9d-57e9-422f-b6b6-a2ab4089845e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/b1dc8c9d-57e9-422f-b6b6-a2ab4089845e/ticks/637666178612856613\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"06c3da4c-be9c-4b9c-9bb1-c29b06dc2943\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:21.2856613Z\",\"submissionTimestamp\":\"2021-09-07T13:25:26.1292429Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"fa96b680-b3f9-471c-a777-a69da710ac89\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/fa96b680-b3f9-471c-a777-a69da710ac89/ticks/637666172866182094\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ce0cce81-7af2-48c6-b614-da08e1048548\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.6182094Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"138520b9-0d15-4108-98e6-b26cfcaed86c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/138520b9-0d15-4108-98e6-b26cfcaed86c/ticks/637666172864682093\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:46.4682093Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b49bfb26-b7bd-488b-bf76-f4891ad74605\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/b49bfb26-b7bd-488b-bf76-f4891ad74605/ticks/637666172863682069\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"22765ce3-92ae-4aed-954d-7f26ab018c84\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.3682069Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"575b58d7-a757-4a45-aebe-40195806a39c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/575b58d7-a757-4a45-aebe-40195806a39c/ticks/637666172849132353\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:44.9132353Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"870fddbd-ee80-4254-b798-ab2e71de1de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/870fddbd-ee80-4254-b798-ab2e71de1de1/ticks/637666172832824197\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c6e734b2-12f7-4965-8ec4-f7feb27666b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:43.2824197Z\",\"submissionTimestamp\":\"2021-09-07T13:15:26.1178018Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"4e08dab9-10e0-49d3-abf6-4a61f7315de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4e08dab9-10e0-49d3-abf6-4a61f7315de1/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"75ec2246-b3ed-4a2a-8d99-85232ae352cd\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"f5231d65-9872-4ab7-82fa-030783fd80bd\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/f5231d65-9872-4ab7-82fa-030783fd80bd/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d1f0bd9a-7d00-4270-8164-a37d77ad40a8\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e50013de-1290-4050-945c-edd8ac16b016\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e50013de-1290-4050-945c-edd8ac16b016/ticks/637666172560836200\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_RAGRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"accessTier\\\":\\\"Hot\\\",\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":true,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:16.08362Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1731361Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_82d8bc07964745aea15e0404956f5881_637683119144530386"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "964f3fb9-0643-4d65-877e-970431bdfd0e"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035834Z:964f3fb9-0643-4d65-877e-970431bdfd0e"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:34 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:33.856Z",
+        "time": 642,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 642
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "14b66618-5952-485e-bee1-b6544b98ac7f"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:35.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "cb664b4a-9a26-4fc7-a612-438f7a7a2500"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:35 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:34.513Z",
+        "time": 1104,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1104
+        }
+      },
+      {
+        "_id": "396844fb10796ff14cd9ef4c38881321",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "81c93daf-c2bb-4b1e-85bd-ccbf8a728ade"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1600,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://stefanexamplestorage.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 762,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 762,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2dc6af55-c01e-0072-4153-b3177b000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "81c93daf-c2bb-4b1e-85bd-ccbf8a728ade"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:36 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:35.638Z",
+        "time": 1004,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1004
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "25311904-75d1-4e61-9671-e3806d81b156"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=AnHYQ2bpBUhMts-6pGlGCKc-ExxYAQAAAGo449gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:37.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8d90d2c8-a5ff-48d8-99b3-2be3bc9a2900"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:36 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:36.657Z",
+        "time": 727,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 727
+        }
+      },
+      {
+        "_id": "35a194af62cb1877e4f3a2940d92adfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3fb9f8f8-c9bc-4ce3-8a35-186ecffc24d7"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1657,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://stefanexamplestorage.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e9cb6b1d-b003-0025-5853-b3b948000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "3fb9f8f8-c9bc-4ce3-8a35-186ecffc24d7"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:37 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:37.401Z",
+        "time": 1054,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1054
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3fd49194-7fc5-45ca-b966-8790d03646ab"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T11:58:38+08:00' and eventTimestamp le '2021-09-27T11:58:38+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T11%3A58%3A38%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T11%3A58%3A38%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_AppServices_Group%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstorageaccountstefaafb8%27"
+        },
+        "response": {
+          "bodySize": 16179,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16179,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"71d2ca88-e069-4418-a9a1-5e61fa4e29e7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/71d2ca88-e069-4418-a9a1-5e61fa4e29e7/ticks/637683118197796970\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fc21cc29-04bb-4c52-bd10-09f62bdcc345\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.779697Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022/ticks/637683118197546829\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7546829Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"34858c5b-8c5d-4884-b748-2ab3d59bd78b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/34858c5b-8c5d-4884-b748-2ab3d59bd78b/ticks/637683118197378385\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8b8be42f-bfef-4507-95f6-ccd2a0bfca45\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7378385Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"cb12a0cf-8b0e-494b-a483-05cc8e2af298\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/cb12a0cf-8b0e-494b-a483-05cc8e2af298/ticks/637683118197028379\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7028379Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"9ab0273f-4168-420b-a82a-04a95ef004b9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/9ab0273f-4168-420b-a82a-04a95ef004b9/ticks/637680895404911980\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"e3e29761-cb4f-44b6-9c21-c4bef3490d74\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-24T14:12:20.491198Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"f3127244-2903-49eb-8290-896fb807e4bf\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f3127244-2903-49eb-8290-896fb807e4bf/ticks/637680895402811842\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T14:12:20.2811842Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"f4c0ba23-4f98-4def-837e-c8de0728547e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f4c0ba23-4f98-4def-837e-c8de0728547e/ticks/637680004888576312\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ccd64de2-9c2f-4578-8496-5808bf5ae478\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:28:08.8576312Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1600853Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"abee07ad-735f-4daf-a00b-dbcb2420491c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/abee07ad-735f-4daf-a00b-dbcb2420491c/ticks/637680004886626307\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:28:08.6626307Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1590849Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"609c11d9-f767-47fc-b7f6-2b01de6df6d3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/609c11d9-f767-47fc-b7f6-2b01de6df6d3/ticks/637680004138311948\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"aa7000e2-9f8d-45c0-8eaf-ab889d7022c8\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:26:53.8311948Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"f7bd6f5d-a4a6-459f-b677-7cc6aef350bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f7bd6f5d-a4a6-459f-b677-7cc6aef350bb/ticks/637680004131562335\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:26:53.1562335Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"95e08496-5682-44b1-aa43-bc8364b7f678\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/95e08496-5682-44b1-aa43-bc8364b7f678/ticks/637674012546036667\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"188d14f7-04dd-4948-acb1-1216172a19c3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:54.6036667Z\",\"submissionTimestamp\":\"2021-09-16T15:01:46.1692025Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"8a01ea00-bd83-41d8-8de7-bc51b80d4652\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/8a01ea00-bd83-41d8-8de7-bc51b80d4652/ticks/637674012295717803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"99bdf78f-4602-4a8c-83b4-19ed0c0e9cd1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:29.5717803Z\",\"submissionTimestamp\":\"2021-09-16T15:01:53.1386235Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"b30ffc87-ee15-41e7-81c0-0fb4b05895ff\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/b30ffc87-ee15-41e7-81c0-0fb4b05895ff/ticks/637674006534406250\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"3113ca2b-d2bc-4f4f-9a8f-89c167e9218a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-16T14:50:53.440625Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"01af52fc-5b12-4703-98b4-cc67db95435e\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/01af52fc-5b12-4703-98b4-cc67db95435e/ticks/637674006528456482\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:52.8456482Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"cf10aecf-4960-4246-8021-a91b9767a6ee\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/cf10aecf-4960-4246-8021-a91b9767a6ee/ticks/637674006518718327\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ce1ef8-dabe-4c1b-a7f3-06409c83d4e5\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:51.8718327Z\",\"submissionTimestamp\":\"2021-09-16T14:52:09.1184465Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"18d6742e-9780-4410-87f2-7861ad8ebcaf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/18d6742e-9780-4410-87f2-7861ad8ebcaf/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46e3061f-4966-444c-8a1a-5fcc9c793c50\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"e279382a-ca7b-4fb4-bca3-d72bbacb841b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/e279382a-ca7b-4fb4-bca3-d72bbacb841b/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"36894b22-1fe1-4514-a797-ba687ae30306\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"0ee36506-e3f0-4f97-9a2f-deccfc7f3576\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/0ee36506-e3f0-4f97-9a2f-deccfc7f3576/ticks/637674006235104764\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"location\\\":\\\"Central US\\\",\\\"properties\\\":{\\\"supportsHttpsTrafficOnly\\\":true,\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:23.5104764Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.1747877Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_8b2e5a286c2a4458a7645084bd844f96_637683119194215880"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "15acc1eb-2d00-4483-a74d-4a3849e1e4d5"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210927T035839Z:15acc1eb-2d00-4483-a74d-4a3849e1e4d5"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:39 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:38.483Z",
+        "time": 975,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 975
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d1581ed9-270e-47a9-a68e-3da5aa467468"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:40.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "985e2533-994e-4f29-bc8f-21beb5302100"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - EUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:39 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 716,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:39.488Z",
+        "time": 1112,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1112
+        }
+      },
+      {
+        "_id": "11cca1bdf5f08f97880274f522d9c376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d3995b56-9a4f-43dd-8cd0-1818467f8ad9"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1606,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 694,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 694,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a572c96f-c01e-0066-5c53-b31b3d000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "d3995b56-9a4f-43dd-8cd0-1818467f8ad9"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:41 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:40.610Z",
+        "time": 901,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 901
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e06b2fa8-7e3c-4368-b0b1-28b33dec0bdf"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=AmAE9kbD-KRMg45NHMu-4l4-ExxYAQAAAHA449gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:42.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7dba225b-e88f-4896-9556-af3c62312200"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:41 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:41.531Z",
+        "time": 795,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 795
+        }
+      },
+      {
+        "_id": "dd3d6e3698ab7e26997ca5b4d8d2d5d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "bb7d32c9-1843-4b52-8290-eb701d77fb5e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1663,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "96ef7993-9003-0018-3653-b384f2000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "bb7d32c9-1843-4b52-8290-eb701d77fb5e"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:43 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:42.332Z",
+        "time": 1008,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1008
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "600671fe-f979-4277-a8cb-c00d12b45589"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632718723\",\"not_before\":\"1632714823\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T03:58:43.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "600671fe-f979-4277-a8cb-c00d12b45589"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0f9f9943-6e57-408d-89a3-6f091b275f00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 03:58:43 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T03:58:43.349Z",
+        "time": 475,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 475
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "adb6a192-84aa-42b9-8db3-511fd4f7464a"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -3135,11 +5294,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -3169,15 +5328,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "aad3b367-a8b1-4b3d-865e-07553ea31c4e"
+              "value": "c51e70e5-a74b-4fad-8675-88e44fa1ec87"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "aad3b367-a8b1-4b3d-865e-07553ea31c4e"
+              "value": "c51e70e5-a74b-4fad-8675-88e44fa1ec87"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002728Z:aad3b367-a8b1-4b3d-865e-07553ea31c4e"
+              "value": "EASTASIA:20210927T035844Z:c51e70e5-a74b-4fad-8675-88e44fa1ec87"
             },
             {
               "name": "strict-transport-security",
@@ -3189,7 +5348,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:28 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:43 GMT"
             },
             {
               "name": "connection",
@@ -3197,17 +5356,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 588,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:27.186Z",
-        "time": 291,
+        "startedDateTime": "2021-09-27T03:58:43.832Z",
+        "time": 306,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3215,11 +5374,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 291
+          "wait": 306
         }
       },
       {
-        "_id": "fdd715e1980721ffa1627855f200941f",
+        "_id": "5379ef7a9b553caec8be83eab3a154ed",
         "_order": 0,
         "cache": {},
         "request": {
@@ -3239,7 +5398,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "b3452717-51a7-4519-baa1-4e0861292eaa"
+              "value": "be38225f-9efd-4f47-9e2e-0d9d8995203d"
             },
             {
               "_fromType": "array",
@@ -3249,7 +5408,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -3276,7 +5435,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1879,
+          "headersSize": 1873,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -3285,14 +5444,14 @@
               "value": "2019-12-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/networkwatcherrg/providers/Microsoft.Network/networkWatchers/NetworkWatcher_westus/flowLogs?api-version=2019-12-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/networkwatcherrg/providers/Microsoft.Network/networkWatchers/NetworkWatcher_centralus/flowLogs?api-version=2019-12-01"
         },
         "response": {
-          "bodySize": 287,
+          "bodySize": 1399,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 287,
-            "text": "{\r\n  \"value\": []\r\n}"
+            "size": 1399,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"NSG-DefaultResourceGroup-CUS-flowlog\",\r\n      \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_centralus/flowLogs/NSG-DefaultResourceGroup-CUS-flowlog\",\r\n      \"etag\": \"W/\\\"e15f95ac-9572-448a-b157-5097c6051440\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"targetResourceId\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkSecurityGroups/NSG\",\r\n        \"targetResourceGuid\": \"0e112a13-93cf-4ab0-9fce-3c502c55f89d\",\r\n        \"storageId\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\r\n        \"enabled\": true,\r\n        \"flowAnalyticsConfiguration\": {\r\n          \"networkWatcherFlowAnalyticsConfiguration\": {\r\n            \"enabled\": false,\r\n            \"trafficAnalyticsInterval\": 0\r\n          }\r\n        },\r\n        \"retentionPolicy\": {\r\n          \"days\": 0,\r\n          \"enabled\": false\r\n        },\r\n        \"format\": {\r\n          \"type\": \"JSON\",\r\n          \"version\": 2\r\n        }\r\n      },\r\n      \"type\": \"Microsoft.Network/networkWatchers/flowLogs\",\r\n      \"location\": \"centralus\",\r\n      \"tags\": {}\r\n    }\r\n  ]\r\n}"
           },
           "cookies": [],
           "headers": [
@@ -3318,15 +5477,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "cba45b49-53a7-4dd1-b751-52d1afa12481"
+              "value": "2238c465-589b-47cd-a0a7-50c4ba9abab3"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "7ff130a1-366e-40c4-9172-ed065b08d036"
+              "value": "e482f212-e3f0-4942-ad9c-8967003a2a29"
             },
             {
               "name": "x-ms-arm-service-request-id",
-              "value": "ef91e054-9eee-4e76-af0a-034c44ee1557"
+              "value": "fa541248-9087-46dc-b202-802b9f3b5672"
             },
             {
               "name": "strict-transport-security",
@@ -3342,7 +5501,7 @@
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002728Z:7ff130a1-366e-40c4-9172-ed065b08d036"
+              "value": "EASTASIA:20210927T035844Z:e482f212-e3f0-4942-ad9c-8967003a2a29"
             },
             {
               "name": "x-content-type-options",
@@ -3350,21 +5509,21 @@
             },
             {
               "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:28 GMT"
+              "value": "Mon, 27 Sep 2021 03:58:44 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 699,
+          "headersSize": 694,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-19T00:27:27.493Z",
-        "time": 385,
+        "startedDateTime": "2021-09-27T03:58:44.154Z",
+        "time": 514,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3372,164 +5531,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 385
-        }
-      },
-      {
-        "_id": "c71014fbcea88d9f243668c26407fbbe",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "64db6728-cc3b-44bf-a361-1560b9609d00"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Linux-5.4.0-67-generic)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "management.azure.com"
-            }
-          ],
-          "headersSize": 1879,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "2019-12-01"
-            }
-          ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/networkwatcherrg/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus/flowLogs?api-version=2019-12-01"
-        },
-        "response": {
-          "bodySize": 1345,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1345,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev-j1dev-flowlog\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus/flowLogs/j1dev-j1dev-flowlog\",\r\n      \"etag\": \"W/\\\"5fe8be0c-0d9a-450b-913f-2e1896a9ab43\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"targetResourceId\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkSecurityGroups/j1dev\",\r\n        \"targetResourceGuid\": \"e68eafb0-f091-4701-82ff-0978bc014a8d\",\r\n        \"storageId\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\r\n        \"enabled\": true,\r\n        \"flowAnalyticsConfiguration\": {\r\n          \"networkWatcherFlowAnalyticsConfiguration\": {\r\n            \"enabled\": false,\r\n            \"trafficAnalyticsInterval\": 0\r\n          }\r\n        },\r\n        \"retentionPolicy\": {\r\n          \"days\": 30,\r\n          \"enabled\": true\r\n        },\r\n        \"format\": {\r\n          \"type\": \"JSON\",\r\n          \"version\": 2\r\n        }\r\n      },\r\n      \"type\": \"Microsoft.Network/networkWatchers/flowLogs\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {}\r\n    }\r\n  ]\r\n}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "05e68978-2624-4d99-bb8a-982c44933350"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "eee02b1f-2abf-4b53-a9cc-8ad103f896d6"
-            },
-            {
-              "name": "x-ms-arm-service-request-id",
-              "value": "1c47bc71-8e0b-4b91-9ebf-cd546361979d"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CANADACENTRAL:20210319T002729Z:eee02b1f-2abf-4b53-a9cc-8ad103f896d6"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 19 Mar 2021 00:27:28 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 699,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-19T00:27:27.903Z",
-        "time": 331,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 331
+          "wait": 514
         }
       }
     ],

--- a/src/steps/resource-manager/network/__recordings__/rm-network-private-endpoint-resource-relationships_2489136482/recording.har
+++ b/src/steps/resource-manager/network/__recordings__/rm-network-private-endpoint-resource-relationships_2489136482/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "f748b1cf-0183-4dc3-bbad-6491ca0dca33"
+              "value": "0781983b-c59a-4550-bacf-8599bc586f52"
             },
             {
               "name": "return-client-request-id",
@@ -41,7 +41,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -56,7 +56,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -70,18 +70,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620243662\",\"not_before\":\"1620239762\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750271\",\"not_before\":\"1632746371\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-06-04T18:41:02.000Z",
+              "expires": "2021-10-27T12:44:31.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -135,15 +135,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "f748b1cf-0183-4dc3-bbad-6491ca0dca33"
+              "value": "0781983b-c59a-4550-bacf-8599bc586f52"
             },
             {
               "name": "x-ms-request-id",
-              "value": "03737858-b88a-41e8-a7a3-b1251ff59e00"
+              "value": "7ef39528-80f4-42c4-bdcc-7e174bd08400"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - WUS2 ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -166,7 +166,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:01 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:31 GMT"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:01.795Z",
-        "time": 276,
+        "startedDateTime": "2021-09-27T12:44:30.853Z",
+        "time": 984,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,11 +192,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 276
+          "wait": 984
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 0,
         "cache": {},
         "request": {
@@ -211,7 +211,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "64b79c64-9124-456f-950c-a9b2a4780b58"
+              "value": "a6be7308-9430-4a9a-a040-8aad6362f90c"
             },
             {
               "_fromType": "array",
@@ -226,7 +226,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -253,7 +253,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -265,11 +265,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -299,15 +299,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "880dd552-854a-4ee6-9840-c680b9d5099d"
+              "value": "608e2faa-135e-4e42-9c1d-e8958409c2e7"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "880dd552-854a-4ee6-9840-c680b9d5099d"
+              "value": "608e2faa-135e-4e42-9c1d-e8958409c2e7"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210505T184102Z:880dd552-854a-4ee6-9840-c680b9d5099d"
+              "value": "GERMANYWESTCENTRAL:20210927T124432Z:608e2faa-135e-4e42-9c1d-e8958409c2e7"
             },
             {
               "name": "strict-transport-security",
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:02 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:32 GMT"
             },
             {
               "name": "connection",
@@ -327,17 +327,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:02.074Z",
-        "time": 260,
+        "startedDateTime": "2021-09-27T12:44:31.918Z",
+        "time": 874,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -345,11 +345,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 260
+          "wait": 874
         }
       },
       {
-        "_id": "c9d6dbee91365ea9a6e208a3dd1605c4",
+        "_id": "65b39ca75483f0ca33c5ac4a87ec1aa8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -369,7 +369,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "28463e32-df53-40fa-a7c1-b373e974f93b"
+              "value": "1b969429-a89e-469c-85b8-65ee18c80f96"
             },
             {
               "_fromType": "array",
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -406,7 +406,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1807,
+          "headersSize": 1816,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -415,14 +415,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 4025,
+          "bodySize": 1459,
           "content": {
-            "mimeType": "application/json",
-            "size": 4025,
-            "text": "{\"value\":[{\"identity\":{\"principalId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"SystemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/privateEndpointConnections/ndowmon1j1dev.b3bd9e44-46d8-44b7-a579-3b8ed0b9b8ef\",\"name\":\"ndowmon1j1dev.b3bd9e44-46d8-44b7-a579-3b8ed0b9b8ef\",\"type\":\"Microsoft.Storage/storageAccounts/privateEndpointConnections\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateEndpoint\":{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/privateEndpoints/j1dev\"},\"privateLinkServiceConnectionState\":{\"status\":\"Approved\",\"description\":\"Auto-Approved\",\"actionRequired\":\"None\"}}}],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"resourceAccessRules\":[],\"bypass\":\"Logging, Metrics, AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[{\"value\":\"76.182.33.160\",\"action\":\"Allow\"}],\"defaultAction\":\"Deny\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://ndowmon11-j1dev.vault.azure.net/keys/j1dev/325432ed4deb46bebe09d39dc071f090\",\"lastKeyRotationTimestamp\":\"2021-03-09T16:48:13.3984368Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"keyname\":\"j1dev\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.2628136Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1dev.dfs.core.windows.net/\",\"web\":\"https://ndowmon1j1dev.z13.web.core.windows.net/\",\"blob\":\"https://ndowmon1j1dev.blob.core.windows.net/\",\"queue\":\"https://ndowmon1j1dev.queue.core.windows.net/\",\"table\":\"https://ndowmon1j1dev.table.core.windows.net/\",\"file\":\"https://ndowmon1j1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1devblobstorage\",\"name\":\"ndowmon1j1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.3721528Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://ndowmon1j1devblobstorage.blob.core.windows.net/\",\"table\":\"https://ndowmon1j1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"BlockBlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmonblob\",\"name\":\"ndowmonblob\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:31:05.2073047Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:31:05.2073047Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-04-20T18:31:05.0979564Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmonblob.dfs.core.windows.net/\",\"web\":\"https://ndowmonblob.z13.web.core.windows.net/\",\"blob\":\"https://ndowmonblob.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"FileStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmonfilestorage\",\"name\":\"ndowmonfilestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"largeFileSharesState\":\"Enabled\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:02:17.6453431Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:02:17.6453431Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-04-20T18:02:17.5359936Z\",\"primaryEndpoints\":{\"file\":\"https://ndowmonfilestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmonstoragev1\",\"name\":\"ndowmonstoragev1\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:00:34.2235636Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:00:34.2235636Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-04-20T18:00:34.1141895Z\",\"primaryEndpoints\":{\"blob\":\"https://ndowmonstoragev1.blob.core.windows.net/\",\"queue\":\"https://ndowmonstoragev1.queue.core.windows.net/\",\"table\":\"https://ndowmonstoragev1.table.core.windows.net/\",\"file\":\"https://ndowmonstoragev1.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"blob\":\"https://ndowmonstoragev1-secondary.blob.core.windows.net/\",\"queue\":\"https://ndowmonstoragev1-secondary.queue.core.windows.net/\",\"table\":\"https://ndowmonstoragev1-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmonstoragev1premium\",\"name\":\"ndowmonstoragev1premium\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:37:48.0034838Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:37:48.0034838Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-04-20T18:37:47.9097035Z\",\"primaryEndpoints\":{\"blob\":\"https://ndowmonstoragev1premium.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmonstoragev2\",\"name\":\"ndowmonstoragev2\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:29:19.5199037Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-04-20T18:29:19.5199037Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-04-20T18:29:19.4105474Z\",\"primaryEndpoints\":{\"web\":\"https://ndowmonstoragev2.z13.web.core.windows.net/\",\"blob\":\"https://ndowmonstoragev2.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1459,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"name\":\"regenerateaccesskeytest\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnections/regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"name\":\"regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"type\":\"Microsoft.Storage/storageAccounts/privateEndpointConnections\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateEndpoint\":{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints/private-endpoint\"},\"privateLinkServiceConnectionState\":{\"status\":\"Approved\",\"description\":\"Auto-Approved\",\"actionRequired\":\"None\"}}}],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-20T15:02:41.5642636Z\",\"primaryEndpoints\":{\"web\":\"https://regenerateaccesskeytest.z13.web.core.windows.net/\",\"blob\":\"https://regenerateaccesskeytest.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"name\":\"sqlvab7pt3ww5qhmdw\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-23T11:32:50.8155392Z\",\"primaryEndpoints\":{\"dfs\":\"https://sqlvab7pt3ww5qhmdw.dfs.core.windows.net/\",\"web\":\"https://sqlvab7pt3ww5qhmdw.z13.web.core.windows.net/\",\"blob\":\"https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/\",\"queue\":\"https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/\",\"table\":\"https://sqlvab7pt3ww5qhmdw.table.core.windows.net/\",\"file\":\"https://sqlvab7pt3ww5qhmdw.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"name\":\"stefanexamplestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-07T13:14:18.4460771Z\",\"primaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage.table.core.windows.net/\",\"file\":\"https://stefanexamplestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage-secondary.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage-secondary.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage-secondary.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage-secondary.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"name\":\"storageaccountstefaafb8\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"centralus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-16T14:50:27.0370951Z\",\"primaryEndpoints\":{\"blob\":\"https://storageaccountstefaafb8.blob.core.windows.net/\",\"queue\":\"https://storageaccountstefaafb8.queue.core.windows.net/\",\"table\":\"https://storageaccountstefaafb8.table.core.windows.net/\",\"file\":\"https://storageaccountstefaafb8.file.core.windows.net/\"},\"primaryLocation\":\"centralus\",\"statusOfPrimary\":\"available\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -436,7 +436,7 @@
             },
             {
               "name": "content-type",
-              "value": "application/json"
+              "value": "application/json; charset=utf-8"
             },
             {
               "name": "expires",
@@ -447,28 +447,28 @@
               "value": "Accept-Encoding"
             },
             {
-              "name": "x-ms-request-id",
-              "value": "e63fc974-37fe-4f55-b937-9fac3dc8ac89"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
+              "name": "x-ms-original-request-ids",
+              "value": "4732d57b-84ed-4098-9831-8fbf80ae08e3, 5fa4b172-fdeb-4eb6-9bc7-43aea5ef259d"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
               "value": "11999"
             },
             {
-              "name": "server",
-              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+              "name": "x-ms-request-id",
+              "value": "831dc581-77f4-489b-951c-e7bc4a86ceff"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "2dd51607-a164-4955-88bd-81efc27136c4"
+              "value": "831dc581-77f4-489b-951c-e7bc4a86ceff"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210505T184102Z:2dd51607-a164-4955-88bd-81efc27136c4"
+              "value": "GERMANYWESTCENTRAL:20210927T124433Z:831dc581-77f4-489b-951c-e7bc4a86ceff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
             },
             {
               "name": "x-content-type-options",
@@ -476,21 +476,25 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:02 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:33 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1459"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 703,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:02.341Z",
-        "time": 427,
+        "startedDateTime": "2021-09-27T12:44:32.832Z",
+        "time": 715,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -498,11 +502,509 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 427
+          "wait": 715
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "28a6e6ba-58b0-4c2b-89ee-09a7b08a1c5c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750274\",\"not_before\":\"1632746374\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:34.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "28a6e6ba-58b0-4c2b-89ee-09a7b08a1c5c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "bada0a00-633c-433f-a6ff-56e10ef64600"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:33 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:33.560Z",
+        "time": 760,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 760
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "a34a58c9-e10c-40ae-b374-e41b3799936c"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11998"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "135fae01-d21f-46f5-91c8-591038a385ef"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "135fae01-d21f-46f5-91c8-591038a385ef"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T124435Z:135fae01-d21f-46f5-91c8-591038a385ef"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:34 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 593,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:34.326Z",
+        "time": 739,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 739
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "650d57ea-786f-4afa-9e52-9f47f9aa61de"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:44:35+02:00' and eventTimestamp le '2021-09-27T14:44:35+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A44%3A35%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A44%3A35%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FDefaultResourceGroup-CUS%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fregenerateaccesskeytest%27"
+        },
+        "response": {
+          "bodySize": 27501,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 27501,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"e1996591-2700-4c40-b9ff-ebf8bad0fae7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/e1996591-2700-4c40-b9ff-ebf8bad0fae7/ticks/637683129742655982\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"40279215-5610-4fa4-89f0-405b7436c005\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:16:14.2655982Z\",\"submissionTimestamp\":\"2021-09-27T04:17:32.135054Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"5883d6b0-5eee-4c9d-ad2d-4ff594fdc746\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/5883d6b0-5eee-4c9d-ad2d-4ff594fdc746/ticks/637683129571384933\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"a5b002d2-b372-4b40-952a-4a7b0a3a3514\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-27T04:15:57.1384933Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"38134267-7818-43f4-993d-0131dbfac8ab\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/38134267-7818-43f4-993d-0131dbfac8ab/ticks/637683129569535355\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:56.9535355Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"a6756e91-3abe-4431-b98b-912a630b7311\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/a6756e91-3abe-4431-b98b-912a630b7311/ticks/637683129448318219\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"00f3e1ef-04b2-411f-a58e-1f9532f921db\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T04:15:44.8318219Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"584d2154-ac7b-40bd-9794-5bf34a360f24\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/584d2154-ac7b-40bd-9794-5bf34a360f24/ticks/637683129446517689\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:44.6517689Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"a704a2cb-eb4d-4a35-805e-ead94ad19f43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/a704a2cb-eb4d-4a35-805e-ead94ad19f43/ticks/637680001929101036\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"0225ea72-f781-4f6e-9fe5-d6a0c2474557\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:23:12.9101036Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"ee04b008-d832-4d27-a31d-d6477b7c56bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ee04b008-d832-4d27-a31d-d6477b7c56bb/ticks/637680001926901032\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:23:12.6901032Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"47870c69-2372-4d1a-9917-44ee82af3d43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/47870c69-2372-4d1a-9917-44ee82af3d43/ticks/637679999082738446\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"31101762-006a-4ed7-89d9-49ca3036ab80\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:18:28.2738446Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"0bb50929-cabd-4f23-9f59-230d8444fdc2\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/0bb50929-cabd-4f23-9f59-230d8444fdc2/ticks/637679999074987777\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:18:27.4987777Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"9f03ce09-20a6-4d06-95d4-ef9682fe9dcb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9f03ce09-20a6-4d06-95d4-ef9682fe9dcb/ticks/637679990444693037\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4e305746-c740-4588-b06a-7d6040286b8a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:04:04.4693037Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"cafd852a-38ab-43de-9c4e-8ae9d2e0aa39\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cafd852a-38ab-43de-9c4e-8ae9d2e0aa39/ticks/637679990442442997\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:04:04.2442997Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"70e4e7f2-a8fb-42fe-8940-2777f9f0d373\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/70e4e7f2-a8fb-42fe-8940-2777f9f0d373/ticks/637679185425534061\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8d275523-3648-4cb1-9685-2170c4968840\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:22.5534061Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"8777e717-fee0-422a-ae58-7e871fdf0394\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/8777e717-fee0-422a-ae58-7e871fdf0394/ticks/637679185423183513\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:22.3183513Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"28e8a43f-d061-4b3d-b13c-ae0cc610de21\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/28e8a43f-d061-4b3d-b13c-ae0cc610de21/ticks/637679185357882256\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1d0fc11b-5f8a-414e-b58f-a17cf1e90f0f\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:15.7882256Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"d1f38226-b5fc-4ff8-9a00-3093b11f81c0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d1f38226-b5fc-4ff8-9a00-3093b11f81c0/ticks/637679185355782736\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:15.5782736Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac/ticks/637679179809610416\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"47695443-19d5-493e-a4e8-7789b0e60377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:33:00.9610416Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"d0717133-9bd8-40f6-9771-8b3f656b9068\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d0717133-9bd8-40f6-9771-8b3f656b9068/ticks/637679179807409713\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:33:00.7409713Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"62f1c7a0-52d0-47e8-831e-52bb6a043101\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/62f1c7a0-52d0-47e8-831e-52bb6a043101/ticks/637677475939857920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1cc9b1d1-3ad3-4be5-804d-107cff738cd4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:13:13.985792Z\",\"submissionTimestamp\":\"2021-09-20T15:14:24.1932217Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"f0381753-4ff1-45ed-99df-0a0f74f21bb7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/f0381753-4ff1-45ed-99df-0a0f74f21bb7/ticks/637677475660997035\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"446855e9-2947-4f06-9ddb-4249a30ad8e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:12:46.0997035Z\",\"submissionTimestamp\":\"2021-09-20T15:14:11.1254588Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"1813f4e7-9bf6-4710-ac12-489b32de7fd6\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1813f4e7-9bf6-4710-ac12-489b32de7fd6/ticks/637677474240400287\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1608dd41-cc4f-471b-8c4d-3a4393333377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:24.0400287Z\",\"submissionTimestamp\":\"2021-09-20T15:13:05.4897023Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"e0f6b157-a5ea-4c30-948d-5f3b5b30f14a\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e0f6b157-a5ea-4c30-948d-5f3b5b30f14a/ticks/637677474232600486\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:23.2600486Z\",\"submissionTimestamp\":\"2021-09-20T15:12:05.1607741Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"848862b2-56a3-4837-9562-bbd64dad53cc\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/848862b2-56a3-4837-9562-bbd64dad53cc/ticks/637677474228858674\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"90c74ebf-f83f-4196-8840-c20aa40bc0ca\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:22.8858674Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"83c32961-cc44-4648-9186-5d672cf75d83\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/83c32961-cc44-4648-9186-5d672cf75d83/ticks/637677474226509192\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:22.6509192Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"e4c18ff5-a195-41b8-89b0-cab13faa6f27\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e4c18ff5-a195-41b8-89b0-cab13faa6f27/ticks/637677471861822795\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"a40adc80-7e2f-4c2b-9621-5cc901366e2a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:26.1822795Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556/ticks/637677471859722688\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.9722688Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"cf6386d9-e6ab-42bd-9e5a-83cefa4c8199\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cf6386d9-e6ab-42bd-9e5a-83cefa4c8199/ticks/637677471856711620\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ea0187af-8198-4c98-97bd-4220a5bcd942\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.671162Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"b0e07419-dc8f-414f-82cd-53f01df6a401\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b0e07419-dc8f-414f-82cd-53f01df6a401/ticks/637677471854611536\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.4611536Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"d8243a16-ab46-4322-8dea-d563d7f88d39\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d8243a16-ab46-4322-8dea-d563d7f88d39/ticks/637677471851671673\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fb259f93-8cbf-4974-83a9-6862b96eb049\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.1671673Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"6154366b-4323-45a8-b328-4d746d69a1d9\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6154366b-4323-45a8-b328-4d746d69a1d9/ticks/637677471847621619\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"requestbody\":\"{\\\"keyName\\\":\\\"key1\\\"}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:24.7621619Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"2fa63062-2f22-4759-90af-464f8be3b5c3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/2fa63062-2f22-4759-90af-464f8be3b5c3/ticks/637677471779112974\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4b5c0812-a756-4dda-97af-8ba7463e5d4c\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:17.9112974Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"6bd2ac81-1521-409d-ab9f-62a24b0ffd2d\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6bd2ac81-1521-409d-ab9f-62a24b0ffd2d/ticks/637677471777013163\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:17.7013163Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"6f2ead07-65c7-4527-8729-88a168ace6e9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/6f2ead07-65c7-4527-8729-88a168ace6e9/ticks/637677469905184323\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"5095ece2-d23b-4405-9663-0319f48b0234\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:03:10.5184323Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"85385ce4-5123-480f-b5ca-93ad14251b67\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/85385ce4-5123-480f-b5ca-93ad14251b67/ticks/637677469895868920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"257770ea-c767-43e6-8175-a296a4200be4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.586892Z\",\"submissionTimestamp\":\"2021-09-20T15:04:47.0753231Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1eed7870-0320-420b-ba7a-9c8a375031d0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/1eed7870-0320-420b-ba7a-9c8a375031d0/ticks/637677469894434112\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.4434112Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"9e8ec575-53e1-4cdf-aac6-1b6fe831f315\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9e8ec575-53e1-4cdf-aac6-1b6fe831f315/ticks/637677469636227096\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"57dc2ec8-7845-4db5-b514-99690b6a867b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6227096Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"ff1449dd-10cf-4a75-bbfc-f243cc8c63da\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ff1449dd-10cf-4a75-bbfc-f243cc8c63da/ticks/637677469636177088\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"5adc31a9-0f71-4dc9-b0d6-b2b7a3ef6cf0\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6177088Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1fd27944-0a26-4bb1-a0e3-fba30c720db0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1fd27944-0a26-4bb1-a0e3-fba30c720db0/ticks/637677469575072028\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Premium_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":false,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:37.5072028Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_2336f548701d432397781ef80ac0dd01_637683434759143475"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "452ca066-d85c-4fe1-b369-6ca190eaa817"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T124435Z:452ca066-d85c-4fe1-b369-6ca190eaa817"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:35 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:35.083Z",
+        "time": 866,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 866
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -527,12 +1029,12 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "7b7737e3-2205-4d7f-bea1-0f6e05aff748"
+              "value": "808b045a-3f47-47a5-882c-7e1556d2afac"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -554,7 +1056,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 428,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -563,7 +1065,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -574,7 +1076,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-06-04T18:41:03.000Z",
+              "expires": "2021-10-27T12:44:36.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -630,11 +1132,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "ec10a09e-8bb7-495a-a02b-508d7b6a9f00"
+              "value": "febfba5a-4daf-47e2-bb1f-a2f7131a4200"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - WUS2 ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -653,21 +1155,21 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:03 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:35 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 717,
+          "headersSize": 716,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:02.790Z",
-        "time": 243,
+        "startedDateTime": "2021-09-27T12:44:35.998Z",
+        "time": 675,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -675,11 +1177,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 243
+          "wait": 675
         }
       },
       {
-        "_id": "5dbc34c006894f7ce143f08803d3acba",
+        "_id": "12ec0509765fac63d7064f131c7b3918",
         "_order": 0,
         "cache": {},
         "request": {
@@ -694,12 +1196,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "e9876bf9-edaa-4324-87d0-66040030ca44"
+              "value": "885d29ab-320d-424f-b37d-4414fa0e612f"
             },
             {
               "_fromType": "array",
@@ -718,10 +1220,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.blob.core.windows.net"
+              "value": "regenerateaccesskeytest.blob.core.windows.net"
             }
           ],
-          "headersSize": 1586,
+          "headersSize": 1615,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -734,24 +1236,20 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1dev.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://regenerateaccesskeytest.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 805,
+          "bodySize": 236,
           "content": {
-            "mimeType": "application/xml",
-            "size": 805,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+            "mimeType": "text/plain",
+            "size": 236,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
+              "name": "content-length",
+              "value": "236"
             },
             {
               "name": "server",
@@ -759,29 +1257,29 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "3af91492-c01e-00f5-24de-41d815000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "e9876bf9-edaa-4324-87d0-66040030ca44"
+              "value": "5b59106a-101c-00e1-2e9d-b305c7000000"
             },
             {
               "name": "x-ms-version",
               "value": "2020-06-12"
             },
             {
+              "name": "x-ms-client-request-id",
+              "value": "885d29ab-320d-424f-b37d-4414fa0e612f"
+            },
+            {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:03 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:36 GMT"
             }
           ],
-          "headersSize": 295,
+          "headersSize": 257,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:03.040Z",
-        "time": 843,
+        "startedDateTime": "2021-09-27T12:44:36.686Z",
+        "time": 653,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -789,11 +1287,168 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 843
+          "wait": 653
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "519df192-3c5e-4573-9d4d-db0f95740190"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:44:37+02:00' and eventTimestamp le '2021-09-27T14:44:37+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A44%3A37%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A44%3A37%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_SQL_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fsqlvab7pt3ww5qhmdw%27"
+        },
+        "response": {
+          "bodySize": 12761,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 12761,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"1bf92f9b-047b-4228-84df-7c2ed64bacdf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/1bf92f9b-047b-4228-84df-7c2ed64bacdf/ticks/637679941964644382\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46f46d72-c836-4fb5-81df-39d87ee35361\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:43:16.4644382Z\",\"submissionTimestamp\":\"2021-09-23T11:45:03.183974Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0/ticks/637679941750596914\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"'audit' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"e4bbfd9b-2399-4547-bc1b-72028b20383d\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/e4bbfd9b-2399-4547-bc1b-72028b20383d/ticks/637679941750596914\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"'auditIfNotExists' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"5e859926-06ba-422b-b976-128ae719d9c5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/5e859926-06ba-422b-b976-128ae719d9c5/ticks/637679941731506587\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"3d667eff-b604-4b94-9aa0-f6ae6b20cd2e\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:53.1506587Z\",\"submissionTimestamp\":\"2021-09-23T11:43:29.1239763Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44a7cc1c-09a5-408a-bb6d-7159bd091493\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/44a7cc1c-09a5-408a-bb6d-7159bd091493/ticks/637679936036356606\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"57d231f9-c955-4a39-81a7-e0ca1179c7c3\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T11:33:23.6356606Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1880622Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"c997130c-e08c-4218-8c43-b292200e4d82\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/c997130c-e08c-4218-8c43-b292200e4d82/ticks/637679936001153487\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"scope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:20.1153487Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1860603Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"db28785d-d234-4156-85d1-f93663a89aa7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/db28785d-d234-4156-85d1-f93663a89aa7/ticks/637679935941633332\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1645c04a-9f69-472c-8224-c5be3334796c\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:14.1633332Z\",\"submissionTimestamp\":\"2021-09-23T11:34:50.1441225Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"685222b6-8e45-4a6f-9116-77895f3c68eb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/685222b6-8e45-4a6f-9116-77895f3c68eb/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"5f9205a3-3c45-4db5-abf6-4cbba8b09865\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d4290f0f-f81f-48ff-8d26-686074ca277a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d4290f0f-f81f-48ff-8d26-686074ca277a/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"463cb640-befe-45af-b4d7-b5470a837a59\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"b821643d-9081-4a4b-a57c-2f8ca07b7002\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/b821643d-9081-4a4b-a57c-2f8ca07b7002/ticks/637679935726410258\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:52.6410258Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"dab4de05-9d1d-41af-bda7-78b884be52d5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/dab4de05-9d1d-41af-bda7-78b884be52d5/ticks/637679935680160357\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/2a1a9cdf-e04d-429a-8416-3bfb72a1b26f/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountsShouldRestrictNetworkAccessUsingVirtualNetworkRulesMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\\\",\\\"policyDefinitionEffect\\\":\\\"Audit\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:48.0160357Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d5d150f2-829f-42ea-8a70-cb7aead80689\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d5d150f2-829f-42ea-8a70-cb7aead80689/ticks/637679935679959308\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":\\\"true\\\",\\\"allowBlobPublicAccess\\\":\\\"false\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:47.9959308Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_8b40744ae6944c5bb13d6fa01fbbb812_637683434782124789"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "d0a62efe-4b54-4cb9-9bdc-fa8bbfcf77dd"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T124438Z:d0a62efe-4b54-4cb9-9bdc-fa8bbfcf77dd"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:37 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:37.372Z",
+        "time": 887,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 887
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 1,
         "cache": {},
         "request": {
@@ -818,17 +1473,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5b93818b-b29b-4292-b29e-c9d446e090cf"
+              "value": "faaea0d0-ca87-4159-acf5-c28e54f1ccda"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": "fpc=Au5eMJqK-6FDvnXEo5TG6xsRsITIAQAAAL7dJNgOAAAA"
+              "value": ""
             },
             {
               "_fromType": "array",
@@ -845,7 +1500,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 476,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -854,7 +1509,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -865,7 +1520,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-06-04T18:41:04.000Z",
+              "expires": "2021-10-27T12:44:38.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -925,11 +1580,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "32bcaf10-d6b9-4603-824b-acb3fee54400"
+              "value": "83571b6a-3b90-4dfe-9428-7fbc96c44700"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - NCUS ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -948,17 +1603,17 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:03 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:38 GMT"
             }
           ],
-          "headersSize": 717,
+          "headersSize": 716,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:03.900Z",
-        "time": 102,
+        "startedDateTime": "2021-09-27T12:44:38.271Z",
+        "time": 663,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -966,11 +1621,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 102
+          "wait": 663
         }
       },
       {
-        "_id": "af6a01d1852c557b688492da54e4f9fe",
+        "_id": "155a15bd9bc9daa4c43589a03bdf5d4b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -984,18 +1639,13 @@
             },
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "application/xml"
-            },
-            {
-              "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "65ff78cb-d49b-49d6-83d5-37c0ab969daa"
+              "value": "815b4e8e-a0fb-4848-8950-b4ff4c0682b4"
             },
             {
               "_fromType": "array",
@@ -1009,15 +1659,15 @@
             },
             {
               "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "accept",
+              "value": "*/*"
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.queue.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.blob.core.windows.net"
             }
           ],
-          "headersSize": 1643,
+          "headersSize": 1605,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1028,27 +1678,19 @@
             {
               "name": "comp",
               "value": "properties"
-            },
-            {
-              "name": "timeout",
-              "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1dev.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+          "url": "https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 626,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/xml",
-            "size": 626,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+            "size": 749,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
             {
               "name": "transfer-encoding",
               "value": "chunked"
@@ -1059,15 +1701,15 @@
             },
             {
               "name": "server",
-              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
             },
             {
               "name": "x-ms-request-id",
-              "value": "e6cd4a93-4003-00a6-30de-41fb21000000"
+              "value": "615c6b2e-201e-0082-6a9d-b3d6d8000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "65ff78cb-d49b-49d6-83d5-37c0ab969daa"
+              "value": "815b4e8e-a0fb-4848-8950-b4ff4c0682b4"
             },
             {
               "name": "x-ms-version",
@@ -1075,17 +1717,17 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:03 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:39 GMT"
             }
           ],
-          "headersSize": 321,
+          "headersSize": 295,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:04.007Z",
-        "time": 151,
+        "startedDateTime": "2021-09-27T12:44:38.943Z",
+        "time": 562,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1093,11 +1735,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 151
+          "wait": 562
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 2,
         "cache": {},
         "request": {
@@ -1122,17 +1764,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "ec45fb8f-eb33-4144-ac7b-5a072736f09d"
+              "value": "f700bf8a-5c83-481c-87a5-9769e711e63e"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": ""
+              "value": "fpc=ApzFsdSOKzhOjdddWwUkVDY-ExxYAQAAALWz49gOAAAA"
             },
             {
               "_fromType": "array",
@@ -1149,7 +1791,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 428,
+          "headersSize": 485,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1158,7 +1800,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -1169,298 +1811,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-06-04T18:41:04.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "0fbd9ce1-70f3-41e4-adce-118da7bc5200"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - EUS ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
-            }
-          ],
-          "headersSize": 716,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:04.183Z",
-        "time": 214,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 214
-        }
-      },
-      {
-        "_id": "ee4f6ed8f5c33ad8b5cafac8001e69f6",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "9bd86bf7-7761-45da-84d3-8763b4c244bc"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmon1j1devblobstorage.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1608,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmon1j1devblobstorage.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 651,
-          "content": {
-            "mimeType": "application/xml",
-            "size": 651,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "4c0a6a7d-d01e-0086-74de-41a21f000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "9bd86bf7-7761-45da-84d3-8763b4c244bc"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
-            }
-          ],
-          "headersSize": 295,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:04.402Z",
-        "time": 145,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 145
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 3,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "5d2a84c0-f543-428c-8739-2ba33ae46c6e"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 428,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:04.000Z",
+              "expires": "2021-10-27T12:44:40.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1516,11 +1867,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "7ce5f1b8-18b1-4635-a16e-8f04b52b4300"
+              "value": "15e761f4-4265-46e6-ac53-bad5ac6a8500"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - NCUS ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1539,7 +1890,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:39 GMT"
             },
             {
               "name": "content-length",
@@ -1552,8 +1903,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:04.554Z",
-        "time": 226,
+        "startedDateTime": "2021-09-27T12:44:39.531Z",
+        "time": 727,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1561,593 +1912,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 226
+          "wait": 727
         }
       },
       {
-        "_id": "15a643201034c8f86afac99f8a433004",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "d0b1c6dd-36b4-47dc-beea-0ba215720d75"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmonblob.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1582,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmonblob.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 706,
-          "content": {
-            "mimeType": "application/xml",
-            "size": 706,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "138f3bcb-a01e-0006-1bde-414870000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "d0b1c6dd-36b4-47dc-beea-0ba215720d75"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
-            }
-          ],
-          "headersSize": 295,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:04.783Z",
-        "time": 127,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 127
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 4,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "05002881-4ded-459b-8429-49483674b5e0"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 428,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:05.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "d669f644-cba3-4f16-a219-0bed6cf6a100"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - WUS2 ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            }
-          ],
-          "headersSize": 717,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:04.917Z",
-        "time": 227,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 227
-        }
-      },
-      {
-        "_id": "d5fd3fd1e95e7d543dc6a5c6c9f71be3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "be4443c5-5137-48e8-85c5-5140ff9f0502"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmonstoragev1.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1592,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmonstoragev1.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 694,
-          "content": {
-            "mimeType": "application/xml",
-            "size": 694,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "94e0791f-801e-0035-23de-418cea000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "be4443c5-5137-48e8-85c5-5140ff9f0502"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
-            }
-          ],
-          "headersSize": 295,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:05.151Z",
-        "time": 196,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 196
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 5,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "aad17c27-cff2-4904-ac80-5cfb63ac0192"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": "fpc=AmmurI9u8ixOqwBvGtAQqQ0RsITIAQAAAMHdJNgOAAAA"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 476,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:05.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "05989990-5535-4460-a70a-7ff015a05200"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - EUS ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            }
-          ],
-          "headersSize": 716,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:05.356Z",
-        "time": 104,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 104
-        }
-      },
-      {
-        "_id": "4c3bdec717e797cdef142cf123c35fb2",
+        "_id": "8bb93cbc2d87e49d3993a0fdc741e834",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2167,12 +1936,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "e15d5204-5dc7-45d2-a204-e931c6e25a68"
+              "value": "171c2e71-bdc5-445c-9c31-ffa7ab612322"
             },
             {
               "_fromType": "array",
@@ -2191,10 +1960,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmonstoragev1.queue.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.queue.core.windows.net"
             }
           ],
-          "headersSize": 1649,
+          "headersSize": 1662,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2211,7 +1980,7 @@
               "value": "30"
             }
           ],
-          "url": "https://ndowmonstoragev1.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+          "url": "https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
         },
         "response": {
           "bodySize": 573,
@@ -2240,11 +2009,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "7a7fbe78-2003-0095-7dde-41084b000000"
+              "value": "9c0a2817-7003-0019-669d-b317dd000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "e15d5204-5dc7-45d2-a204-e931c6e25a68"
+              "value": "171c2e71-bdc5-445c-9c31-ffa7ab612322"
             },
             {
               "name": "x-ms-version",
@@ -2252,7 +2021,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:04 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:40 GMT"
             }
           ],
           "headersSize": 321,
@@ -2261,8 +2030,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:05.464Z",
-        "time": 119,
+        "startedDateTime": "2021-09-27T12:44:40.264Z",
+        "time": 614,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2270,26 +2039,21 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 119
+          "wait": 614
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 6,
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 2,
         "cache": {},
         "request": {
-          "bodySize": 194,
+          "bodySize": 0,
           "cookies": [],
           "headers": [
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
               "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
@@ -2299,179 +2063,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "8d5968d3-dcf9-4b9c-8685-8ae10aeb1d92"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 428,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:05.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "512f28c3-c64b-49d2-9b3c-61b02c2e5400"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - SCUS ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            }
-          ],
-          "headersSize": 717,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:05.589Z",
-        "time": 232,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 232
-        }
-      },
-      {
-        "_id": "a5130843cae6cc95799b9b8fae8443d8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "7753f998-a072-4f0a-9fb6-26c118a2727e"
+              "value": "84890eb4-c9e8-46bf-8f3a-5c55017e1ed8"
             },
             {
               "_fromType": "array",
@@ -2480,593 +2072,8 @@
             },
             {
               "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmonstoragev1premium.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1606,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmonstoragev1premium.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 223,
-          "content": {
-            "mimeType": "text/plain",
-            "size": 223,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-length",
-              "value": "223"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "0eb46aff-701c-008e-5ede-418f1d000000"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "7753f998-a072-4f0a-9fb6-26c118a2727e"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            }
-          ],
-          "headersSize": 257,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:05.825Z",
-        "time": 160,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 160
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 7,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "8fcb5021-dc95-4782-a49e-73195577dbd1"
-            },
-            {
-              "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 428,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:06.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "c2dac948-81db-4c79-b502-a3f7739e5600"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - SCUS ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:06 GMT"
-            }
-          ],
-          "headersSize": 717,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:05.991Z",
-        "time": 186,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 186
-        }
-      },
-      {
-        "_id": "274f1c82e1c869b6762bde266c52f7a0",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v12.21.0; Darwin 20.3.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "8eeabdae-549e-4a96-98b5-1e0d664e48bd"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "host",
-              "value": "ndowmonstoragev2.blob.core.windows.net"
-            }
-          ],
-          "headersSize": 1592,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            }
-          ],
-          "url": "https://ndowmonstoragev2.blob.core.windows.net/?restype=service&comp=properties"
-        },
-        "response": {
-          "bodySize": 223,
-          "content": {
-            "mimeType": "text/plain",
-            "size": 223,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-length",
-              "value": "223"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a439de86-e01c-00e6-3ede-416acd000000"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "8eeabdae-549e-4a96-98b5-1e0d664e48bd"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            }
-          ],
-          "headersSize": 257,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:06.181Z",
-        "time": 160,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 160
-        }
-      },
-      {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "26514e93-59d9-4796-90f9-1efa5837027e"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1620243666\",\"not_before\":\"1620239766\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-06-04T18:41:06.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "26514e93-59d9-4796-90f9-1efa5837027e"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "a976de94-86b9-487a-bb9a-0f3ba4994200"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11654.25 - NCUS ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Wed, 05 May 2021 18:41:05 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 787,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-05-05T18:41:06.348Z",
-        "time": 216,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 216
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "915cfe51-6e38-46dd-8086-de6502fc7765"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -3093,7 +2100,1699 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1677,
+          "headersSize": 2177,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:44:40+02:00' and eventTimestamp le '2021-09-27T14:44:40+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A44%3A40%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A44%3A40%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_Storage_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstefanexamplestorage%27"
+        },
+        "response": {
+          "bodySize": 16299,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16299,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713/ticks/637680751208063831\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"9f9c4957-cbe0-4829-8e91-6ef594969333\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-24T10:12:00.8063831Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"8903f8d4-7a4c-456d-be34-33660212b2bd\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/8903f8d4-7a4c-456d-be34-33660212b2bd/ticks/637680751206863840\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T10:12:00.686384Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"927daf50-bb12-4bb1-960e-005dd0196385\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/927daf50-bb12-4bb1-960e-005dd0196385/ticks/637680036884982412\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"2fbc6389-ef5b-43c4-8771-5500d31026d5\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created (HTTP Status Code: 201)\"},\"eventTimestamp\":\"2021-09-23T14:21:28.4982412Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"f60bee7d-a7ea-4f59-9d88-658fafc85b1f\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/f60bee7d-a7ea-4f59-9d88-658fafc85b1f/ticks/637680036855632564\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T14:21:25.5632564Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0dde252b-5665-4e8a-a936-4daba0d8a575\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0dde252b-5665-4e8a-a936-4daba0d8a575/ticks/637677468635548611\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"b1001d0c-e882-4506-b8ab-9163d906f654\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:01:03.5548611Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0842ad8b-0a70-4ce5-8652-a7f2114e8000\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0842ad8b-0a70-4ce5-8652-a7f2114e8000/ticks/637677468633347789\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:01:03.3347789Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a/ticks/637666178855994320\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"2bc25043-553e-48b1-ad9b-ce9926416ca9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:45.599432Z\",\"submissionTimestamp\":\"2021-09-07T13:26:18.0982287Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b1dc8c9d-57e9-422f-b6b6-a2ab4089845e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/b1dc8c9d-57e9-422f-b6b6-a2ab4089845e/ticks/637666178612856613\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"06c3da4c-be9c-4b9c-9bb1-c29b06dc2943\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:21.2856613Z\",\"submissionTimestamp\":\"2021-09-07T13:25:26.1292429Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"fa96b680-b3f9-471c-a777-a69da710ac89\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/fa96b680-b3f9-471c-a777-a69da710ac89/ticks/637666172866182094\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ce0cce81-7af2-48c6-b614-da08e1048548\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.6182094Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"138520b9-0d15-4108-98e6-b26cfcaed86c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/138520b9-0d15-4108-98e6-b26cfcaed86c/ticks/637666172864682093\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:46.4682093Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b49bfb26-b7bd-488b-bf76-f4891ad74605\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/b49bfb26-b7bd-488b-bf76-f4891ad74605/ticks/637666172863682069\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"22765ce3-92ae-4aed-954d-7f26ab018c84\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.3682069Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"575b58d7-a757-4a45-aebe-40195806a39c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/575b58d7-a757-4a45-aebe-40195806a39c/ticks/637666172849132353\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:44.9132353Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"870fddbd-ee80-4254-b798-ab2e71de1de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/870fddbd-ee80-4254-b798-ab2e71de1de1/ticks/637666172832824197\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c6e734b2-12f7-4965-8ec4-f7feb27666b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:43.2824197Z\",\"submissionTimestamp\":\"2021-09-07T13:15:26.1178018Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"4e08dab9-10e0-49d3-abf6-4a61f7315de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4e08dab9-10e0-49d3-abf6-4a61f7315de1/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"75ec2246-b3ed-4a2a-8d99-85232ae352cd\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"f5231d65-9872-4ab7-82fa-030783fd80bd\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/f5231d65-9872-4ab7-82fa-030783fd80bd/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d1f0bd9a-7d00-4270-8164-a37d77ad40a8\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e50013de-1290-4050-945c-edd8ac16b016\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e50013de-1290-4050-945c-edd8ac16b016/ticks/637666172560836200\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_RAGRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"accessTier\\\":\\\"Hot\\\",\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":true,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:16.08362Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1731361Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_e26a59a6a18b4b71a8896edebf324dc4_637683434817772780"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "f6b4bbcf-e3fc-4e47-8cc3-69dc87f551f5"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T124441Z:f6b4bbcf-e3fc-4e47-8cc3-69dc87f551f5"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:40 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:40.890Z",
+        "time": 916,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 916
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "6491231c-0a99-4496-bde0-17f9036363b0"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:42.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "edfc395d-34ba-4e68-a7c8-6acb95264700"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:42 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:41.818Z",
+        "time": 729,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 729
+        }
+      },
+      {
+        "_id": "396844fb10796ff14cd9ef4c38881321",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "864dc6f1-6d93-4b67-8a17-675a9c4acd53"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1609,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://stefanexamplestorage.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 762,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 762,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3d3900b0-801e-003e-4b9d-b3874b000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "864dc6f1-6d93-4b67-8a17-675a9c4acd53"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:43 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:42.552Z",
+        "time": 611,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 611
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "e151e529-372b-41a5-be0b-2e5524264aee"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=AqaEqrWMNqhLpxDKgmXXwK0-ExxYAQAAALmz49gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:43.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "358762aa-6108-4b57-a0d9-83a5984d5500"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:43 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:43.169Z",
+        "time": 569,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 569
+        }
+      },
+      {
+        "_id": "35a194af62cb1877e4f3a2940d92adfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "a77464f2-0e50-4c3e-b826-c3da6ed8243f"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1666,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://stefanexamplestorage.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "73e40872-9003-0050-369d-b3d264000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "a77464f2-0e50-4c3e-b826-c3da6ed8243f"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:43 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:43.743Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5d3261fd-233a-4589-9b48-66a3e728dce5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:44:44+02:00' and eventTimestamp le '2021-09-27T14:44:44+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A44%3A44%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A44%3A44%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_AppServices_Group%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstorageaccountstefaafb8%27"
+        },
+        "response": {
+          "bodySize": 16495,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16495,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"71d2ca88-e069-4418-a9a1-5e61fa4e29e7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/71d2ca88-e069-4418-a9a1-5e61fa4e29e7/ticks/637683118197796970\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fc21cc29-04bb-4c52-bd10-09f62bdcc345\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.779697Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022/ticks/637683118197546829\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7546829Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"34858c5b-8c5d-4884-b748-2ab3d59bd78b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/34858c5b-8c5d-4884-b748-2ab3d59bd78b/ticks/637683118197378385\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8b8be42f-bfef-4507-95f6-ccd2a0bfca45\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7378385Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"cb12a0cf-8b0e-494b-a483-05cc8e2af298\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/cb12a0cf-8b0e-494b-a483-05cc8e2af298/ticks/637683118197028379\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7028379Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"9ab0273f-4168-420b-a82a-04a95ef004b9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/9ab0273f-4168-420b-a82a-04a95ef004b9/ticks/637680895404911980\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"e3e29761-cb4f-44b6-9c21-c4bef3490d74\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-24T14:12:20.491198Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"f3127244-2903-49eb-8290-896fb807e4bf\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f3127244-2903-49eb-8290-896fb807e4bf/ticks/637680895402811842\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T14:12:20.2811842Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"f4c0ba23-4f98-4def-837e-c8de0728547e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f4c0ba23-4f98-4def-837e-c8de0728547e/ticks/637680004888576312\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ccd64de2-9c2f-4578-8496-5808bf5ae478\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:28:08.8576312Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1600853Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"abee07ad-735f-4daf-a00b-dbcb2420491c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/abee07ad-735f-4daf-a00b-dbcb2420491c/ticks/637680004886626307\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:28:08.6626307Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1590849Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"609c11d9-f767-47fc-b7f6-2b01de6df6d3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/609c11d9-f767-47fc-b7f6-2b01de6df6d3/ticks/637680004138311948\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"aa7000e2-9f8d-45c0-8eaf-ab889d7022c8\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:26:53.8311948Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"f7bd6f5d-a4a6-459f-b677-7cc6aef350bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f7bd6f5d-a4a6-459f-b677-7cc6aef350bb/ticks/637680004131562335\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:26:53.1562335Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"95e08496-5682-44b1-aa43-bc8364b7f678\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/95e08496-5682-44b1-aa43-bc8364b7f678/ticks/637674012546036667\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"188d14f7-04dd-4948-acb1-1216172a19c3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:54.6036667Z\",\"submissionTimestamp\":\"2021-09-16T15:01:46.1692025Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"8a01ea00-bd83-41d8-8de7-bc51b80d4652\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/8a01ea00-bd83-41d8-8de7-bc51b80d4652/ticks/637674012295717803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"99bdf78f-4602-4a8c-83b4-19ed0c0e9cd1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:29.5717803Z\",\"submissionTimestamp\":\"2021-09-16T15:01:53.1386235Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"b30ffc87-ee15-41e7-81c0-0fb4b05895ff\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/b30ffc87-ee15-41e7-81c0-0fb4b05895ff/ticks/637674006534406250\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"3113ca2b-d2bc-4f4f-9a8f-89c167e9218a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-16T14:50:53.440625Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"01af52fc-5b12-4703-98b4-cc67db95435e\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/01af52fc-5b12-4703-98b4-cc67db95435e/ticks/637674006528456482\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:52.8456482Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"cf10aecf-4960-4246-8021-a91b9767a6ee\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/cf10aecf-4960-4246-8021-a91b9767a6ee/ticks/637674006518718327\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ce1ef8-dabe-4c1b-a7f3-06409c83d4e5\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:51.8718327Z\",\"submissionTimestamp\":\"2021-09-16T14:52:09.1184465Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"18d6742e-9780-4410-87f2-7861ad8ebcaf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/18d6742e-9780-4410-87f2-7861ad8ebcaf/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46e3061f-4966-444c-8a1a-5fcc9c793c50\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"e279382a-ca7b-4fb4-bca3-d72bbacb841b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/e279382a-ca7b-4fb4-bca3-d72bbacb841b/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"36894b22-1fe1-4514-a797-ba687ae30306\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"0ee36506-e3f0-4f97-9a2f-deccfc7f3576\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/0ee36506-e3f0-4f97-9a2f-deccfc7f3576/ticks/637674006235104764\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"location\\\":\\\"Central US\\\",\\\"properties\\\":{\\\"supportsHttpsTrafficOnly\\\":true,\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:23.5104764Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.1747877Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_295ddf4809b44ba3b9a1cb21263169ba_637683434852809978"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "de5b2922-9647-4874-b227-6c9d6bcf333f"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T124445Z:de5b2922-9647-4874-b227-6c9d6bcf333f"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:44 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:44.316Z",
+        "time": 992,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 992
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "395b1955-de26-42df-b870-b1cd3a5d0b28"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:45.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fabac303-62f3-4eb5-bdad-0ace32134d00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:45 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:45.319Z",
+        "time": 699,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 699
+        }
+      },
+      {
+        "_id": "11cca1bdf5f08f97880274f522d9c376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "6b1a1017-1aa8-4ae9-9f08-bdd4a91e7ec3"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1615,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 694,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 694,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "ea7b6688-c01e-0044-479d-b3750b000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "6b1a1017-1aa8-4ae9-9f08-bdd4a91e7ec3"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:45 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:46.023Z",
+        "time": 688,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 688
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "b8cdfb88-131e-4ba6-8601-b3b3a4f7df87"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=Ag34j8YByEhOjg4XdOmsg10-ExxYAQAAAL2z49gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:47.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "09eb09d3-d758-4e2e-8ec4-69744adb4800"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - EUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:46 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 716,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:46.722Z",
+        "time": 450,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 450
+        }
+      },
+      {
+        "_id": "dd3d6e3698ab7e26997ca5b4d8d2d5d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9ede2288-6101-4cf0-b1e5-2d7c6f3fe094"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1672,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e079ce4b-f003-0021-289d-b3c456000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "9ede2288-6101-4cf0-b1e5-2d7c6f3fe094"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:52 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:47.176Z",
+        "time": 5839,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5839
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "7a78db33-0b04-4b12-afc2-e7d497ba247c"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750293\",\"not_before\":\"1632746393\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:44:53.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "7a78db33-0b04-4b12-afc2-e7d497ba247c"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7479681a-c0f3-449e-a2f8-af8094955300"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:44:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:44:53.020Z",
+        "time": 560,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 560
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "2ed21865-5a45-4990-824f-23ba522cdc15"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -3105,11 +3804,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -3139,15 +3838,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "67afda5f-350f-49c2-afc8-ba2b0e835e10"
+              "value": "9d94075f-e259-4c11-801e-c6b7e9a27485"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "67afda5f-350f-49c2-afc8-ba2b0e835e10"
+              "value": "9d94075f-e259-4c11-801e-c6b7e9a27485"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210505T184106Z:67afda5f-350f-49c2-afc8-ba2b0e835e10"
+              "value": "GERMANYWESTCENTRAL:20210927T124454Z:9d94075f-e259-4c11-801e-c6b7e9a27485"
             },
             {
               "name": "strict-transport-security",
@@ -3159,7 +3858,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:06 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:54 GMT"
             },
             {
               "name": "connection",
@@ -3167,17 +3866,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:06.568Z",
-        "time": 261,
+        "startedDateTime": "2021-09-27T12:44:53.583Z",
+        "time": 795,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3185,11 +3884,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 261
+          "wait": 795
         }
       },
       {
-        "_id": "ecb5f2d6ed34cb5f680e033b754bca17",
+        "_id": "b18dcf356b173b0dd715044ed8c17edd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -3209,7 +3908,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "8f73fb02-414e-4abd-9944-38c1c0052024"
+              "value": "4d48686f-8821-4546-9bc5-c4ddb83e64da"
             },
             {
               "_fromType": "array",
@@ -3219,7 +3918,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v12.21.0 OS/(x64-Darwin-20.3.0)"
+              "value": "@azure/arm-network/20.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -3246,7 +3945,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1829,
+          "headersSize": 1857,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -3255,14 +3954,14 @@
               "value": "2019-12-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/privateEndpoints?api-version=2019-12-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints?api-version=2019-12-01"
         },
         "response": {
-          "bodySize": 1471,
+          "bodySize": 1575,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1471,
-            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"j1dev\",\r\n      \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/privateEndpoints/j1dev\",\r\n      \"etag\": \"W/\\\"5deb1672-31ab-4267-9c9f-b81870edb6b2\\\"\",\r\n      \"type\": \"Microsoft.Network/privateEndpoints\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"0401f021-66e5-4c10-a4bd-271605d06f4a\",\r\n        \"privateLinkServiceConnections\": [\r\n          {\r\n            \"name\": \"j1dev\",\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/privateEndpoints/j1dev/privateLinkServiceConnections/j1dev\",\r\n            \"etag\": \"W/\\\"5deb1672-31ab-4267-9c9f-b81870edb6b2\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateLinkServiceId\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\r\n              \"groupIds\": [\r\n                \"blob\"\r\n              ],\r\n              \"privateLinkServiceConnectionState\": {\r\n                \"status\": \"Approved\",\r\n                \"description\": \"Auto-Approved\",\r\n                \"actionsRequired\": \"None\"\r\n              }\r\n            },\r\n            \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n          }\r\n        ],\r\n        \"manualPrivateLinkServiceConnections\": [],\r\n        \"subnet\": {\r\n          \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/virtualNetworks/j1dev/subnets/j1dev\"\r\n        },\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\": \"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Network/networkInterfaces/j1dev.nic.d1ed3f5a-4558-49f1-a29f-b78665579c7e\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+            "size": 1575,
+            "text": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"private-endpoint\",\r\n      \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints/private-endpoint\",\r\n      \"etag\": \"W/\\\"0ff4824b-48ff-46d6-b63a-a7f31b85befc\\\"\",\r\n      \"type\": \"Microsoft.Network/privateEndpoints\",\r\n      \"location\": \"centralus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"b047591d-97b9-4b1a-8213-7c714c7f0caa\",\r\n        \"privateLinkServiceConnections\": [\r\n          {\r\n            \"name\": \"private-endpoint\",\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints/private-endpoint/privateLinkServiceConnections/private-endpoint\",\r\n            \"etag\": \"W/\\\"0ff4824b-48ff-46d6-b63a-a7f31b85befc\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateLinkServiceId\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\r\n              \"groupIds\": [\r\n                \"blob\"\r\n              ],\r\n              \"privateLinkServiceConnectionState\": {\r\n                \"status\": \"Approved\",\r\n                \"description\": \"Auto-Approved\",\r\n                \"actionsRequired\": \"None\"\r\n              }\r\n            },\r\n            \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n          }\r\n        ],\r\n        \"manualPrivateLinkServiceConnections\": [],\r\n        \"subnet\": {\r\n          \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/virtualNetworks/sample-vn/subnets/default\"\r\n        },\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\": \"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/networkInterfaces/private-endpoint.nic.7d42a76d-176a-4aea-8665-9d9e85b5058c\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
           },
           "cookies": [],
           "headers": [
@@ -3288,15 +3987,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "10b4e8c9-bcac-4d48-9d4f-08ce5d4ee1f7"
+              "value": "b83366de-e2b2-42e0-80df-f20e31fa160a"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "c7240aa1-0d90-4303-bef1-5e67970bbed1"
+              "value": "5cd25ea8-dfc6-4804-a5f0-52f2f9620f26"
             },
             {
               "name": "x-ms-arm-service-request-id",
-              "value": "f57ecc9d-4f61-4a1f-9928-9bcc11c45ab7"
+              "value": "eabc196b-84ac-4350-88d7-8d8dc03f0366"
             },
             {
               "name": "strict-transport-security",
@@ -3312,7 +4011,7 @@
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210505T184107Z:c7240aa1-0d90-4303-bef1-5e67970bbed1"
+              "value": "GERMANYWESTCENTRAL:20210927T124454Z:5cd25ea8-dfc6-4804-a5f0-52f2f9620f26"
             },
             {
               "name": "x-content-type-options",
@@ -3320,21 +4019,21 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:41:06 GMT"
+              "value": "Mon, 27 Sep 2021 12:44:54 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 695,
+          "headersSize": 704,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:41:06.834Z",
-        "time": 369,
+        "startedDateTime": "2021-09-27T12:44:54.385Z",
+        "time": 631,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3342,7 +4041,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 369
+          "wait": 631
         }
       }
     ],

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -1314,10 +1314,16 @@ describe('rm-network-private-endpoint-resource-relationships', () => {
 
   async function getSetupEntities(config: IntegrationConfig) {
     const accountEntity = getMockAccountEntity(config);
-    const resourceGroupEntity = getMockResourceGroupEntity('j1dev');
+    const resourceGroupEntity = getMockResourceGroupEntity(
+      'DefaultResourceGroup-CUS',
+    );
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [accountEntity, resourceGroupEntity],
       setData: {
         [ACCOUNT_ENTITY_TYPE]: accountEntity,
@@ -1333,13 +1339,13 @@ describe('rm-network-private-endpoint-resource-relationships', () => {
     const privateEndpointEntities = context.jobState.collectedEntities.filter(
       (e) => e._type === NetworkEntities.PRIVATE_ENDPOINT._type,
     );
-    const j1devPrivateEndpointEntities = privateEndpointEntities.filter(
-      (e) => e.name === 'j1dev',
+    const examplePrivateEndpointEntities = privateEndpointEntities.filter(
+      (e) => e.name === 'private-endpoint',
     );
-    expect(j1devPrivateEndpointEntities).toHaveLength(1);
+    expect(examplePrivateEndpointEntities).toHaveLength(1);
 
     return {
-      privateEndpointEntity: j1devPrivateEndpointEntities[0],
+      privateEndpointEntity: examplePrivateEndpointEntities[0],
       storageAccountEntities,
     };
   }
@@ -1349,7 +1355,15 @@ describe('rm-network-private-endpoint-resource-relationships', () => {
       directory: __dirname,
       name: 'rm-network-private-endpoint-resource-relationships',
       options: {
-        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        matchRequestsBy: getMatchRequestsBy({
+          config: configFromEnv,
+          options: {
+            headers: false,
+            url: {
+              query: false,
+            },
+          },
+        }),
       },
     });
 
@@ -1359,7 +1373,11 @@ describe('rm-network-private-endpoint-resource-relationships', () => {
     } = await getSetupEntities(configFromEnv);
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [...storageAccountEntities, privateEndpointEntity],
     });
 
@@ -1553,7 +1571,15 @@ describe('rm-network-flow-logs', () => {
       directory: __dirname,
       name: 'rm-network-flow-logs',
       options: {
-        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        matchRequestsBy: getMatchRequestsBy({
+          config: configFromEnv,
+          options: {
+            headers: false,
+            url: {
+              query: false,
+            },
+          },
+        }),
       },
     });
 
@@ -1562,10 +1588,18 @@ describe('rm-network-flow-logs', () => {
       networkWatcherEntities,
       securityGroupEntities,
       storageAccountEntities,
-    } = await getSetupEntities(configFromEnv);
+    } = await getSetupEntities({
+      ...configFromEnv,
+      directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+      subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+    });
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [
         ...networkWatcherEntities,
         ...securityGroupEntities,

--- a/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-accounts_690738595/recording.har
+++ b/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-accounts_690738595/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -59,18 +59,18 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
-          "bodySize": 1615,
+          "bodySize": 1671,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1615,
+            "size": 1671,
             "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:06.000Z",
+              "expires": "2021-10-26T12:31:56.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -105,10 +105,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1615"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -130,11 +126,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "2ed22f7a-f1cc-4bfa-8ce7-03af3f872200"
+              "value": "a446a0ef-572a-47cb-9b0a-b3c96aa41c00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.15 - NCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -153,21 +149,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:05 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:55 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1671"
             }
           ],
-          "headersSize": 731,
+          "headersSize": 736,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:05.999Z",
-        "time": 238,
+        "startedDateTime": "2021-09-26T12:31:55.220Z",
+        "time": 1213,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -175,7 +175,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 1213
         }
       },
       {
@@ -194,7 +194,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "fde44676-8035-cd45-5fc2-981285d072ae"
+              "value": "7597d957-81a3-8599-0d40-6fc0305c99b1"
             },
             {
               "_fromType": "array",
@@ -226,18 +226,18 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1880,
+          "headersSize": 1936,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://graph.microsoft.com/v1.0/organization"
         },
         "response": {
-          "bodySize": 1358,
+          "bodySize": 1470,
           "content": {
             "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
-            "size": 1358,
-            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/992d7bbe-b367-459c-a10f-cf3fd16103ab/directoryObjects/992d7bbe-b367-459c-a10f-cf3fd16103ab/Microsoft.DirectoryServices.Organization\",\"id\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2020-07-16T17:54:20Z\",\"displayName\":\"Default Directory\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"ndowmon@gmail.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":192,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2020-09-15T15:38:22Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"ndowmongmail.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
+            "size": 1470,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/19ae0f99-6fc6-444b-bd54-97504efc66ad/directoryObjects/19ae0f99-6fc6-444b-bd54-97504efc66ad/Microsoft.DirectoryServices.Organization\",\"id\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2021-09-01T14:59:04Z\",\"dataBoundary\":\"None\",\"displayName\":\"JupiterOne Azure Integration Development\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"nick.dowmon_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":89,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2021-09-01T20:02:55Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"j1AzureIntegrationDev.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +247,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:06 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:56 GMT"
             },
             {
               "name": "content-type",
@@ -267,15 +267,15 @@
             },
             {
               "name": "request-id",
-              "value": "6b177a58-7ac4-4f45-9c0c-421355195f13"
+              "value": "a2b01177-dba9-4efe-a2b6-a386a6d79087"
             },
             {
               "name": "client-request-id",
-              "value": "fde44676-8035-cd45-5fc2-981285d072ae"
+              "value": "7597d957-81a3-8599-0d40-6fc0305c99b1"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"CH01EPF00004DDD\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Korea Central\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"SE1PEPF00000A31\"}}"
             },
             {
               "name": "x-ms-resource-unit",
@@ -286,14 +286,14 @@
               "value": "4.0"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 609,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:06.242Z",
-        "time": 273,
+        "startedDateTime": "2021-09-26T12:31:56.452Z",
+        "time": 527,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,7 +301,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 527
         }
       },
       {
@@ -320,7 +320,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "abcbc6af-50e8-4aea-95d4-15de1aa56053"
+              "value": "049ca0b3-770f-f9bd-be5c-304532ffdd64"
             },
             {
               "_fromType": "array",
@@ -352,7 +352,7 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1918,
+          "headersSize": 1974,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -373,7 +373,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:07 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:57 GMT"
             },
             {
               "name": "content-type",
@@ -397,29 +397,29 @@
             },
             {
               "name": "request-id",
-              "value": "83324d95-1d09-4ad1-99fb-5ef5bc911a20"
+              "value": "1e0c42f0-4521-4def-a3d5-38583bc8cec8"
             },
             {
               "name": "client-request-id",
-              "value": "abcbc6af-50e8-4aea-95d4-15de1aa56053"
+              "value": "049ca0b3-770f-f9bd-be5c-304532ffdd64"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"CH01EPF00004DD9\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"Korea Central\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"SE1PEPF00000A30\"}}"
             },
             {
               "name": "odata-version",
               "value": "4.0"
             }
           ],
-          "headersSize": 611,
+          "headersSize": 608,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:06.522Z",
-        "time": 830,
+        "startedDateTime": "2021-09-26T12:31:56.990Z",
+        "time": 969,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -427,11 +427,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 830
+          "wait": 969
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 0,
         "cache": {},
         "request": {
@@ -448,7 +448,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "d6f48388-3def-4b26-97e4-cb87d8f46c78"
+              "value": "89c2dc7a-bd73-411f-934d-e8b5e2208e76"
             },
             {
               "name": "return-client-request-id",
@@ -493,18 +493,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665487\",\"not_before\":\"1615661587\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632663118\",\"not_before\":\"1632659218\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:07.000Z",
+              "expires": "2021-10-26T12:31:58.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -558,15 +558,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "d6f48388-3def-4b26-97e4-cb87d8f46c78"
+              "value": "89c2dc7a-bd73-411f-934d-e8b5e2208e76"
             },
             {
               "name": "x-ms-request-id",
-              "value": "5c4677a0-7d24-4ee1-94d9-e3bde6f32300"
+              "value": "0f9f9943-6e57-408d-89a3-6f096d171e00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -589,7 +589,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:06 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:58 GMT"
             },
             {
               "name": "connection",
@@ -600,14 +600,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:07.370Z",
-        "time": 150,
+        "startedDateTime": "2021-09-26T12:31:57.998Z",
+        "time": 961,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -615,11 +615,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 150
+          "wait": 961
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 0,
         "cache": {},
         "request": {
@@ -634,7 +634,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "be4bb4b8-f5f0-4167-b8be-2e902f232dfa"
+              "value": "7a38718f-c9bb-44a7-a3cc-d0c16b64bedd"
             },
             {
               "_fromType": "array",
@@ -649,7 +649,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -676,7 +676,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -688,11 +688,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -718,19 +718,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "63192db2-9913-4783-8d78-2a742a9b6503"
+              "value": "5071bb77-2d10-4ca3-8a8a-4dd58cfd6af1"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "63192db2-9913-4783-8d78-2a742a9b6503"
+              "value": "5071bb77-2d10-4ca3-8a8a-4dd58cfd6af1"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185808Z:63192db2-9913-4783-8d78-2a742a9b6503"
+              "value": "EASTASIA:20210926T123159Z:5071bb77-2d10-4ca3-8a8a-4dd58cfd6af1"
             },
             {
               "name": "strict-transport-security",
@@ -742,7 +742,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:07 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:59 GMT"
             },
             {
               "name": "connection",
@@ -750,17 +750,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:07.546Z",
-        "time": 624,
+        "startedDateTime": "2021-09-26T12:31:59.010Z",
+        "time": 399,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -768,11 +768,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 624
+          "wait": 399
         }
       },
       {
-        "_id": "9e0d5d54a7748c5a868c8dbd10fe430c",
+        "_id": "1c325c20e61373bdb053d0556f09e7ed",
         "_order": 0,
         "cache": {},
         "request": {
@@ -792,7 +792,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "e80265a5-5288-4aad-b80b-896a9fa889b5"
+              "value": "1d999eee-4b76-423a-9b2a-d5910577e877"
             },
             {
               "_fromType": "array",
@@ -802,7 +802,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -829,7 +829,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1836,
+          "headersSize": 1837,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -842,14 +842,14 @@
               "value": "2015-11-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resources?%24filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resources?%24filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01"
         },
         "response": {
-          "bodySize": 306,
+          "bodySize": 304,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 306,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/ndowmon11-j1dev\",\"name\":\"ndowmon11-j1dev\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"}}]}"
+            "size": 304,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1\",\"name\":\"example-key-vault-1\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{}}]}"
           },
           "cookies": [],
           "headers": [
@@ -875,19 +875,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "cb395ad8-4ef5-4ec1-925c-0a8b7bc67a04"
+              "value": "9048e03c-9d2b-458c-b6fc-0cfa2992dd28"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "cb395ad8-4ef5-4ec1-925c-0a8b7bc67a04"
+              "value": "9048e03c-9d2b-458c-b6fc-0cfa2992dd28"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185808Z:cb395ad8-4ef5-4ec1-925c-0a8b7bc67a04"
+              "value": "EASTASIA:20210926T123159Z:9048e03c-9d2b-458c-b6fc-0cfa2992dd28"
             },
             {
               "name": "strict-transport-security",
@@ -899,7 +899,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:08 GMT"
+              "value": "Sun, 26 Sep 2021 12:31:59 GMT"
             },
             {
               "name": "connection",
@@ -907,17 +907,17 @@
             },
             {
               "name": "content-length",
-              "value": "306"
+              "value": "304"
             }
           ],
-          "headersSize": 590,
+          "headersSize": 589,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:08.184Z",
-        "time": 298,
+        "startedDateTime": "2021-09-26T12:31:59.427Z",
+        "time": 327,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -925,11 +925,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 298
+          "wait": 327
         }
       },
       {
-        "_id": "c71f6883f7c1f727a6bd4a3887f6c854",
+        "_id": "2324c6c630251fe158f68b77a39126db",
         "_order": 0,
         "cache": {},
         "request": {
@@ -949,7 +949,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "dfd848de-4da7-4880-a9e0-e607397b3555"
+              "value": "37bea655-d278-4bcf-93a8-bf4d602a91df"
             },
             {
               "_fromType": "array",
@@ -959,7 +959,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-keyvault/1.2.1 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -986,7 +986,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1835,
+          "headersSize": 1857,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -995,14 +995,14 @@
               "value": "2018-02-14"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/ndowmon11-j1dev?api-version=2018-02-14"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/stefan_keyvaults_group/providers/Microsoft.KeyVault/vaults/example-key-vault-1?api-version=2018-02-14"
         },
         "response": {
-          "bodySize": 1607,
+          "bodySize": 1429,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1607,
-            "text": "{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/ndowmon11-j1dev\",\"name\":\"ndowmon11-j1dev\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"sku\":{\"family\":\"A\",\"name\":\"standard\"},\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"accessPolicies\":[{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"objectId\":\"b6e7f627-8731-47bd-be0e-477d1cbc6e17\",\"permissions\":{\"keys\":[\"Get\",\"List\",\"Update\",\"Create\",\"Import\",\"Delete\",\"Recover\",\"Backup\",\"Restore\"],\"secrets\":[],\"certificates\":[]}},{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"objectId\":\"64242f8f-67ee-4f0c-b644-0766b42e8e91\",\"permissions\":{\"keys\":[\"Get\",\"Create\",\"Recover\",\"Delete\",\"Purge\"],\"secrets\":[\"Get\"],\"certificates\":[],\"storage\":[]}},{\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"objectId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"permissions\":{\"keys\":[\"get\",\"wrapkey\",\"unwrapkey\"]}}],\"enabledForDeployment\":false,\"enabledForDiskEncryption\":true,\"enabledForTemplateDeployment\":false,\"enableSoftDelete\":true,\"softDeleteRetentionInDays\":7,\"enableRbacAuthorization\":false,\"enablePurgeProtection\":true,\"vaultUri\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"provisioningState\":\"Succeeded\"}}"
+            "size": 1429,
+            "text": "{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1\",\"name\":\"example-key-vault-1\",\"type\":\"Microsoft.KeyVault/vaults\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"sku\":{\"family\":\"A\",\"name\":\"Standard\"},\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"accessPolicies\":[{\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"objectId\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"permissions\":{\"keys\":[\"Get\",\"List\",\"Update\",\"Create\",\"Import\",\"Delete\",\"Recover\",\"Backup\",\"Restore\"],\"secrets\":[\"Get\",\"List\",\"Set\",\"Delete\",\"Recover\",\"Backup\",\"Restore\"],\"certificates\":[\"Get\",\"List\",\"Update\",\"Create\",\"Import\",\"Delete\",\"Recover\",\"Backup\",\"Restore\",\"ManageContacts\",\"ManageIssuers\",\"GetIssuers\",\"ListIssuers\",\"SetIssuers\",\"DeleteIssuers\"]}}],\"enabledForDeployment\":false,\"enabledForDiskEncryption\":false,\"enabledForTemplateDeployment\":false,\"enableSoftDelete\":true,\"softDeleteRetentionInDays\":90,\"enableRbacAuthorization\":false,\"vaultUri\":\"https://example-key-vault-1.vault.azure.net/\",\"provisioningState\":\"Succeeded\"}}"
           },
           "cookies": [],
           "headers": [
@@ -1028,15 +1028,15 @@
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "dfd848de-4da7-4880-a9e0-e607397b3555"
+              "value": "37bea655-d278-4bcf-93a8-bf4d602a91df"
             },
             {
               "name": "x-ms-keyvault-service-version",
-              "value": "1.1.248.2"
+              "value": "1.5.99.5"
             },
             {
               "name": "x-ms-request-id",
-              "value": "683d9ef3-238a-4a99-b423-538a2a4bf37a"
+              "value": "7005a67a-5396-477e-9657-58f7685eee3d"
             },
             {
               "name": "strict-transport-security",
@@ -1048,7 +1048,7 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "server",
@@ -1064,29 +1064,29 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "a26d47f7-7f22-417f-b397-7c0e6d56f725"
+              "value": "687b68fa-13af-47d7-812a-3b5b0f00747d"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185808Z:a26d47f7-7f22-417f-b397-7c0e6d56f725"
+              "value": "EASTASIA:20210926T123201Z:687b68fa-13af-47d7-812a-3b5b0f00747d"
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:08 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:00 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 781,
+          "headersSize": 779,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:08.493Z",
-        "time": 310,
+        "startedDateTime": "2021-09-26T12:31:59.772Z",
+        "time": 1502,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1094,11 +1094,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 310
+          "wait": 1502
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 1,
         "cache": {},
         "request": {
@@ -1115,7 +1115,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "768223a8-17a3-4edd-b4d2-290e3b7a6f55"
+              "value": "7e6429a7-af9e-487e-869f-eddb8e412c05"
             },
             {
               "name": "return-client-request-id",
@@ -1160,18 +1160,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665489\",\"not_before\":\"1615661589\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632663122\",\"not_before\":\"1632659222\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:09.000Z",
+              "expires": "2021-10-26T12:32:02.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1204,10 +1204,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -1229,15 +1225,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "768223a8-17a3-4edd-b4d2-290e3b7a6f55"
+              "value": "7e6429a7-af9e-487e-869f-eddb8e412c05"
             },
             {
               "name": "x-ms-request-id",
-              "value": "dca758a8-10e2-4936-a461-636244f52300"
+              "value": "4f5b9e03-f331-456e-8e82-a5a4bc6b1a00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.15 - EUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -1260,21 +1256,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:09 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:01 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 786,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:08.820Z",
-        "time": 174,
+        "startedDateTime": "2021-09-26T12:32:01.304Z",
+        "time": 1263,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1282,11 +1282,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 174
+          "wait": 1263
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 1,
         "cache": {},
         "request": {
@@ -1301,7 +1301,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "d67b91c1-2d87-42ca-8d44-c82d1651b795"
+              "value": "b4c86e45-a008-4f7c-bbd4-2ad2d06908ad"
             },
             {
               "_fromType": "array",
@@ -1316,7 +1316,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1343,7 +1343,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1355,11 +1355,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -1389,15 +1389,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "af6d4cb5-da75-4d90-9f31-dbb8b11fb870"
+              "value": "da398f3a-8fac-4103-b071-59576b3cef50"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "af6d4cb5-da75-4d90-9f31-dbb8b11fb870"
+              "value": "da398f3a-8fac-4103-b071-59576b3cef50"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185809Z:af6d4cb5-da75-4d90-9f31-dbb8b11fb870"
+              "value": "EASTASIA:20210926T123203Z:da398f3a-8fac-4103-b071-59576b3cef50"
             },
             {
               "name": "strict-transport-security",
@@ -1409,7 +1409,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:08 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:02 GMT"
             },
             {
               "name": "connection",
@@ -1417,17 +1417,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:08.999Z",
-        "time": 272,
+        "startedDateTime": "2021-09-26T12:32:02.576Z",
+        "time": 325,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1435,11 +1435,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 272
+          "wait": 325
         }
       },
       {
-        "_id": "a05cf64d60aef4a7d98650e5b963c489",
+        "_id": "6341ce2a72b803eab395181f6d187dae",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1459,7 +1459,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "2654ee2f-08ed-4150-8e26-52b5063599a6"
+              "value": "a3499851-d8c4-4146-9e3b-5ccb6bc603fa"
             },
             {
               "_fromType": "array",
@@ -1469,7 +1469,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1496,7 +1496,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1891,
+          "headersSize": 1913,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1505,14 +1505,14 @@
               "value": "2017-05-01-preview"
             }
           ],
-          "url": "https://management.azure.com//subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.KeyVault/vaults/ndowmon11-j1dev/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
+          "url": "https://management.azure.com//subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_KeyVaults_Group/providers/Microsoft.KeyVault/vaults/example-key-vault-1/providers/microsoft.insights/diagnosticSettings?api-version=2017-05-01-preview"
         },
         "response": {
-          "bodySize": 1065,
+          "bodySize": 273,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1065,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourcegroups/j1dev/providers/microsoft.keyvault/vaults/ndowmon11-j1dev/providers/microsoft.insights/diagnosticSettings/j1dev_key_vault_diag_set\",\"type\":\"Microsoft.Insights/diagnosticSettings\",\"name\":\"j1dev_key_vault_diag_set\",\"location\":null,\"kind\":null,\"tags\":null,\"properties\":{\"storageAccountId\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"serviceBusRuleId\":null,\"workspaceId\":null,\"eventHubAuthorizationRuleId\":null,\"eventHubName\":null,\"metrics\":[{\"category\":\"AllMetrics\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logs\":[{\"category\":\"AuditEvent\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":1}}],\"logAnalyticsDestinationType\":null},\"identity\":null}]}"
+            "size": 273,
+            "text": "{\"value\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -1542,11 +1542,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "ef9a256b-a0a5-4263-95da-85b38aa14f91"
+              "value": "b86dee54-061f-4db3-a481-3633ce3cd117"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "server",
@@ -1554,11 +1554,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "0b552483-b504-4878-bb46-6522ca931763"
+              "value": "3cc1f4b5-d73d-40c6-b122-3fab68160d2a"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185810Z:0b552483-b504-4878-bb46-6522ca931763"
+              "value": "EASTASIA:20210926T123204Z:3cc1f4b5-d73d-40c6-b122-3fab68160d2a"
             },
             {
               "name": "x-content-type-options",
@@ -1566,21 +1566,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:09 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:04 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 625,
+          "headersSize": 624,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:09.278Z",
-        "time": 737,
+        "startedDateTime": "2021-09-26T12:32:02.908Z",
+        "time": 1911,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1588,11 +1588,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 737
+          "wait": 1911
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 2,
         "cache": {},
         "request": {
@@ -1609,7 +1609,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "bd47663c-42eb-4200-bb2f-dc0ee1c78776"
+              "value": "39a35d5b-9c0e-41a8-ada5-a70a53f6c8cc"
             },
             {
               "name": "return-client-request-id",
@@ -1654,18 +1654,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665490\",\"not_before\":\"1615661590\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632663125\",\"not_before\":\"1632659225\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:10.000Z",
+              "expires": "2021-10-26T12:32:05.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1698,10 +1698,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -1723,15 +1719,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "bd47663c-42eb-4200-bb2f-dc0ee1c78776"
+              "value": "39a35d5b-9c0e-41a8-ada5-a70a53f6c8cc"
             },
             {
               "name": "x-ms-request-id",
-              "value": "459fae41-5349-43e4-9a49-bb3330eb2100"
+              "value": "ca7a1fad-3d4d-4667-808d-46c3fcf51e00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.15 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -1754,21 +1750,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:09 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:05 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:10.021Z",
-        "time": 179,
+        "startedDateTime": "2021-09-26T12:32:04.829Z",
+        "time": 1117,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1776,11 +1776,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 179
+          "wait": 1117
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 2,
         "cache": {},
         "request": {
@@ -1795,7 +1795,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "8bc9d173-f88c-47cc-a258-7cac3a8eecae"
+              "value": "07228e59-a424-47b2-84c5-9ee565eca9ea"
             },
             {
               "_fromType": "array",
@@ -1810,7 +1810,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1837,7 +1837,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1677,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1849,11 +1849,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -1883,15 +1883,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "0baf5603-c893-40b7-ba41-ced3386cce5d"
+              "value": "11053a46-1494-47ff-b4ea-e9e75057477f"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "0baf5603-c893-40b7-ba41-ced3386cce5d"
+              "value": "11053a46-1494-47ff-b4ea-e9e75057477f"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185810Z:0baf5603-c893-40b7-ba41-ced3386cce5d"
+              "value": "EASTASIA:20210926T123206Z:11053a46-1494-47ff-b4ea-e9e75057477f"
             },
             {
               "name": "strict-transport-security",
@@ -1903,7 +1903,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:10 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:06 GMT"
             },
             {
               "name": "connection",
@@ -1911,17 +1911,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 583,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:10.205Z",
-        "time": 273,
+        "startedDateTime": "2021-09-26T12:32:05.956Z",
+        "time": 336,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1929,11 +1929,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 336
         }
       },
       {
-        "_id": "c9d6dbee91365ea9a6e208a3dd1605c4",
+        "_id": "65b39ca75483f0ca33c5ac4a87ec1aa8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1953,7 +1953,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "6066e32d-794e-4492-928e-9650e2f39781"
+              "value": "057b0f20-ab97-4504-81b0-11692f65da27"
             },
             {
               "_fromType": "array",
@@ -1963,7 +1963,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -1990,7 +1990,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1806,
+          "headersSize": 1807,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1999,14 +1999,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 2459,
+          "bodySize": 1304,
           "content": {
-            "mimeType": "application/json",
-            "size": 2459,
-            "text": "{\"value\":[{\"identity\":{\"principalId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"SystemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"resourceAccessRules\":[],\"bypass\":\"Logging, Metrics, AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[{\"value\":\"76.182.33.160\",\"action\":\"Allow\"}],\"defaultAction\":\"Deny\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://ndowmon11-j1dev.vault.azure.net/keys/j1dev/325432ed4deb46bebe09d39dc071f090\",\"lastKeyRotationTimestamp\":\"2021-03-09T16:48:13.3984368Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"keyname\":\"j1dev\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.2628136Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1dev.dfs.core.windows.net/\",\"web\":\"https://ndowmon1j1dev.z13.web.core.windows.net/\",\"blob\":\"https://ndowmon1j1dev.blob.core.windows.net/\",\"queue\":\"https://ndowmon1j1dev.queue.core.windows.net/\",\"table\":\"https://ndowmon1j1dev.table.core.windows.net/\",\"file\":\"https://ndowmon1j1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1devblobstorage\",\"name\":\"ndowmon1j1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.3721528Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://ndowmon1j1devblobstorage.blob.core.windows.net/\",\"table\":\"https://ndowmon1j1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1304,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"name\":\"regenerateaccesskeytest\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-20T15:02:41.5642636Z\",\"primaryEndpoints\":{\"web\":\"https://regenerateaccesskeytest.z13.web.core.windows.net/\",\"blob\":\"https://regenerateaccesskeytest.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"name\":\"sqlvab7pt3ww5qhmdw\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-23T11:32:50.8155392Z\",\"primaryEndpoints\":{\"dfs\":\"https://sqlvab7pt3ww5qhmdw.dfs.core.windows.net/\",\"web\":\"https://sqlvab7pt3ww5qhmdw.z13.web.core.windows.net/\",\"blob\":\"https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/\",\"queue\":\"https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/\",\"table\":\"https://sqlvab7pt3ww5qhmdw.table.core.windows.net/\",\"file\":\"https://sqlvab7pt3ww5qhmdw.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"name\":\"stefanexamplestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-07T13:14:18.4460771Z\",\"primaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage.table.core.windows.net/\",\"file\":\"https://stefanexamplestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage-secondary.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage-secondary.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage-secondary.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage-secondary.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"name\":\"storageaccountstefaafb8\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"centralus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-16T14:50:27.0370951Z\",\"primaryEndpoints\":{\"blob\":\"https://storageaccountstefaafb8.blob.core.windows.net/\",\"queue\":\"https://storageaccountstefaafb8.queue.core.windows.net/\",\"table\":\"https://storageaccountstefaafb8.table.core.windows.net/\",\"file\":\"https://storageaccountstefaafb8.file.core.windows.net/\"},\"primaryLocation\":\"centralus\",\"statusOfPrimary\":\"available\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -2020,7 +2020,7 @@
             },
             {
               "name": "content-type",
-              "value": "application/json"
+              "value": "application/json; charset=utf-8"
             },
             {
               "name": "expires",
@@ -2031,28 +2031,28 @@
               "value": "Accept-Encoding"
             },
             {
-              "name": "x-ms-request-id",
-              "value": "df3c441a-31a6-4e90-a791-5bd77f638a61"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
+              "name": "x-ms-original-request-ids",
+              "value": "9b82a229-7e3f-45e7-9c43-7e2500d99795, 8c943b1c-88c6-439a-836f-a82d82288a2a"
             },
             {
               "name": "x-ms-ratelimit-remaining-subscription-reads",
               "value": "11999"
             },
             {
-              "name": "server",
-              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
+              "name": "x-ms-request-id",
+              "value": "97589097-03f3-4374-ab8a-47bd2fdd326e"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "dd117205-aa59-4b2b-b7d0-f84731a67279"
+              "value": "97589097-03f3-4374-ab8a-47bd2fdd326e"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185810Z:dd117205-aa59-4b2b-b7d0-f84731a67279"
+              "value": "EASTASIA:20210926T123207Z:97589097-03f3-4374-ab8a-47bd2fdd326e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
             },
             {
               "name": "x-content-type-options",
@@ -2060,21 +2060,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:10 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:06 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1304"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 693,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:10.483Z",
-        "time": 322,
+        "startedDateTime": "2021-09-26T12:32:06.311Z",
+        "time": 1069,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2082,11 +2086,509 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 322
+          "wait": 1069
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "438f2b93-45bb-4a8a-bc6c-de83180978e5"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632663128\",\"not_before\":\"1632659228\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:08.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "438f2b93-45bb-4a8a-bc6c-de83180978e5"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2fa1d20b-5241-4aa9-87a8-55ebf2561900"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.15 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:07 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:07.395Z",
+        "time": 1316,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1316
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5ea6edff-4403-45a8-870b-c8c32019c50b"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1677,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "35270b68-0931-4900-9374-25c6414273b8"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "35270b68-0931-4900-9374-25c6414273b8"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210926T123209Z:35270b68-0931-4900-9374-25c6414273b8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:08 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 583,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:08.716Z",
+        "time": 339,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 339
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "c5520b4c-1cd8-41e7-88bc-0f51a07786b0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-28T20:32:09+08:00' and eventTimestamp le '2021-09-26T20:32:09+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-28T20%3A32%3A09%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-26T20%3A32%3A09%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FDefaultResourceGroup-CUS%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fregenerateaccesskeytest%27"
+        },
+        "response": {
+          "bodySize": 22567,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 22567,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"a704a2cb-eb4d-4a35-805e-ead94ad19f43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/a704a2cb-eb4d-4a35-805e-ead94ad19f43/ticks/637680001929101036\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"0225ea72-f781-4f6e-9fe5-d6a0c2474557\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:23:12.9101036Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"ee04b008-d832-4d27-a31d-d6477b7c56bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ee04b008-d832-4d27-a31d-d6477b7c56bb/ticks/637680001926901032\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:23:12.6901032Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"47870c69-2372-4d1a-9917-44ee82af3d43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/47870c69-2372-4d1a-9917-44ee82af3d43/ticks/637679999082738446\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"31101762-006a-4ed7-89d9-49ca3036ab80\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:18:28.2738446Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"0bb50929-cabd-4f23-9f59-230d8444fdc2\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/0bb50929-cabd-4f23-9f59-230d8444fdc2/ticks/637679999074987777\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:18:27.4987777Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"9f03ce09-20a6-4d06-95d4-ef9682fe9dcb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9f03ce09-20a6-4d06-95d4-ef9682fe9dcb/ticks/637679990444693037\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4e305746-c740-4588-b06a-7d6040286b8a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:04:04.4693037Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"cafd852a-38ab-43de-9c4e-8ae9d2e0aa39\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cafd852a-38ab-43de-9c4e-8ae9d2e0aa39/ticks/637679990442442997\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:04:04.2442997Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"70e4e7f2-a8fb-42fe-8940-2777f9f0d373\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/70e4e7f2-a8fb-42fe-8940-2777f9f0d373/ticks/637679185425534061\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8d275523-3648-4cb1-9685-2170c4968840\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:42:22.5534061Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"8777e717-fee0-422a-ae58-7e871fdf0394\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/8777e717-fee0-422a-ae58-7e871fdf0394/ticks/637679185423183513\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:22.3183513Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"28e8a43f-d061-4b3d-b13c-ae0cc610de21\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/28e8a43f-d061-4b3d-b13c-ae0cc610de21/ticks/637679185357882256\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1d0fc11b-5f8a-414e-b58f-a17cf1e90f0f\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:42:15.7882256Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"d1f38226-b5fc-4ff8-9a00-3093b11f81c0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d1f38226-b5fc-4ff8-9a00-3093b11f81c0/ticks/637679185355782736\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:15.5782736Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac/ticks/637679179809610416\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"47695443-19d5-493e-a4e8-7789b0e60377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-22T14:33:00.9610416Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"d0717133-9bd8-40f6-9771-8b3f656b9068\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d0717133-9bd8-40f6-9771-8b3f656b9068/ticks/637679179807409713\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:33:00.7409713Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"62f1c7a0-52d0-47e8-831e-52bb6a043101\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/62f1c7a0-52d0-47e8-831e-52bb6a043101/ticks/637677475939857920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1cc9b1d1-3ad3-4be5-804d-107cff738cd4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:13:13.985792Z\",\"submissionTimestamp\":\"2021-09-20T15:14:24.1932217Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"f0381753-4ff1-45ed-99df-0a0f74f21bb7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/f0381753-4ff1-45ed-99df-0a0f74f21bb7/ticks/637677475660997035\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"446855e9-2947-4f06-9ddb-4249a30ad8e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:12:46.0997035Z\",\"submissionTimestamp\":\"2021-09-20T15:14:11.1254588Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"1813f4e7-9bf6-4710-ac12-489b32de7fd6\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1813f4e7-9bf6-4710-ac12-489b32de7fd6/ticks/637677474240400287\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1608dd41-cc4f-471b-8c4d-3a4393333377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:10:24.0400287Z\",\"submissionTimestamp\":\"2021-09-20T15:13:05.4897023Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"e0f6b157-a5ea-4c30-948d-5f3b5b30f14a\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e0f6b157-a5ea-4c30-948d-5f3b5b30f14a/ticks/637677474232600486\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:23.2600486Z\",\"submissionTimestamp\":\"2021-09-20T15:12:05.1607741Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"848862b2-56a3-4837-9562-bbd64dad53cc\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/848862b2-56a3-4837-9562-bbd64dad53cc/ticks/637677474228858674\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"90c74ebf-f83f-4196-8840-c20aa40bc0ca\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:10:22.8858674Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"83c32961-cc44-4648-9186-5d672cf75d83\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/83c32961-cc44-4648-9186-5d672cf75d83/ticks/637677474226509192\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:22.6509192Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"e4c18ff5-a195-41b8-89b0-cab13faa6f27\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e4c18ff5-a195-41b8-89b0-cab13faa6f27/ticks/637677471861822795\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"a40adc80-7e2f-4c2b-9621-5cc901366e2a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:26.1822795Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556/ticks/637677471859722688\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.9722688Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"cf6386d9-e6ab-42bd-9e5a-83cefa4c8199\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cf6386d9-e6ab-42bd-9e5a-83cefa4c8199/ticks/637677471856711620\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ea0187af-8198-4c98-97bd-4220a5bcd942\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:25.671162Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"b0e07419-dc8f-414f-82cd-53f01df6a401\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b0e07419-dc8f-414f-82cd-53f01df6a401/ticks/637677471854611536\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.4611536Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"d8243a16-ab46-4322-8dea-d563d7f88d39\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d8243a16-ab46-4322-8dea-d563d7f88d39/ticks/637677471851671673\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Regenerate Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fb259f93-8cbf-4974-83a9-6862b96eb049\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:25.1671673Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"6154366b-4323-45a8-b328-4d746d69a1d9\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6154366b-4323-45a8-b328-4d746d69a1d9/ticks/637677471847621619\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Regenerate Storage Account Keys\"},\"properties\":{\"requestbody\":\"{\\\"keyName\\\":\\\"key1\\\"}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:24.7621619Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"2fa63062-2f22-4759-90af-464f8be3b5c3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/2fa63062-2f22-4759-90af-464f8be3b5c3/ticks/637677471779112974\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4b5c0812-a756-4dda-97af-8ba7463e5d4c\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:06:17.9112974Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"6bd2ac81-1521-409d-ab9f-62a24b0ffd2d\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6bd2ac81-1521-409d-ab9f-62a24b0ffd2d/ticks/637677471777013163\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:17.7013163Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"6f2ead07-65c7-4527-8729-88a168ace6e9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/6f2ead07-65c7-4527-8729-88a168ace6e9/ticks/637677469905184323\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"5095ece2-d23b-4405-9663-0319f48b0234\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:03:10.5184323Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"85385ce4-5123-480f-b5ca-93ad14251b67\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/85385ce4-5123-480f-b5ca-93ad14251b67/ticks/637677469895868920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"257770ea-c767-43e6-8175-a296a4200be4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.586892Z\",\"submissionTimestamp\":\"2021-09-20T15:04:47.0753231Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1eed7870-0320-420b-ba7a-9c8a375031d0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/1eed7870-0320-420b-ba7a-9c8a375031d0/ticks/637677469894434112\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.4434112Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"9e8ec575-53e1-4cdf-aac6-1b6fe831f315\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9e8ec575-53e1-4cdf-aac6-1b6fe831f315/ticks/637677469636227096\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"57dc2ec8-7845-4db5-b514-99690b6a867b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6227096Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"ff1449dd-10cf-4a75-bbfc-f243cc8c63da\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ff1449dd-10cf-4a75-bbfc-f243cc8c63da/ticks/637677469636177088\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"5adc31a9-0f71-4dc9-b0d6-b2b7a3ef6cf0\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6177088Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1fd27944-0a26-4bb1-a0e3-fba30c720db0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1fd27944-0a26-4bb1-a0e3-fba30c720db0/ticks/637677469575072028\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Premium_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":false,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:37.5072028Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_37bbabf93e09419da94a9f1b4cfbd9be_637682563298676366"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "8a6cbd3c-0a69-4175-b0ae-55422cc4b899"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210926T123209Z:8a6cbd3c-0a69-4175-b0ae-55422cc4b899"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:08 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:09.069Z",
+        "time": 770,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 770
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 1,
         "cache": {},
         "request": {
@@ -2111,12 +2613,12 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "9b6e78fd-813b-407d-a6f7-7c208c406f7d"
+              "value": "9666e87e-e8dc-4f91-a438-392b87b83387"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
@@ -2138,7 +2640,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 428,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2147,7 +2649,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -2158,7 +2660,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:11.000Z",
+              "expires": "2021-10-26T12:32:10.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -2214,11 +2716,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "33f0b1db-5e53-4263-9d0b-1889d2bc2400"
+              "value": "2938910f-bc78-4b7d-ac2a-fcad6d581f00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.15 - SCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -2237,21 +2739,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:10 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:10 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:10.825Z",
-        "time": 154,
+        "startedDateTime": "2021-09-26T12:32:09.883Z",
+        "time": 1083,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2259,11 +2761,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 154
+          "wait": 1083
         }
       },
       {
-        "_id": "5dbc34c006894f7ce143f08803d3acba",
+        "_id": "12ec0509765fac63d7064f131c7b3918",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2278,12 +2780,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "11b732e3-0eec-4c16-afd7-ec121b2fb840"
+              "value": "6bf103b8-16ab-4553-9abd-f1ab49abc94b"
             },
             {
               "_fromType": "array",
@@ -2302,10 +2804,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.blob.core.windows.net"
+              "value": "regenerateaccesskeytest.blob.core.windows.net"
             }
           ],
-          "headersSize": 1585,
+          "headersSize": 1606,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2318,14 +2820,458 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1dev.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://regenerateaccesskeytest.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 805,
+          "bodySize": 236,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 236,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "236"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "46684724-501c-002a-14d2-b297f7000000"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "6bf103b8-16ab-4553-9abd-f1ab49abc94b"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:11 GMT"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:10.987Z",
+        "time": 1239,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1239
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "1c621452-5381-4ed9-9ec0-74c36f69c62e"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2162,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-28T20:32:12+08:00' and eventTimestamp le '2021-09-26T20:32:12+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-28T20%3A32%3A12%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-26T20%3A32%3A12%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_SQL_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fsqlvab7pt3ww5qhmdw%27"
+        },
+        "response": {
+          "bodySize": 13185,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 13185,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"1bf92f9b-047b-4228-84df-7c2ed64bacdf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/1bf92f9b-047b-4228-84df-7c2ed64bacdf/ticks/637679941964644382\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46f46d72-c836-4fb5-81df-39d87ee35361\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:43:16.4644382Z\",\"submissionTimestamp\":\"2021-09-23T11:45:03.183974Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0/ticks/637679941750596914\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"e4bbfd9b-2399-4547-bc1b-72028b20383d\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/e4bbfd9b-2399-4547-bc1b-72028b20383d/ticks/637679941750596914\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"5e859926-06ba-422b-b976-128ae719d9c5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/5e859926-06ba-422b-b976-128ae719d9c5/ticks/637679941731506587\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"3d667eff-b604-4b94-9aa0-f6ae6b20cd2e\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:53.1506587Z\",\"submissionTimestamp\":\"2021-09-23T11:43:29.1239763Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44a7cc1c-09a5-408a-bb6d-7159bd091493\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/44a7cc1c-09a5-408a-bb6d-7159bd091493/ticks/637679936036356606\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"57d231f9-c955-4a39-81a7-e0ca1179c7c3\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T11:33:23.6356606Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1880622Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"c997130c-e08c-4218-8c43-b292200e4d82\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/c997130c-e08c-4218-8c43-b292200e4d82/ticks/637679936001153487\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"scope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:20.1153487Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1860603Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"db28785d-d234-4156-85d1-f93663a89aa7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/db28785d-d234-4156-85d1-f93663a89aa7/ticks/637679935941633332\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1645c04a-9f69-472c-8224-c5be3334796c\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:14.1633332Z\",\"submissionTimestamp\":\"2021-09-23T11:34:50.1441225Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"685222b6-8e45-4a6f-9116-77895f3c68eb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/685222b6-8e45-4a6f-9116-77895f3c68eb/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"5f9205a3-3c45-4db5-abf6-4cbba8b09865\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d4290f0f-f81f-48ff-8d26-686074ca277a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d4290f0f-f81f-48ff-8d26-686074ca277a/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"463cb640-befe-45af-b4d7-b5470a837a59\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"b821643d-9081-4a4b-a57c-2f8ca07b7002\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/b821643d-9081-4a4b-a57c-2f8ca07b7002/ticks/637679935726410258\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:52.6410258Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"dab4de05-9d1d-41af-bda7-78b884be52d5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/dab4de05-9d1d-41af-bda7-78b884be52d5/ticks/637679935680160357\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/2a1a9cdf-e04d-429a-8416-3bfb72a1b26f/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountsShouldRestrictNetworkAccessUsingVirtualNetworkRulesMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\\\",\\\"policyDefinitionEffect\\\":\\\"Audit\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:48.0160357Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d5d150f2-829f-42ea-8a70-cb7aead80689\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d5d150f2-829f-42ea-8a70-cb7aead80689/ticks/637679935679959308\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":\\\"true\\\",\\\"allowBlobPublicAccess\\\":\\\"false\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:47.9959308Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_7d13846b20dc4812ad9483aa3acb3a4a_637682563330103418"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "c3d6b71f-9d53-4369-af1d-5f238d9a2066"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210926T123213Z:c3d6b71f-9d53-4369-af1d-5f238d9a2066"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:12 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:12.257Z",
+        "time": 753,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 753
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9939e348-0a47-4465-8426-1d4508c5f35b"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:14.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2ca591cb-0ee6-45ee-9e4f-cdf9a0511d00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:13 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 696,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:13.030Z",
+        "time": 1107,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1107
+        }
+      },
+      {
+        "_id": "155a15bd9bc9daa4c43589a03bdf5d4b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "df4a3526-f319-4404-8457-0b672d01cfc5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "sqlvab7pt3ww5qhmdw.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1596,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 749,
           "content": {
             "mimeType": "application/xml",
-            "size": 805,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+            "size": 749,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
@@ -2343,11 +3289,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "1b1dbadd-501e-0061-663a-186f7c000000"
+              "value": "11ede05c-001e-0085-12d2-b2babb000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "11b732e3-0eec-4c16-afd7-ec121b2fb840"
+              "value": "df4a3526-f319-4404-8457-0b672d01cfc5"
             },
             {
               "name": "x-ms-version",
@@ -2355,7 +3301,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:11 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:15 GMT"
             }
           ],
           "headersSize": 295,
@@ -2364,8 +3310,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:10.988Z",
-        "time": 767,
+        "startedDateTime": "2021-09-26T12:32:14.153Z",
+        "time": 1156,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2373,315 +3319,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 767
+          "wait": 1156
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
-        "_order": 2,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-language",
-              "value": "en-US"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "480b13f4-4b5c-4c71-b869-4d809f5c8929"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": "fpc=Atviej9dBSRBqFgmAr_0iBkRsITIAQAAAEIC39cOAAAA"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            }
-          ],
-          "headersSize": 475,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
-        },
-        "response": {
-          "bodySize": 1316,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1316,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-12T18:58:11.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "sameSite": "none",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "0ce61d46-e507-4246-a423-ee65436c2600"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:11 GMT"
-            }
-          ],
-          "headersSize": 712,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-13T18:58:11.773Z",
-        "time": 80,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 80
-        }
-      },
-      {
-        "_id": "af6a01d1852c557b688492da54e4f9fe",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/xml"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-ms-client-request-id",
-              "value": "fe285207-e9cf-4639-a6b6-8341a0d66f9a"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "cookie",
-              "value": ""
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "ndowmon1j1dev.queue.core.windows.net"
-            }
-          ],
-          "headersSize": 1642,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "restype",
-              "value": "service"
-            },
-            {
-              "name": "comp",
-              "value": "properties"
-            },
-            {
-              "name": "timeout",
-              "value": "30"
-            }
-          ],
-          "url": "https://ndowmon1j1dev.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
-        },
-        "response": {
-          "bodySize": 626,
-          "content": {
-            "mimeType": "application/xml",
-            "size": 626,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
-            },
-            {
-              "name": "server",
-              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "7983feb6-e003-0039-643a-18b723000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "fe285207-e9cf-4639-a6b6-8341a0d66f9a"
-            },
-            {
-              "name": "x-ms-version",
-              "value": "2020-06-12"
-            },
-            {
-              "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:11 GMT"
-            }
-          ],
-          "headersSize": 321,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-13T18:58:11.860Z",
-        "time": 205,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 205
-        }
-      },
-      {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 3,
         "cache": {},
         "request": {
@@ -2706,17 +3348,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "7e914002-08b9-43c1-9ef6-77a1a02382a3"
+              "value": "73e2bd84-f9ee-4ad7-8900-ee5f79896ec3"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": ""
+              "value": "fpc=Agt-a_5MpPJPnLup9vT-4hU"
             },
             {
               "_fromType": "array",
@@ -2733,7 +3375,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 455,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2742,7 +3384,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -2753,7 +3395,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:12.000Z",
+              "expires": "2021-10-26T12:32:16.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -2809,11 +3451,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "5e9cdb7b-d94d-473b-b2c9-116192e81f00"
+              "value": "a7049e88-481d-4947-9faf-86f5a1cb1a00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.15 - NCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -2832,21 +3474,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:11 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:16 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:12.078Z",
-        "time": 153,
+        "startedDateTime": "2021-09-26T12:32:15.348Z",
+        "time": 941,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2854,11 +3496,472 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 153
+          "wait": 941
         }
       },
       {
-        "_id": "ee4f6ed8f5c33ad8b5cafac8001e69f6",
+        "_id": "8bb93cbc2d87e49d3993a0fdc741e834",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "153cdc3d-6ed7-45b4-8965-9441ea51c78a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "sqlvab7pt3ww5qhmdw.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1653,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1754c9d3-9003-002e-2cd2-b2c571000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "153cdc3d-6ed7-45b4-8965-9441ea51c78a"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:16 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:16.303Z",
+        "time": 1078,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1078
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9d3de57d-7b9e-4426-a72d-291216fa15b5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2168,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-28T20:32:17+08:00' and eventTimestamp le '2021-09-26T20:32:17+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-28T20%3A32%3A17%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-26T20%3A32%3A17%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_Storage_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstefanexamplestorage%27"
+        },
+        "response": {
+          "bodySize": 16343,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16343,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713/ticks/637680751208063831\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"9f9c4957-cbe0-4829-8e91-6ef594969333\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-24T10:12:00.8063831Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"8903f8d4-7a4c-456d-be34-33660212b2bd\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/8903f8d4-7a4c-456d-be34-33660212b2bd/ticks/637680751206863840\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T10:12:00.686384Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"927daf50-bb12-4bb1-960e-005dd0196385\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/927daf50-bb12-4bb1-960e-005dd0196385/ticks/637680036884982412\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"2fbc6389-ef5b-43c4-8771-5500d31026d5\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T14:21:28.4982412Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"f60bee7d-a7ea-4f59-9d88-658fafc85b1f\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/f60bee7d-a7ea-4f59-9d88-658fafc85b1f/ticks/637680036855632564\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T14:21:25.5632564Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0dde252b-5665-4e8a-a936-4daba0d8a575\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0dde252b-5665-4e8a-a936-4daba0d8a575/ticks/637677468635548611\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"b1001d0c-e882-4506-b8ab-9163d906f654\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-20T15:01:03.5548611Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0842ad8b-0a70-4ce5-8652-a7f2114e8000\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0842ad8b-0a70-4ce5-8652-a7f2114e8000/ticks/637677468633347789\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:01:03.3347789Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a/ticks/637666178855994320\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"2bc25043-553e-48b1-ad9b-ce9926416ca9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:45.599432Z\",\"submissionTimestamp\":\"2021-09-07T13:26:18.0982287Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b1dc8c9d-57e9-422f-b6b6-a2ab4089845e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/b1dc8c9d-57e9-422f-b6b6-a2ab4089845e/ticks/637666178612856613\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"06c3da4c-be9c-4b9c-9bb1-c29b06dc2943\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:21.2856613Z\",\"submissionTimestamp\":\"2021-09-07T13:25:26.1292429Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"fa96b680-b3f9-471c-a777-a69da710ac89\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/fa96b680-b3f9-471c-a777-a69da710ac89/ticks/637666172866182094\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ce0cce81-7af2-48c6-b614-da08e1048548\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.6182094Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"138520b9-0d15-4108-98e6-b26cfcaed86c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/138520b9-0d15-4108-98e6-b26cfcaed86c/ticks/637666172864682093\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:46.4682093Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b49bfb26-b7bd-488b-bf76-f4891ad74605\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/b49bfb26-b7bd-488b-bf76-f4891ad74605/ticks/637666172863682069\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"22765ce3-92ae-4aed-954d-7f26ab018c84\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.3682069Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"575b58d7-a757-4a45-aebe-40195806a39c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/575b58d7-a757-4a45-aebe-40195806a39c/ticks/637666172849132353\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:44.9132353Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"870fddbd-ee80-4254-b798-ab2e71de1de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/870fddbd-ee80-4254-b798-ab2e71de1de1/ticks/637666172832824197\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c6e734b2-12f7-4965-8ec4-f7feb27666b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:43.2824197Z\",\"submissionTimestamp\":\"2021-09-07T13:15:26.1178018Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"4e08dab9-10e0-49d3-abf6-4a61f7315de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4e08dab9-10e0-49d3-abf6-4a61f7315de1/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"75ec2246-b3ed-4a2a-8d99-85232ae352cd\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"f5231d65-9872-4ab7-82fa-030783fd80bd\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/f5231d65-9872-4ab7-82fa-030783fd80bd/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d1f0bd9a-7d00-4270-8164-a37d77ad40a8\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e50013de-1290-4050-945c-edd8ac16b016\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e50013de-1290-4050-945c-edd8ac16b016/ticks/637666172560836200\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_RAGRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"accessTier\\\":\\\"Hot\\\",\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":true,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:16.08362Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1731361Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_aa008ffdc72c4a72b4a579707ec690ea_637682563381240941"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11995"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "5418482c-02a5-42cd-b067-18d6d062f4e5"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210926T123218Z:5418482c-02a5-42cd-b067-18d6d062f4e5"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:17 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:17.406Z",
+        "time": 676,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 676
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8b3fb521-b2a1-495d-8814-323c41d0e1ce"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:18.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "aae7d3f0-a571-4307-9a53-eac625e41a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.15 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:17 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:18.103Z",
+        "time": 479,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 479
+        }
+      },
+      {
+        "_id": "396844fb10796ff14cd9ef4c38881321",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2873,12 +3976,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "79c25d2c-a8f5-49ff-91a9-e22ceb5566c2"
+              "value": "083e7034-2784-438c-a8a2-d6af71256c62"
             },
             {
               "_fromType": "array",
@@ -2897,10 +4000,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1devblobstorage.blob.core.windows.net"
+              "value": "stefanexamplestorage.blob.core.windows.net"
             }
           ],
-          "headersSize": 1607,
+          "headersSize": 1600,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2913,14 +4016,14 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1devblobstorage.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://stefanexamplestorage.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 651,
+          "bodySize": 762,
           "content": {
             "mimeType": "application/xml",
-            "size": 651,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+            "size": 762,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
@@ -2938,11 +4041,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "f477a148-a01e-0047-123a-1805fd000000"
+              "value": "e333f252-401e-006c-6fd2-b2fba3000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "79c25d2c-a8f5-49ff-91a9-e22ceb5566c2"
+              "value": "083e7034-2784-438c-a8a2-d6af71256c62"
             },
             {
               "name": "x-ms-version",
@@ -2950,7 +4053,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:12 GMT"
+              "value": "Sun, 26 Sep 2021 12:32:19 GMT"
             }
           ],
           "headersSize": 295,
@@ -2959,8 +4062,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:12.235Z",
-        "time": 167,
+        "startedDateTime": "2021-09-26T12:32:18.594Z",
+        "time": 1082,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2968,7 +4071,1063 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 167
+          "wait": 1082
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "39d42d75-c096-4e60-8a5b-5bad46bac22d"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=Ala2K19BwgtKt1ihx9Q4t14-ExxYAQAAAFFf4tgOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:20.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "ca7a1fad-3d4d-4667-808d-46c31ffa1e00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.15 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:19 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:19.696Z",
+        "time": 894,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 894
+        }
+      },
+      {
+        "_id": "35a194af62cb1877e4f3a2940d92adfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9fade15b-c292-4a07-b518-eb48d16ddfd9"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1657,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://stefanexamplestorage.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "79b049d4-3003-0066-6dd2-b25f14000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "9fade15b-c292-4a07-b518-eb48d16ddfd9"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:21 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:20.601Z",
+        "time": 1093,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1093
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "4dd3962e-1b8b-4d9d-9ec8-06b015f99a4c"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-28T20:32:21+08:00' and eventTimestamp le '2021-09-26T20:32:21+08:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-28T20%3A32%3A21%2B08%3A00%27%20and%20eventTimestamp%20le%20%272021-09-26T20%3A32%3A21%2B08%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_AppServices_Group%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstorageaccountstefaafb8%27"
+        },
+        "response": {
+          "bodySize": 13241,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 13241,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"9ab0273f-4168-420b-a82a-04a95ef004b9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/9ab0273f-4168-420b-a82a-04a95ef004b9/ticks/637680895404911980\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"e3e29761-cb4f-44b6-9c21-c4bef3490d74\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-24T14:12:20.491198Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"f3127244-2903-49eb-8290-896fb807e4bf\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f3127244-2903-49eb-8290-896fb807e4bf/ticks/637680895402811842\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T14:12:20.2811842Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"f4c0ba23-4f98-4def-837e-c8de0728547e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f4c0ba23-4f98-4def-837e-c8de0728547e/ticks/637680004888576312\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ccd64de2-9c2f-4578-8496-5808bf5ae478\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:28:08.8576312Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1600853Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"abee07ad-735f-4daf-a00b-dbcb2420491c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/abee07ad-735f-4daf-a00b-dbcb2420491c/ticks/637680004886626307\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:28:08.6626307Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1590849Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"609c11d9-f767-47fc-b7f6-2b01de6df6d3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/609c11d9-f767-47fc-b7f6-2b01de6df6d3/ticks/637680004138311948\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"aa7000e2-9f8d-45c0-8eaf-ab889d7022c8\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-23T13:26:53.8311948Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"f7bd6f5d-a4a6-459f-b677-7cc6aef350bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f7bd6f5d-a4a6-459f-b677-7cc6aef350bb/ticks/637680004131562335\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:26:53.1562335Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"95e08496-5682-44b1-aa43-bc8364b7f678\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/95e08496-5682-44b1-aa43-bc8364b7f678/ticks/637674012546036667\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"188d14f7-04dd-4948-acb1-1216172a19c3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:54.6036667Z\",\"submissionTimestamp\":\"2021-09-16T15:01:46.1692025Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"8a01ea00-bd83-41d8-8de7-bc51b80d4652\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/8a01ea00-bd83-41d8-8de7-bc51b80d4652/ticks/637674012295717803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"99bdf78f-4602-4a8c-83b4-19ed0c0e9cd1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:29.5717803Z\",\"submissionTimestamp\":\"2021-09-16T15:01:53.1386235Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"b30ffc87-ee15-41e7-81c0-0fb4b05895ff\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/b30ffc87-ee15-41e7-81c0-0fb4b05895ff/ticks/637674006534406250\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"3113ca2b-d2bc-4f4f-9a8f-89c167e9218a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-16T14:50:53.440625Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"01af52fc-5b12-4703-98b4-cc67db95435e\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/01af52fc-5b12-4703-98b4-cc67db95435e/ticks/637674006528456482\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:52.8456482Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"cf10aecf-4960-4246-8021-a91b9767a6ee\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/cf10aecf-4960-4246-8021-a91b9767a6ee/ticks/637674006518718327\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ce1ef8-dabe-4c1b-a7f3-06409c83d4e5\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:51.8718327Z\",\"submissionTimestamp\":\"2021-09-16T14:52:09.1184465Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"18d6742e-9780-4410-87f2-7861ad8ebcaf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/18d6742e-9780-4410-87f2-7861ad8ebcaf/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46e3061f-4966-444c-8a1a-5fcc9c793c50\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"e279382a-ca7b-4fb4-bca3-d72bbacb841b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/e279382a-ca7b-4fb4-bca3-d72bbacb841b/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"36894b22-1fe1-4514-a797-ba687ae30306\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"0ee36506-e3f0-4f97-9a2f-deccfc7f3576\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/0ee36506-e3f0-4f97-9a2f-deccfc7f3576/ticks/637674006235104764\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"location\\\":\\\"Central US\\\",\\\"properties\\\":{\\\"supportsHttpsTrafficOnly\\\":true,\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:23.5104764Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.1747877Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "EastAsia_baccfc6f609441398ea9f35086521bbf_637682563425146428"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "23635529-71f6-4f8a-9dab-0c973ddd91c6"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "EASTASIA:20210926T123222Z:23635529-71f6-4f8a-9dab-0c973ddd91c6"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:22 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:21.713Z",
+        "time": 771,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 771
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "257f085c-a27c-480d-aa2c-6115ce430cb9"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 428,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:23.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2938910f-bc78-4b7d-ac2a-fcade65b1f00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.15 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:22 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 696,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:22.508Z",
+        "time": 1050,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1050
+        }
+      },
+      {
+        "_id": "11cca1bdf5f08f97880274f522d9c376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "590f9eb2-c71f-4550-b0a4-216de28df9cc"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1606,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 694,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 694,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "3e2218ea-101e-0064-2ad2-b219c7000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "590f9eb2-c71f-4550-b0a4-216de28df9cc"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:24 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:23.570Z",
+        "time": 961,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 961
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8040173f-595b-479c-812d-e6c4dde7f070"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.17.6 OS/(x64-Darwin-20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=AhDAemDp6q5Gre7T83o3NtU"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 455,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-26T12:32:25.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0f9f9943-6e57-408d-89a3-6f09911e1e00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:24 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:24.554Z",
+        "time": 746,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 746
+        }
+      },
+      {
+        "_id": "dd3d6e3698ab7e26997ca5b4d8d2d5d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.17.6; Darwin 20.6.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "30f07721-4d5d-433b-8f7c-d689378459bc"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1663,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "af48ae1a-3003-005a-05d2-b2afe6000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "30f07721-4d5d-433b-8f7c-d689378459bc"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 26 Sep 2021 12:32:26 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-26T12:32:25.313Z",
+        "time": 988,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 988
         }
       }
     ],

--- a/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-containers_2223249107/recording.har
+++ b/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-containers_2223249107/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -59,18 +59,18 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
-          "bodySize": 1615,
+          "bodySize": 1671,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1615,
+            "size": 1671,
             "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:36.000Z",
+              "expires": "2021-10-27T12:54:56.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -126,11 +126,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "d8649fca-4468-4376-90cd-f5d757932100"
+              "value": "7ef39528-80f4-42c4-bdcc-7e17cb908600"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "_fromType": "array",
@@ -149,7 +149,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:36 GMT"
+              "value": "Mon, 27 Sep 2021 12:54:56 GMT"
             },
             {
               "name": "connection",
@@ -157,17 +157,17 @@
             },
             {
               "name": "content-length",
-              "value": "1615"
+              "value": "1671"
             }
           ],
-          "headersSize": 731,
+          "headersSize": 736,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:36.540Z",
-        "time": 286,
+        "startedDateTime": "2021-09-27T12:54:56.010Z",
+        "time": 1025,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -175,7 +175,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 286
+          "wait": 1025
         }
       },
       {
@@ -194,7 +194,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "9ac1e41b-8fee-6fe1-3925-cea99106ce88"
+              "value": "7eb8bb41-696b-9f24-247a-aa1daaa46bd0"
             },
             {
               "_fromType": "array",
@@ -226,18 +226,18 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1880,
+          "headersSize": 1936,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://graph.microsoft.com/v1.0/organization"
         },
         "response": {
-          "bodySize": 1358,
+          "bodySize": 1470,
           "content": {
             "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
-            "size": 1358,
-            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/992d7bbe-b367-459c-a10f-cf3fd16103ab/directoryObjects/992d7bbe-b367-459c-a10f-cf3fd16103ab/Microsoft.DirectoryServices.Organization\",\"id\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2020-07-16T17:54:20Z\",\"displayName\":\"Default Directory\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"ndowmon@gmail.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":192,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2020-09-15T15:38:22Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"ndowmongmail.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
+            "size": 1470,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/19ae0f99-6fc6-444b-bd54-97504efc66ad/directoryObjects/19ae0f99-6fc6-444b-bd54-97504efc66ad/Microsoft.DirectoryServices.Organization\",\"id\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2021-09-01T14:59:04Z\",\"dataBoundary\":\"None\",\"displayName\":\"JupiterOne Azure Integration Development\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"nick.dowmon_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":111,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2021-09-01T20:02:55Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"j1AzureIntegrationDev.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +247,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:36 GMT"
+              "value": "Mon, 27 Sep 2021 12:54:57 GMT"
             },
             {
               "name": "content-type",
@@ -267,15 +267,15 @@
             },
             {
               "name": "request-id",
-              "value": "6450aedf-a22e-4384-a1a6-84fc5068f063"
+              "value": "16ad260c-f0ef-420e-93ed-594c911fd67d"
             },
             {
               "name": "client-request-id",
-              "value": "9ac1e41b-8fee-6fe1-3925-cea99106ce88"
+              "value": "7eb8bb41-696b-9f24-247a-aa1daaa46bd0"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"005\",\"RoleInstance\":\"CH01EPF000051E6\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"West Europe\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"AM1PEPF000057F3\"}}"
             },
             {
               "name": "x-ms-resource-unit",
@@ -286,14 +286,14 @@
               "value": "4.0"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 607,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:36.828Z",
-        "time": 283,
+        "startedDateTime": "2021-09-27T12:54:57.053Z",
+        "time": 442,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,7 +301,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 283
+          "wait": 442
         }
       },
       {
@@ -320,7 +320,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "4b731e31-1d41-7ffd-4124-efedeeb4137b"
+              "value": "99cabf2d-e736-9077-1562-e2c04e87f74d"
             },
             {
               "_fromType": "array",
@@ -352,7 +352,7 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1918,
+          "headersSize": 1974,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -373,7 +373,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:37 GMT"
+              "value": "Mon, 27 Sep 2021 12:54:59 GMT"
             },
             {
               "name": "content-type",
@@ -397,29 +397,29 @@
             },
             {
               "name": "request-id",
-              "value": "a7dfc231-376b-4d9a-8b8a-8ff8dc794c28"
+              "value": "91700a95-abe1-46ac-95af-e1c4596eb605"
             },
             {
               "name": "client-request-id",
-              "value": "4b731e31-1d41-7ffd-4124-efedeeb4137b"
+              "value": "99cabf2d-e736-9077-1562-e2c04e87f74d"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"005\",\"RoleInstance\":\"CH01EPF00005069\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"West Europe\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"AM1PEPF000057DD\"}}"
             },
             {
               "name": "odata-version",
               "value": "4.0"
             }
           ],
-          "headersSize": 611,
+          "headersSize": 606,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:37.116Z",
-        "time": 548,
+        "startedDateTime": "2021-09-27T12:54:57.504Z",
+        "time": 2445,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -427,11 +427,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 548
+          "wait": 2445
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 0,
         "cache": {},
         "request": {
@@ -448,7 +448,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "7ca0a325-9eb4-4e41-a9db-02c54e03c082"
+              "value": "ab2e9faf-ee0a-44ad-b403-daf2acc755b5"
             },
             {
               "name": "return-client-request-id",
@@ -464,7 +464,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -479,7 +479,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -493,18 +493,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665517\",\"not_before\":\"1615661617\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750900\",\"not_before\":\"1632747000\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:37.000Z",
+              "expires": "2021-10-27T12:55:00.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -558,15 +558,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "7ca0a325-9eb4-4e41-a9db-02c54e03c082"
+              "value": "ab2e9faf-ee0a-44ad-b403-daf2acc755b5"
             },
             {
               "name": "x-ms-request-id",
-              "value": "e2788bc3-dac4-4918-b003-66652a6e2100"
+              "value": "7dba225b-e88f-4896-9556-af3c4f4a4800"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - NCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -589,7 +589,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:37 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:00 GMT"
             },
             {
               "name": "connection",
@@ -600,14 +600,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:37.669Z",
-        "time": 172,
+        "startedDateTime": "2021-09-27T12:55:00.032Z",
+        "time": 739,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -615,11 +615,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 739
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 0,
         "cache": {},
         "request": {
@@ -634,7 +634,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "6aeef2c9-4a65-4d2b-88ff-5f8302b11c81"
+              "value": "4d64e55a-baa8-4d5a-8f55-c52c592e211e"
             },
             {
               "_fromType": "array",
@@ -649,7 +649,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -676,7 +676,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -688,11 +688,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -722,15 +722,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "e734a572-fcfd-475b-87aa-bc88455f6e26"
+              "value": "821b0af0-3496-445e-8a2a-1ec55a9e27e7"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "e734a572-fcfd-475b-87aa-bc88455f6e26"
+              "value": "821b0af0-3496-445e-8a2a-1ec55a9e27e7"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185838Z:e734a572-fcfd-475b-87aa-bc88455f6e26"
+              "value": "GERMANYWESTCENTRAL:20210927T125501Z:821b0af0-3496-445e-8a2a-1ec55a9e27e7"
             },
             {
               "name": "strict-transport-security",
@@ -742,7 +742,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:37 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:00 GMT"
             },
             {
               "name": "connection",
@@ -750,17 +750,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:37.845Z",
-        "time": 332,
+        "startedDateTime": "2021-09-27T12:55:00.835Z",
+        "time": 830,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -768,11 +768,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 332
+          "wait": 830
         }
       },
       {
-        "_id": "c9d6dbee91365ea9a6e208a3dd1605c4",
+        "_id": "65b39ca75483f0ca33c5ac4a87ec1aa8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -792,7 +792,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "2aaba86e-e3c6-4930-9a9d-c0cfef97d000"
+              "value": "1b7638d1-9c98-4709-8d13-07cef49ea37d"
             },
             {
               "_fromType": "array",
@@ -802,7 +802,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -829,7 +829,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1806,
+          "headersSize": 1816,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -838,14 +838,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 2459,
+          "bodySize": 1459,
           "content": {
-            "mimeType": "application/json",
-            "size": 2459,
-            "text": "{\"value\":[{\"identity\":{\"principalId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"SystemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"resourceAccessRules\":[],\"bypass\":\"Logging, Metrics, AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[{\"value\":\"76.182.33.160\",\"action\":\"Allow\"}],\"defaultAction\":\"Deny\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://ndowmon11-j1dev.vault.azure.net/keys/j1dev/325432ed4deb46bebe09d39dc071f090\",\"lastKeyRotationTimestamp\":\"2021-03-09T16:48:13.3984368Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"keyname\":\"j1dev\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.2628136Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1dev.dfs.core.windows.net/\",\"web\":\"https://ndowmon1j1dev.z13.web.core.windows.net/\",\"blob\":\"https://ndowmon1j1dev.blob.core.windows.net/\",\"queue\":\"https://ndowmon1j1dev.queue.core.windows.net/\",\"table\":\"https://ndowmon1j1dev.table.core.windows.net/\",\"file\":\"https://ndowmon1j1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1devblobstorage\",\"name\":\"ndowmon1j1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.3721528Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://ndowmon1j1devblobstorage.blob.core.windows.net/\",\"table\":\"https://ndowmon1j1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1459,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"name\":\"regenerateaccesskeytest\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnections/regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"name\":\"regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"type\":\"Microsoft.Storage/storageAccounts/privateEndpointConnections\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateEndpoint\":{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints/private-endpoint\"},\"privateLinkServiceConnectionState\":{\"status\":\"Approved\",\"description\":\"Auto-Approved\",\"actionRequired\":\"None\"}}}],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-20T15:02:41.5642636Z\",\"primaryEndpoints\":{\"web\":\"https://regenerateaccesskeytest.z13.web.core.windows.net/\",\"blob\":\"https://regenerateaccesskeytest.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"name\":\"sqlvab7pt3ww5qhmdw\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-23T11:32:50.8155392Z\",\"primaryEndpoints\":{\"dfs\":\"https://sqlvab7pt3ww5qhmdw.dfs.core.windows.net/\",\"web\":\"https://sqlvab7pt3ww5qhmdw.z13.web.core.windows.net/\",\"blob\":\"https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/\",\"queue\":\"https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/\",\"table\":\"https://sqlvab7pt3ww5qhmdw.table.core.windows.net/\",\"file\":\"https://sqlvab7pt3ww5qhmdw.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"name\":\"stefanexamplestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-07T13:14:18.4460771Z\",\"primaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage.table.core.windows.net/\",\"file\":\"https://stefanexamplestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage-secondary.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage-secondary.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage-secondary.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage-secondary.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"name\":\"storageaccountstefaafb8\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"centralus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-16T14:50:27.0370951Z\",\"primaryEndpoints\":{\"blob\":\"https://storageaccountstefaafb8.blob.core.windows.net/\",\"queue\":\"https://storageaccountstefaafb8.queue.core.windows.net/\",\"table\":\"https://storageaccountstefaafb8.table.core.windows.net/\",\"file\":\"https://storageaccountstefaafb8.file.core.windows.net/\"},\"primaryLocation\":\"centralus\",\"statusOfPrimary\":\"available\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -859,7 +859,7 @@
             },
             {
               "name": "content-type",
-              "value": "application/json"
+              "value": "application/json; charset=utf-8"
             },
             {
               "name": "expires",
@@ -870,28 +870,28 @@
               "value": "Accept-Encoding"
             },
             {
+              "name": "x-ms-original-request-ids",
+              "value": "a402ace5-665b-4439-b1ef-2bf8e1e509a0, 0a1fe541-0980-45ae-b1b4-4569f0b4cf55"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
               "name": "x-ms-request-id",
-              "value": "80782e10-bdbc-4e66-a986-87ae0adbb5db"
+              "value": "fa6ca2e6-d2f7-4e79-9660-60f4dbd80de7"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "fa6ca2e6-d2f7-4e79-9660-60f4dbd80de7"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125502Z:fa6ca2e6-d2f7-4e79-9660-60f4dbd80de7"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "46bc45ff-20de-4955-9c9e-64f0ba3071cf"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185838Z:46bc45ff-20de-4955-9c9e-64f0ba3071cf"
             },
             {
               "name": "x-content-type-options",
@@ -899,21 +899,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:38 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:02 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1459"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 703,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:38.182Z",
-        "time": 306,
+        "startedDateTime": "2021-09-27T12:55:01.687Z",
+        "time": 705,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -921,11 +925,509 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 306
+          "wait": 705
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "509d4405-e286-4c21-8073-cf4e122aebf5"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750903\",\"not_before\":\"1632747003\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:03.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "509d4405-e286-4c21-8073-cf4e122aebf5"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "955d3a63-14df-4424-9f7b-c3188cbc8b00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:03 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:02.406Z",
+        "time": 895,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 895
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f14692f9-1304-4224-b77a-d6864827d182"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "e550bf23-e7cb-4fa0-8d47-138351aa3984"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "e550bf23-e7cb-4fa0-8d47-138351aa3984"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125504Z:e550bf23-e7cb-4fa0-8d47-138351aa3984"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:04 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 593,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:03.307Z",
+        "time": 926,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 926
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "54c59f5d-0b1d-46c3-b836-5f23be379eb6"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:55:04+02:00' and eventTimestamp le '2021-09-27T14:55:04+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A55%3A04%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A55%3A04%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FDefaultResourceGroup-CUS%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fregenerateaccesskeytest%27"
+        },
+        "response": {
+          "bodySize": 27501,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 27501,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"e1996591-2700-4c40-b9ff-ebf8bad0fae7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/e1996591-2700-4c40-b9ff-ebf8bad0fae7/ticks/637683129742655982\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"40279215-5610-4fa4-89f0-405b7436c005\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:16:14.2655982Z\",\"submissionTimestamp\":\"2021-09-27T04:17:32.135054Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"5883d6b0-5eee-4c9d-ad2d-4ff594fdc746\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/5883d6b0-5eee-4c9d-ad2d-4ff594fdc746/ticks/637683129571384933\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"a5b002d2-b372-4b40-952a-4a7b0a3a3514\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-27T04:15:57.1384933Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"38134267-7818-43f4-993d-0131dbfac8ab\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/38134267-7818-43f4-993d-0131dbfac8ab/ticks/637683129569535355\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:56.9535355Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"a6756e91-3abe-4431-b98b-912a630b7311\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/a6756e91-3abe-4431-b98b-912a630b7311/ticks/637683129448318219\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"00f3e1ef-04b2-411f-a58e-1f9532f921db\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T04:15:44.8318219Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"584d2154-ac7b-40bd-9794-5bf34a360f24\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/584d2154-ac7b-40bd-9794-5bf34a360f24/ticks/637683129446517689\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:44.6517689Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"a704a2cb-eb4d-4a35-805e-ead94ad19f43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/a704a2cb-eb4d-4a35-805e-ead94ad19f43/ticks/637680001929101036\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"0225ea72-f781-4f6e-9fe5-d6a0c2474557\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:23:12.9101036Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"ee04b008-d832-4d27-a31d-d6477b7c56bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ee04b008-d832-4d27-a31d-d6477b7c56bb/ticks/637680001926901032\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:23:12.6901032Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"47870c69-2372-4d1a-9917-44ee82af3d43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/47870c69-2372-4d1a-9917-44ee82af3d43/ticks/637679999082738446\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"31101762-006a-4ed7-89d9-49ca3036ab80\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:18:28.2738446Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"0bb50929-cabd-4f23-9f59-230d8444fdc2\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/0bb50929-cabd-4f23-9f59-230d8444fdc2/ticks/637679999074987777\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:18:27.4987777Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"9f03ce09-20a6-4d06-95d4-ef9682fe9dcb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9f03ce09-20a6-4d06-95d4-ef9682fe9dcb/ticks/637679990444693037\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4e305746-c740-4588-b06a-7d6040286b8a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:04:04.4693037Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"cafd852a-38ab-43de-9c4e-8ae9d2e0aa39\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cafd852a-38ab-43de-9c4e-8ae9d2e0aa39/ticks/637679990442442997\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:04:04.2442997Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"70e4e7f2-a8fb-42fe-8940-2777f9f0d373\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/70e4e7f2-a8fb-42fe-8940-2777f9f0d373/ticks/637679185425534061\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8d275523-3648-4cb1-9685-2170c4968840\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:22.5534061Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"8777e717-fee0-422a-ae58-7e871fdf0394\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/8777e717-fee0-422a-ae58-7e871fdf0394/ticks/637679185423183513\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:22.3183513Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"28e8a43f-d061-4b3d-b13c-ae0cc610de21\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/28e8a43f-d061-4b3d-b13c-ae0cc610de21/ticks/637679185357882256\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1d0fc11b-5f8a-414e-b58f-a17cf1e90f0f\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:15.7882256Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"d1f38226-b5fc-4ff8-9a00-3093b11f81c0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d1f38226-b5fc-4ff8-9a00-3093b11f81c0/ticks/637679185355782736\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:15.5782736Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac/ticks/637679179809610416\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"47695443-19d5-493e-a4e8-7789b0e60377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:33:00.9610416Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"d0717133-9bd8-40f6-9771-8b3f656b9068\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d0717133-9bd8-40f6-9771-8b3f656b9068/ticks/637679179807409713\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:33:00.7409713Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"62f1c7a0-52d0-47e8-831e-52bb6a043101\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/62f1c7a0-52d0-47e8-831e-52bb6a043101/ticks/637677475939857920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1cc9b1d1-3ad3-4be5-804d-107cff738cd4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:13:13.985792Z\",\"submissionTimestamp\":\"2021-09-20T15:14:24.1932217Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"f0381753-4ff1-45ed-99df-0a0f74f21bb7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/f0381753-4ff1-45ed-99df-0a0f74f21bb7/ticks/637677475660997035\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"446855e9-2947-4f06-9ddb-4249a30ad8e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:12:46.0997035Z\",\"submissionTimestamp\":\"2021-09-20T15:14:11.1254588Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"1813f4e7-9bf6-4710-ac12-489b32de7fd6\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1813f4e7-9bf6-4710-ac12-489b32de7fd6/ticks/637677474240400287\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1608dd41-cc4f-471b-8c4d-3a4393333377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:24.0400287Z\",\"submissionTimestamp\":\"2021-09-20T15:13:05.4897023Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"e0f6b157-a5ea-4c30-948d-5f3b5b30f14a\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e0f6b157-a5ea-4c30-948d-5f3b5b30f14a/ticks/637677474232600486\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:23.2600486Z\",\"submissionTimestamp\":\"2021-09-20T15:12:05.1607741Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"848862b2-56a3-4837-9562-bbd64dad53cc\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/848862b2-56a3-4837-9562-bbd64dad53cc/ticks/637677474228858674\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"90c74ebf-f83f-4196-8840-c20aa40bc0ca\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:22.8858674Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"83c32961-cc44-4648-9186-5d672cf75d83\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/83c32961-cc44-4648-9186-5d672cf75d83/ticks/637677474226509192\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:22.6509192Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"e4c18ff5-a195-41b8-89b0-cab13faa6f27\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e4c18ff5-a195-41b8-89b0-cab13faa6f27/ticks/637677471861822795\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"a40adc80-7e2f-4c2b-9621-5cc901366e2a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:26.1822795Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556/ticks/637677471859722688\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.9722688Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"cf6386d9-e6ab-42bd-9e5a-83cefa4c8199\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cf6386d9-e6ab-42bd-9e5a-83cefa4c8199/ticks/637677471856711620\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ea0187af-8198-4c98-97bd-4220a5bcd942\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.671162Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"b0e07419-dc8f-414f-82cd-53f01df6a401\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b0e07419-dc8f-414f-82cd-53f01df6a401/ticks/637677471854611536\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.4611536Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"d8243a16-ab46-4322-8dea-d563d7f88d39\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d8243a16-ab46-4322-8dea-d563d7f88d39/ticks/637677471851671673\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fb259f93-8cbf-4974-83a9-6862b96eb049\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.1671673Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"6154366b-4323-45a8-b328-4d746d69a1d9\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6154366b-4323-45a8-b328-4d746d69a1d9/ticks/637677471847621619\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"requestbody\":\"{\\\"keyName\\\":\\\"key1\\\"}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:24.7621619Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"2fa63062-2f22-4759-90af-464f8be3b5c3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/2fa63062-2f22-4759-90af-464f8be3b5c3/ticks/637677471779112974\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4b5c0812-a756-4dda-97af-8ba7463e5d4c\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:17.9112974Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"6bd2ac81-1521-409d-ab9f-62a24b0ffd2d\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6bd2ac81-1521-409d-ab9f-62a24b0ffd2d/ticks/637677471777013163\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:17.7013163Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"6f2ead07-65c7-4527-8729-88a168ace6e9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/6f2ead07-65c7-4527-8729-88a168ace6e9/ticks/637677469905184323\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"5095ece2-d23b-4405-9663-0319f48b0234\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:03:10.5184323Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"85385ce4-5123-480f-b5ca-93ad14251b67\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/85385ce4-5123-480f-b5ca-93ad14251b67/ticks/637677469895868920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"257770ea-c767-43e6-8175-a296a4200be4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.586892Z\",\"submissionTimestamp\":\"2021-09-20T15:04:47.0753231Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1eed7870-0320-420b-ba7a-9c8a375031d0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/1eed7870-0320-420b-ba7a-9c8a375031d0/ticks/637677469894434112\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.4434112Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"9e8ec575-53e1-4cdf-aac6-1b6fe831f315\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9e8ec575-53e1-4cdf-aac6-1b6fe831f315/ticks/637677469636227096\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"57dc2ec8-7845-4db5-b514-99690b6a867b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6227096Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"ff1449dd-10cf-4a75-bbfc-f243cc8c63da\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ff1449dd-10cf-4a75-bbfc-f243cc8c63da/ticks/637677469636177088\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"5adc31a9-0f71-4dc9-b0d6-b2b7a3ef6cf0\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6177088Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1fd27944-0a26-4bb1-a0e3-fba30c720db0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1fd27944-0a26-4bb1-a0e3-fba30c720db0/ticks/637677469575072028\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Premium_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":false,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:37.5072028Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_f052be802f6443fd94cf1cc5764d403c_637683441050795530"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "d7fa3a09-722f-4fc4-8b84-e4a919baeecf"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125505Z:d7fa3a09-722f-4fc4-8b84-e4a919baeecf"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:04 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:04.243Z",
+        "time": 857,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 857
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 1,
         "cache": {},
         "request": {
@@ -950,12 +1452,12 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "22ecd6f3-fc70-4486-9e90-3353ed54379b"
+              "value": "736b9f50-6168-413a-8853-d9eda1bddc2b"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -977,7 +1479,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -986,7 +1488,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -997,7 +1499,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:38.000Z",
+              "expires": "2021-10-27T12:55:05.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1032,10 +1534,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -1057,11 +1555,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "d00c8bd0-daec-4b06-8911-bfe881a92300"
+              "value": "febfba5a-4daf-47e2-bb1f-a2f757884300"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1080,17 +1578,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:37 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:05 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 716,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:38.495Z",
-        "time": 153,
+        "startedDateTime": "2021-09-27T12:55:05.152Z",
+        "time": 746,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1098,11 +1600,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 153
+          "wait": 746
         }
       },
       {
-        "_id": "5dbc34c006894f7ce143f08803d3acba",
+        "_id": "12ec0509765fac63d7064f131c7b3918",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1117,12 +1619,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "b612fd60-6eeb-4d66-aaed-e1046fbbdd8e"
+              "value": "e9af0aa3-8420-4ac0-be8d-0e47b786145e"
             },
             {
               "_fromType": "array",
@@ -1141,10 +1643,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.blob.core.windows.net"
+              "value": "regenerateaccesskeytest.blob.core.windows.net"
             }
           ],
-          "headersSize": 1585,
+          "headersSize": 1615,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1157,24 +1659,20 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1dev.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://regenerateaccesskeytest.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 805,
+          "bodySize": 236,
           "content": {
-            "mimeType": "application/xml",
-            "size": 805,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+            "mimeType": "text/plain",
+            "size": 236,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
+              "name": "content-length",
+              "value": "236"
             },
             {
               "name": "server",
@@ -1182,29 +1680,29 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "917fcfdb-a01e-0038-6d3a-18e8ff000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "b612fd60-6eeb-4d66-aaed-e1046fbbdd8e"
+              "value": "49ab092a-301c-00d4-809e-b3ab92000000"
             },
             {
               "name": "x-ms-version",
               "value": "2020-06-12"
             },
             {
+              "name": "x-ms-client-request-id",
+              "value": "e9af0aa3-8420-4ac0-be8d-0e47b786145e"
+            },
+            {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:39 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:06 GMT"
             }
           ],
-          "headersSize": 295,
+          "headersSize": 257,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:38.656Z",
-        "time": 1054,
+        "startedDateTime": "2021-09-27T12:55:05.908Z",
+        "time": 682,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1212,11 +1710,168 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1054
+          "wait": 682
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "5769a3ed-a9e4-42c2-bd68-202a777988ce"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:55:06+02:00' and eventTimestamp le '2021-09-27T14:55:06+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A55%3A06%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A55%3A06%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_SQL_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fsqlvab7pt3ww5qhmdw%27"
+        },
+        "response": {
+          "bodySize": 12761,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 12761,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"1bf92f9b-047b-4228-84df-7c2ed64bacdf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/1bf92f9b-047b-4228-84df-7c2ed64bacdf/ticks/637679941964644382\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46f46d72-c836-4fb5-81df-39d87ee35361\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:43:16.4644382Z\",\"submissionTimestamp\":\"2021-09-23T11:45:03.183974Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0/ticks/637679941750596914\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"'audit' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"e4bbfd9b-2399-4547-bc1b-72028b20383d\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/e4bbfd9b-2399-4547-bc1b-72028b20383d/ticks/637679941750596914\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"'auditIfNotExists' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"5e859926-06ba-422b-b976-128ae719d9c5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/5e859926-06ba-422b-b976-128ae719d9c5/ticks/637679941731506587\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"3d667eff-b604-4b94-9aa0-f6ae6b20cd2e\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:53.1506587Z\",\"submissionTimestamp\":\"2021-09-23T11:43:29.1239763Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44a7cc1c-09a5-408a-bb6d-7159bd091493\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/44a7cc1c-09a5-408a-bb6d-7159bd091493/ticks/637679936036356606\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"57d231f9-c955-4a39-81a7-e0ca1179c7c3\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T11:33:23.6356606Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1880622Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"c997130c-e08c-4218-8c43-b292200e4d82\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/c997130c-e08c-4218-8c43-b292200e4d82/ticks/637679936001153487\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"scope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:20.1153487Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1860603Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"db28785d-d234-4156-85d1-f93663a89aa7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/db28785d-d234-4156-85d1-f93663a89aa7/ticks/637679935941633332\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1645c04a-9f69-472c-8224-c5be3334796c\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:14.1633332Z\",\"submissionTimestamp\":\"2021-09-23T11:34:50.1441225Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"685222b6-8e45-4a6f-9116-77895f3c68eb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/685222b6-8e45-4a6f-9116-77895f3c68eb/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"5f9205a3-3c45-4db5-abf6-4cbba8b09865\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d4290f0f-f81f-48ff-8d26-686074ca277a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d4290f0f-f81f-48ff-8d26-686074ca277a/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"463cb640-befe-45af-b4d7-b5470a837a59\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"b821643d-9081-4a4b-a57c-2f8ca07b7002\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/b821643d-9081-4a4b-a57c-2f8ca07b7002/ticks/637679935726410258\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:52.6410258Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"dab4de05-9d1d-41af-bda7-78b884be52d5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/dab4de05-9d1d-41af-bda7-78b884be52d5/ticks/637679935680160357\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/2a1a9cdf-e04d-429a-8416-3bfb72a1b26f/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountsShouldRestrictNetworkAccessUsingVirtualNetworkRulesMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\\\",\\\"policyDefinitionEffect\\\":\\\"Audit\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:48.0160357Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d5d150f2-829f-42ea-8a70-cb7aead80689\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d5d150f2-829f-42ea-8a70-cb7aead80689/ticks/637679935679959308\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":\\\"true\\\",\\\"allowBlobPublicAccess\\\":\\\"false\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:47.9959308Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_851124c8e2f5456fab2e5ee345016d6a_637683441075822698"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "769a9092-ee67-4c3f-8ea4-8f65c131606b"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125507Z:769a9092-ee67-4c3f-8ea4-8f65c131606b"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:06 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:06.660Z",
+        "time": 960,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 960
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 2,
         "cache": {},
         "request": {
@@ -1241,17 +1896,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "52425656-0e3c-49b2-80c3-72ad319f1d0f"
+              "value": "84998a24-1c91-4029-819b-82219b7545fb"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": "fpc=AurHrL4sIRpPv9Iv0NzObZoRsITIAQAAAF0C39cOAAAA"
+              "value": ""
             },
             {
               "_fromType": "array",
@@ -1268,7 +1923,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 475,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1277,7 +1932,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -1288,7 +1943,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:39.000Z",
+              "expires": "2021-10-27T12:55:08.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1344,11 +1999,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "2628e850-d5ff-4f9f-b3c2-163532ce2400"
+              "value": "2ca591cb-0ee6-45ee-9e4f-cdf95de88b00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1367,21 +2022,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:39 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:08 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:39.716Z",
-        "time": 84,
+        "startedDateTime": "2021-09-27T12:55:07.630Z",
+        "time": 923,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1389,11 +2044,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 923
         }
       },
       {
-        "_id": "af6a01d1852c557b688492da54e4f9fe",
+        "_id": "155a15bd9bc9daa4c43589a03bdf5d4b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1407,18 +2062,13 @@
             },
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "application/xml"
-            },
-            {
-              "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "bc4cf3ae-121f-458d-b94d-38b612ff9379"
+              "value": "45d0cc0b-0c6a-4e32-80ca-0c9a5fb8172b"
             },
             {
               "_fromType": "array",
@@ -1432,15 +2082,15 @@
             },
             {
               "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "accept",
+              "value": "*/*"
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.queue.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.blob.core.windows.net"
             }
           ],
-          "headersSize": 1642,
+          "headersSize": 1605,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1451,27 +2101,19 @@
             {
               "name": "comp",
               "value": "properties"
-            },
-            {
-              "name": "timeout",
-              "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1dev.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+          "url": "https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 626,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/xml",
-            "size": 626,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+            "size": 749,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
             {
               "name": "transfer-encoding",
               "value": "chunked"
@@ -1482,15 +2124,15 @@
             },
             {
               "name": "server",
-              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
             },
             {
               "name": "x-ms-request-id",
-              "value": "da070a6c-c003-00b8-613a-1817f9000000"
+              "value": "f5fcff62-901e-0011-2d9e-b30dd2000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "bc4cf3ae-121f-458d-b94d-38b612ff9379"
+              "value": "45d0cc0b-0c6a-4e32-80ca-0c9a5fb8172b"
             },
             {
               "name": "x-ms-version",
@@ -1498,17 +2140,17 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:39 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:08 GMT"
             }
           ],
-          "headersSize": 321,
+          "headersSize": 295,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:39.805Z",
-        "time": 202,
+        "startedDateTime": "2021-09-27T12:55:08.558Z",
+        "time": 587,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1516,11 +2158,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 202
+          "wait": 587
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 3,
         "cache": {},
         "request": {
@@ -1545,17 +2187,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "411f640d-3bd6-491e-9e35-789879f6cdcc"
+              "value": "582ff502-46ba-4c74-89dc-0820bddcefe6"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": ""
+              "value": "fpc=AjUJNm0yr-lClI0GNXJKDNM-ExxYAQAAACu249gOAAAA"
             },
             {
               "_fromType": "array",
@@ -1572,7 +2214,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 485,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1581,7 +2223,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -1592,7 +2234,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:40.000Z",
+              "expires": "2021-10-27T12:55:09.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1648,11 +2290,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "26ca137f-68e7-4111-9e76-47d76f772100"
+              "value": "cbd9f809-5cc2-4d64-92b7-307b9a744900"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1671,21 +2313,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:39 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:09 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 716,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:40.016Z",
-        "time": 164,
+        "startedDateTime": "2021-09-27T12:55:09.163Z",
+        "time": 478,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1693,11 +2335,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 164
+          "wait": 478
         }
       },
       {
-        "_id": "ee4f6ed8f5c33ad8b5cafac8001e69f6",
+        "_id": "8bb93cbc2d87e49d3993a0fdc741e834",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1711,13 +2353,18 @@
             },
             {
               "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "8aa5bee5-644f-4a24-9dac-48d6004bc870"
+              "value": "5cbb289f-887c-4494-8858-8a2c97199878"
             },
             {
               "_fromType": "array",
@@ -1731,15 +2378,15 @@
             },
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
             },
             {
               "name": "host",
-              "value": "ndowmon1j1devblobstorage.blob.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.queue.core.windows.net"
             }
           ],
-          "headersSize": 1607,
+          "headersSize": 1662,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1750,19 +2397,27 @@
             {
               "name": "comp",
               "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1devblobstorage.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
         },
         "response": {
-          "bodySize": 651,
+          "bodySize": 573,
           "content": {
             "mimeType": "application/xml",
-            "size": 651,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
             {
               "name": "transfer-encoding",
               "value": "chunked"
@@ -1773,15 +2428,15 @@
             },
             {
               "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
             },
             {
               "name": "x-ms-request-id",
-              "value": "361fab02-b01e-0074-193a-185a56000000"
+              "value": "e121392b-6003-0015-7d9e-b380d5000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "8aa5bee5-644f-4a24-9dac-48d6004bc870"
+              "value": "5cbb289f-887c-4494-8858-8a2c97199878"
             },
             {
               "name": "x-ms-version",
@@ -1789,17 +2444,17 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:39 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:09 GMT"
             }
           ],
-          "headersSize": 295,
+          "headersSize": 321,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:40.185Z",
-        "time": 186,
+        "startedDateTime": "2021-09-27T12:55:09.651Z",
+        "time": 606,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1807,205 +2462,22 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 186
+          "wait": 606
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "3858732e-4c9c-4e2f-a4d5-191b32229b4b"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665520\",\"not_before\":\"1615661620\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-12T18:58:40.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "3858732e-4c9c-4e2f-a4d5-191b32229b4b"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "9aad169d-9d92-4a97-9108-3888b86c2300"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:40 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            }
-          ],
-          "headersSize": 782,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-13T18:58:40.376Z",
-        "time": 177,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 177
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 1,
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
             {
               "_fromType": "array",
               "name": "accept-language",
@@ -2014,12 +2486,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "45fd18fe-acb3-4de5-9474-d6a5301cb757"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
+              "value": "b1dff3e8-97ea-42b7-9257-33ee0df6f8d0"
             },
             {
               "_fromType": "array",
@@ -2029,7 +2496,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -2056,7 +2523,1699 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 2177,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:55:10+02:00' and eventTimestamp le '2021-09-27T14:55:10+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A55%3A10%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A55%3A10%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_Storage_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstefanexamplestorage%27"
+        },
+        "response": {
+          "bodySize": 16299,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16299,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713/ticks/637680751208063831\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"9f9c4957-cbe0-4829-8e91-6ef594969333\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-24T10:12:00.8063831Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"8903f8d4-7a4c-456d-be34-33660212b2bd\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/8903f8d4-7a4c-456d-be34-33660212b2bd/ticks/637680751206863840\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T10:12:00.686384Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"927daf50-bb12-4bb1-960e-005dd0196385\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/927daf50-bb12-4bb1-960e-005dd0196385/ticks/637680036884982412\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"2fbc6389-ef5b-43c4-8771-5500d31026d5\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created (HTTP Status Code: 201)\"},\"eventTimestamp\":\"2021-09-23T14:21:28.4982412Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"f60bee7d-a7ea-4f59-9d88-658fafc85b1f\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/f60bee7d-a7ea-4f59-9d88-658fafc85b1f/ticks/637680036855632564\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T14:21:25.5632564Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0dde252b-5665-4e8a-a936-4daba0d8a575\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0dde252b-5665-4e8a-a936-4daba0d8a575/ticks/637677468635548611\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"b1001d0c-e882-4506-b8ab-9163d906f654\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:01:03.5548611Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0842ad8b-0a70-4ce5-8652-a7f2114e8000\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0842ad8b-0a70-4ce5-8652-a7f2114e8000/ticks/637677468633347789\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:01:03.3347789Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a/ticks/637666178855994320\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"2bc25043-553e-48b1-ad9b-ce9926416ca9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:45.599432Z\",\"submissionTimestamp\":\"2021-09-07T13:26:18.0982287Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b1dc8c9d-57e9-422f-b6b6-a2ab4089845e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/b1dc8c9d-57e9-422f-b6b6-a2ab4089845e/ticks/637666178612856613\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"06c3da4c-be9c-4b9c-9bb1-c29b06dc2943\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:21.2856613Z\",\"submissionTimestamp\":\"2021-09-07T13:25:26.1292429Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"fa96b680-b3f9-471c-a777-a69da710ac89\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/fa96b680-b3f9-471c-a777-a69da710ac89/ticks/637666172866182094\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ce0cce81-7af2-48c6-b614-da08e1048548\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.6182094Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"138520b9-0d15-4108-98e6-b26cfcaed86c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/138520b9-0d15-4108-98e6-b26cfcaed86c/ticks/637666172864682093\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:46.4682093Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b49bfb26-b7bd-488b-bf76-f4891ad74605\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/b49bfb26-b7bd-488b-bf76-f4891ad74605/ticks/637666172863682069\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"22765ce3-92ae-4aed-954d-7f26ab018c84\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.3682069Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"575b58d7-a757-4a45-aebe-40195806a39c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/575b58d7-a757-4a45-aebe-40195806a39c/ticks/637666172849132353\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:44.9132353Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"870fddbd-ee80-4254-b798-ab2e71de1de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/870fddbd-ee80-4254-b798-ab2e71de1de1/ticks/637666172832824197\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c6e734b2-12f7-4965-8ec4-f7feb27666b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:43.2824197Z\",\"submissionTimestamp\":\"2021-09-07T13:15:26.1178018Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"4e08dab9-10e0-49d3-abf6-4a61f7315de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4e08dab9-10e0-49d3-abf6-4a61f7315de1/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"75ec2246-b3ed-4a2a-8d99-85232ae352cd\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"f5231d65-9872-4ab7-82fa-030783fd80bd\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/f5231d65-9872-4ab7-82fa-030783fd80bd/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d1f0bd9a-7d00-4270-8164-a37d77ad40a8\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e50013de-1290-4050-945c-edd8ac16b016\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e50013de-1290-4050-945c-edd8ac16b016/ticks/637666172560836200\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_RAGRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"accessTier\\\":\\\"Hot\\\",\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":true,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:16.08362Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1731361Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_012ae18671c84e55bf68d03f3c3500c3_637683441110371662"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "907ca7f7-4119-4ff9-a63d-232837cfe2fd"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125511Z:907ca7f7-4119-4ff9-a63d-232837cfe2fd"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:10 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:10.269Z",
+        "time": 803,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 803
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8092e548-0bb9-43cb-830d-422882819ef0"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:11.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1613991b-fdaa-4935-9176-e60db6db4b00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - EUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:11 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 716,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:11.084Z",
+        "time": 676,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 676
+        }
+      },
+      {
+        "_id": "396844fb10796ff14cd9ef4c38881321",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3803e40a-ebe6-449a-8588-988efe224f16"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1609,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://stefanexamplestorage.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 762,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 762,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8cdef0f3-d01e-001c-619e-b34254000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "3803e40a-ebe6-449a-8588-988efe224f16"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:11 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:11.766Z",
+        "time": 588,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 588
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "9f54a3be-f82b-42e2-a018-7add80940dcd"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=Ak2lOK-lkbhBi2tgYEwIi7M-ExxYAQAAAC-249gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:12.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "0f9f9943-6e57-408d-89a3-6f0945868a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:12 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:12.362Z",
+        "time": 698,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 698
+        }
+      },
+      {
+        "_id": "35a194af62cb1877e4f3a2940d92adfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "de7e9f1e-a306-4ebb-9514-8a6c3d1ecc25"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1666,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://stefanexamplestorage.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "041a32ef-d003-0023-259e-b38af7000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "de7e9f1e-a306-4ebb-9514-8a6c3d1ecc25"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:13 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:13.065Z",
+        "time": 661,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 661
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "b14b29e7-73c7-415f-8abc-23e03d8b0f9b"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:55:13+02:00' and eventTimestamp le '2021-09-27T14:55:13+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A55%3A13%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A55%3A13%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_AppServices_Group%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstorageaccountstefaafb8%27"
+        },
+        "response": {
+          "bodySize": 16495,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16495,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"71d2ca88-e069-4418-a9a1-5e61fa4e29e7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/71d2ca88-e069-4418-a9a1-5e61fa4e29e7/ticks/637683118197796970\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fc21cc29-04bb-4c52-bd10-09f62bdcc345\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.779697Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022/ticks/637683118197546829\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7546829Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"34858c5b-8c5d-4884-b748-2ab3d59bd78b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/34858c5b-8c5d-4884-b748-2ab3d59bd78b/ticks/637683118197378385\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8b8be42f-bfef-4507-95f6-ccd2a0bfca45\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7378385Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"cb12a0cf-8b0e-494b-a483-05cc8e2af298\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/cb12a0cf-8b0e-494b-a483-05cc8e2af298/ticks/637683118197028379\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7028379Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"9ab0273f-4168-420b-a82a-04a95ef004b9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/9ab0273f-4168-420b-a82a-04a95ef004b9/ticks/637680895404911980\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"e3e29761-cb4f-44b6-9c21-c4bef3490d74\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-24T14:12:20.491198Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"f3127244-2903-49eb-8290-896fb807e4bf\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f3127244-2903-49eb-8290-896fb807e4bf/ticks/637680895402811842\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T14:12:20.2811842Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"f4c0ba23-4f98-4def-837e-c8de0728547e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f4c0ba23-4f98-4def-837e-c8de0728547e/ticks/637680004888576312\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ccd64de2-9c2f-4578-8496-5808bf5ae478\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:28:08.8576312Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1600853Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"abee07ad-735f-4daf-a00b-dbcb2420491c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/abee07ad-735f-4daf-a00b-dbcb2420491c/ticks/637680004886626307\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:28:08.6626307Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1590849Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"609c11d9-f767-47fc-b7f6-2b01de6df6d3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/609c11d9-f767-47fc-b7f6-2b01de6df6d3/ticks/637680004138311948\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"aa7000e2-9f8d-45c0-8eaf-ab889d7022c8\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:26:53.8311948Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"f7bd6f5d-a4a6-459f-b677-7cc6aef350bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f7bd6f5d-a4a6-459f-b677-7cc6aef350bb/ticks/637680004131562335\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:26:53.1562335Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"95e08496-5682-44b1-aa43-bc8364b7f678\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/95e08496-5682-44b1-aa43-bc8364b7f678/ticks/637674012546036667\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"188d14f7-04dd-4948-acb1-1216172a19c3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:54.6036667Z\",\"submissionTimestamp\":\"2021-09-16T15:01:46.1692025Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"8a01ea00-bd83-41d8-8de7-bc51b80d4652\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/8a01ea00-bd83-41d8-8de7-bc51b80d4652/ticks/637674012295717803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"99bdf78f-4602-4a8c-83b4-19ed0c0e9cd1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:29.5717803Z\",\"submissionTimestamp\":\"2021-09-16T15:01:53.1386235Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"b30ffc87-ee15-41e7-81c0-0fb4b05895ff\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/b30ffc87-ee15-41e7-81c0-0fb4b05895ff/ticks/637674006534406250\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"3113ca2b-d2bc-4f4f-9a8f-89c167e9218a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-16T14:50:53.440625Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"01af52fc-5b12-4703-98b4-cc67db95435e\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/01af52fc-5b12-4703-98b4-cc67db95435e/ticks/637674006528456482\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:52.8456482Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"cf10aecf-4960-4246-8021-a91b9767a6ee\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/cf10aecf-4960-4246-8021-a91b9767a6ee/ticks/637674006518718327\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ce1ef8-dabe-4c1b-a7f3-06409c83d4e5\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:51.8718327Z\",\"submissionTimestamp\":\"2021-09-16T14:52:09.1184465Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"18d6742e-9780-4410-87f2-7861ad8ebcaf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/18d6742e-9780-4410-87f2-7861ad8ebcaf/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46e3061f-4966-444c-8a1a-5fcc9c793c50\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"e279382a-ca7b-4fb4-bca3-d72bbacb841b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/e279382a-ca7b-4fb4-bca3-d72bbacb841b/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"36894b22-1fe1-4514-a797-ba687ae30306\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"0ee36506-e3f0-4f97-9a2f-deccfc7f3576\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/0ee36506-e3f0-4f97-9a2f-deccfc7f3576/ticks/637674006235104764\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"location\\\":\\\"Central US\\\",\\\"properties\\\":{\\\"supportsHttpsTrafficOnly\\\":true,\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:23.5104764Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.1747877Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_2c9e65a6ae9b4193a6c35ac93d59cab4_637683441144951987"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9cf7d6c0-36f0-4589-bc06-745b41cd17b4"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125514Z:9cf7d6c0-36f0-4589-bc06-745b41cd17b4"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:14 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:13.733Z",
+        "time": 789,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 789
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "07bc68df-0d69-4bec-b72c-36551ee9c3eb"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:15.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "90a1714a-6373-4080-ac14-15f4c6345700"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:14 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:14.531Z",
+        "time": 808,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 808
+        }
+      },
+      {
+        "_id": "11cca1bdf5f08f97880274f522d9c376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "a9f7f868-172e-4b27-88cc-07e53011e3bc"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1615,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 694,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 694,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2607ec86-f01e-0065-689e-b3183a000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "a9f7f868-172e-4b27-88cc-07e53011e3bc"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:15 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:15.343Z",
+        "time": 696,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 696
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d2e39bcd-3f78-4440-9d8b-c0e999ca9941"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=Aq7QTmCSAO1EiqCpaRq1QWI-ExxYAQAAADK249gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:16.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7ef39528-80f4-42c4-bdcc-7e17699f8600"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:16 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:16.048Z",
+        "time": 708,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 708
+        }
+      },
+      {
+        "_id": "dd3d6e3698ab7e26997ca5b4d8d2d5d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "d7a9c541-acab-4f06-a296-404b5ced22fe"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1672,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "8dcf1b81-5003-004a-439e-b39900000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "d7a9c541-acab-4f06-a296-404b5ced22fe"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:22 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:16.760Z",
+        "time": 5820,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5820
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "a5682308-4e73-4106-80d3-dd8dcdf538d5"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750923\",\"not_before\":\"1632747023\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:55:23.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "a5682308-4e73-4106-80d3-dd8dcdf538d5"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "edfc395d-34ba-4e68-a7c8-6acbc2bf4800"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:55:22 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:55:22.585Z",
+        "time": 1217,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1217
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "bd14f764-3f28-4064-ba00-1b7ff76d5ac4"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2068,11 +4227,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -2102,15 +4261,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "b14117e9-9427-41cf-b0b6-8c0cc3d1a5cb"
+              "value": "d1ef0061-be2b-4a92-bf30-1c2c4ea45019"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "b14117e9-9427-41cf-b0b6-8c0cc3d1a5cb"
+              "value": "d1ef0061-be2b-4a92-bf30-1c2c4ea45019"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185840Z:b14117e9-9427-41cf-b0b6-8c0cc3d1a5cb"
+              "value": "GERMANYWESTCENTRAL:20210927T125524Z:d1ef0061-be2b-4a92-bf30-1c2c4ea45019"
             },
             {
               "name": "strict-transport-security",
@@ -2122,7 +4281,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:40 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:24 GMT"
             },
             {
               "name": "connection",
@@ -2130,17 +4289,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:40.557Z",
-        "time": 278,
+        "startedDateTime": "2021-09-27T12:55:23.805Z",
+        "time": 804,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2148,11 +4307,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 278
+          "wait": 804
         }
       },
       {
-        "_id": "d6e1053535beac54840914334f55983d",
+        "_id": "da62aad399b36dee080fe223bb077198",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2172,7 +4331,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "bae0e2c7-2647-4e8f-ab23-0586c3649318"
+              "value": "ed229403-cb82-4f7f-8f20-a7b9619d15ea"
             },
             {
               "_fromType": "array",
@@ -2182,7 +4341,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -2209,7 +4368,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1873,
+          "headersSize": 1909,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2218,14 +4377,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/stefan_storage_resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/containers?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 1499,
+          "bodySize": 273,
           "content": {
             "mimeType": "application/json",
-            "size": 1499,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers/insights-activity-logs\",\"name\":\"insights-activity-logs\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D8D2BA9C07BA7E\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2021-02-16T20:36:59.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers/insights-logs-auditevent\",\"name\":\"insights-logs-auditevent\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D8D2CAA11DF814\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2021-02-16T22:31:40.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers/insights-metrics-pt1m\",\"name\":\"insights-metrics-pt1m\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D8D2CCE6A4EDEC\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2021-02-16T22:47:55.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers/j1dev\",\"name\":\"j1dev\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D82D90F9F01E32\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2020-07-21T16:13:16.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}},{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/blobServices/default/containers/some-other-container\",\"name\":\"some-other-container\",\"type\":\"Microsoft.Storage/storageAccounts/blobServices/containers\",\"etag\":\"\\\"0x8D84F6CF509A47D\\\"\",\"properties\":{\"deleted\":false,\"remainingRetentionDays\":0,\"defaultEncryptionScope\":\"$account-encryption-key\",\"denyEncryptionScopeOverride\":false,\"publicAccess\":\"None\",\"leaseStatus\":\"Unlocked\",\"leaseState\":\"Available\",\"lastModifiedTime\":\"2020-09-02T18:21:05.0000000Z\",\"hasImmutabilityPolicy\":false,\"hasLegalHold\":false}}]}"
+            "size": 273,
+            "text": "{\"value\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -2251,7 +4410,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "df5fc3e9-8dce-41eb-886d-1b46cfb9625e"
+              "value": "0cb8b3a6-8ec7-4e67-a59a-3250eb22ee4b"
             },
             {
               "name": "strict-transport-security",
@@ -2267,11 +4426,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "69d39014-b262-4d77-bdec-ee143a4cb545"
+              "value": "da9f7bac-34d8-411b-89f5-001eeb2b0126"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185841Z:69d39014-b262-4d77-bdec-ee143a4cb545"
+              "value": "GERMANYWESTCENTRAL:20210927T125525Z:da9f7bac-34d8-411b-89f5-001eeb2b0126"
             },
             {
               "name": "x-content-type-options",
@@ -2279,21 +4438,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:41 GMT"
+              "value": "Mon, 27 Sep 2021 12:55:24 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 690,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:40.841Z",
-        "time": 362,
+        "startedDateTime": "2021-09-27T12:55:24.615Z",
+        "time": 650,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2301,7 +4460,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 362
+          "wait": 650
         }
       }
     ],

--- a/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-file-shares_3496468620/recording.har
+++ b/src/steps/resource-manager/storage/__recordings__/resource-manager-step-storage-file-shares_3496468620/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -59,18 +59,18 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
-          "bodySize": 1615,
+          "bodySize": 1671,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1615,
+            "size": 1671,
             "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:41.000Z",
+              "expires": "2021-10-27T12:52:30.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -105,10 +105,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1615"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -130,11 +126,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "f5bb3c2c-48ed-4ff0-b305-206a2b261f00"
+              "value": "7645e800-e5cf-4fd2-a396-e899f34c8700"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
             },
             {
               "_fromType": "array",
@@ -153,21 +149,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:40 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:29 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1671"
             }
           ],
-          "headersSize": 731,
+          "headersSize": 736,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:41.229Z",
-        "time": 184,
+        "startedDateTime": "2021-09-27T12:52:28.698Z",
+        "time": 1991,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -175,7 +175,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 184
+          "wait": 1991
         }
       },
       {
@@ -194,7 +194,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "ccf22dc7-92be-a368-34df-01226b7dbd3a"
+              "value": "892b0097-fc95-9cf5-507b-d0dee340d8ca"
             },
             {
               "_fromType": "array",
@@ -226,18 +226,18 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1880,
+          "headersSize": 1936,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://graph.microsoft.com/v1.0/organization"
         },
         "response": {
-          "bodySize": 1358,
+          "bodySize": 1470,
           "content": {
             "mimeType": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8",
-            "size": 1358,
-            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/992d7bbe-b367-459c-a10f-cf3fd16103ab/directoryObjects/992d7bbe-b367-459c-a10f-cf3fd16103ab/Microsoft.DirectoryServices.Organization\",\"id\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2020-07-16T17:54:20Z\",\"displayName\":\"Default Directory\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"ndowmon@gmail.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":192,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2020-09-15T15:38:22Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"ndowmongmail.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
+            "size": 1470,
+            "text": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#organization\",\"value\":[{\"@odata.id\":\"https://graph.microsoft.com/v2/19ae0f99-6fc6-444b-bd54-97504efc66ad/directoryObjects/19ae0f99-6fc6-444b-bd54-97504efc66ad/Microsoft.DirectoryServices.Organization\",\"id\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"deletedDateTime\":null,\"businessPhones\":[],\"city\":null,\"country\":null,\"countryLetterCode\":\"US\",\"createdDateTime\":\"2021-09-01T14:59:04Z\",\"dataBoundary\":\"None\",\"displayName\":\"JupiterOne Azure Integration Development\",\"isMultipleDataLocationsForServicesEnabled\":null,\"marketingNotificationEmails\":[],\"onPremisesLastSyncDateTime\":null,\"onPremisesSyncEnabled\":null,\"postalCode\":null,\"preferredLanguage\":\"en\",\"securityComplianceNotificationMails\":[],\"securityComplianceNotificationPhones\":[],\"state\":null,\"street\":null,\"technicalNotificationMails\":[\"nick.dowmon_jupiterone.com#EXT#@ndowmongmail.onmicrosoft.com\"],\"tenantType\":\"AAD\",\"directorySizeQuota\":{\"used\":111,\"total\":50000},\"privacyProfile\":null,\"assignedPlans\":[{\"assignedDateTime\":\"2021-09-01T20:02:55Z\",\"capabilityStatus\":\"Enabled\",\"service\":\"WindowsAzure\",\"servicePlanId\":\"fca3e605-0754-4279-8504-3f1229f29614\"}],\"provisionedPlans\":[],\"verifiedDomains\":[{\"capabilities\":\"Email, OfficeCommunicationsOnline\",\"isDefault\":true,\"isInitial\":true,\"name\":\"j1AzureIntegrationDev.onmicrosoft.com\",\"type\":\"Managed\"}]}]}"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +247,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:41 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:30 GMT"
             },
             {
               "name": "content-type",
@@ -267,15 +267,15 @@
             },
             {
               "name": "request-id",
-              "value": "de1eaa60-19f2-4c38-9750-22444208c5a0"
+              "value": "3387cd8e-5b31-44d9-9fa9-03a566b01ca7"
             },
             {
               "name": "client-request-id",
-              "value": "ccf22dc7-92be-a368-34df-01226b7dbd3a"
+              "value": "892b0097-fc95-9cf5-507b-d0dee340d8ca"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"CH01EPF00004E9B\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"West Europe\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"004\",\"RoleInstance\":\"AM2PEPF00008A63\"}}"
             },
             {
               "name": "x-ms-resource-unit",
@@ -286,14 +286,14 @@
               "value": "4.0"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 607,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:41.416Z",
-        "time": 237,
+        "startedDateTime": "2021-09-27T12:52:30.698Z",
+        "time": 382,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,7 +301,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 237
+          "wait": 382
         }
       },
       {
@@ -320,7 +320,7 @@
             {
               "_fromType": "array",
               "name": "client-request-id",
-              "value": "764a3f8b-f02a-df59-ac69-6503e0bbbf18"
+              "value": "49131d3a-91f6-5d94-76f1-634e193e7a34"
             },
             {
               "_fromType": "array",
@@ -352,7 +352,7 @@
               "value": "graph.microsoft.com"
             }
           ],
-          "headersSize": 1918,
+          "headersSize": 1974,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
@@ -373,7 +373,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:34 GMT"
             },
             {
               "name": "content-type",
@@ -397,29 +397,29 @@
             },
             {
               "name": "request-id",
-              "value": "dd13665d-be38-4630-8292-49b5ea9044ee"
+              "value": "d488aec6-8e8d-46bc-8b0f-94fea782b930"
             },
             {
               "name": "client-request-id",
-              "value": "764a3f8b-f02a-df59-ac69-6503e0bbbf18"
+              "value": "49131d3a-91f6-5d94-76f1-634e193e7a34"
             },
             {
               "name": "x-ms-ags-diagnostic",
-              "value": "{\"ServerInfo\":{\"DataCenter\":\"North Central US\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"003\",\"RoleInstance\":\"CH01EPF00004E9C\"}}"
+              "value": "{\"ServerInfo\":{\"DataCenter\":\"West Europe\",\"Slice\":\"E\",\"Ring\":\"5\",\"ScaleUnit\":\"004\",\"RoleInstance\":\"AM2PEPF000088DC\"}}"
             },
             {
               "name": "odata-version",
               "value": "4.0"
             }
           ],
-          "headersSize": 611,
+          "headersSize": 606,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:41.655Z",
-        "time": 440,
+        "startedDateTime": "2021-09-27T12:52:31.094Z",
+        "time": 3604,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -427,11 +427,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 440
+          "wait": 3604
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_id": "9505f38071ef6506ce549685869e9882",
         "_order": 0,
         "cache": {},
         "request": {
@@ -448,7 +448,7 @@
             },
             {
               "name": "client-request-id",
-              "value": "83d12268-cfde-42a7-9b92-2325d277678f"
+              "value": "2b683559-57e3-4f74-b109-4e028c74b646"
             },
             {
               "name": "return-client-request-id",
@@ -464,7 +464,7 @@
             },
             {
               "name": "x-client-os",
-              "value": "darwin"
+              "value": "linux"
             },
             {
               "name": "x-client-cpu",
@@ -479,7 +479,7 @@
               "value": 172
             }
           ],
-          "headersSize": 414,
+          "headersSize": 413,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -493,18 +493,18 @@
               "value": "1.0"
             }
           ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
         },
         "response": {
           "bodySize": 1450,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665522\",\"not_before\":\"1615661622\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750755\",\"not_before\":\"1632746855\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:42.000Z",
+              "expires": "2021-10-27T12:52:35.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -558,15 +558,15 @@
             },
             {
               "name": "client-request-id",
-              "value": "83d12268-cfde-42a7-9b92-2325d277678f"
+              "value": "2b683559-57e3-4f74-b109-4e028c74b646"
             },
             {
               "name": "x-ms-request-id",
-              "value": "ed310a23-94ac-4732-9cdc-102903362400"
+              "value": "b7ca6f32-8498-476a-a8ef-8dd81a1c5000"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - SCUS ProdSlices"
             },
             {
               "name": "x-ms-clitelem",
@@ -589,7 +589,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:34 GMT"
             },
             {
               "name": "connection",
@@ -600,14 +600,14 @@
               "value": "1450"
             }
           ],
-          "headersSize": 782,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:42.099Z",
-        "time": 157,
+        "startedDateTime": "2021-09-27T12:52:34.789Z",
+        "time": 457,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -615,11 +615,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 157
+          "wait": 457
         }
       },
       {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
         "_order": 0,
         "cache": {},
         "request": {
@@ -634,7 +634,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "07b8552f-c1dc-4861-b103-e94d74339d62"
+              "value": "40cca2d3-0e46-47cb-943a-5daee0a42897"
             },
             {
               "_fromType": "array",
@@ -649,7 +649,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -676,7 +676,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -688,11 +688,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -722,15 +722,15 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "6c31311b-547d-4e8d-8536-61e308a579de"
+              "value": "5a3068bf-ccda-4198-aeb2-d41e5e84eb3e"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "6c31311b-547d-4e8d-8536-61e308a579de"
+              "value": "5a3068bf-ccda-4198-aeb2-d41e5e84eb3e"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185842Z:6c31311b-547d-4e8d-8536-61e308a579de"
+              "value": "GERMANYWESTCENTRAL:20210927T125236Z:5a3068bf-ccda-4198-aeb2-d41e5e84eb3e"
             },
             {
               "name": "strict-transport-security",
@@ -742,7 +742,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:36 GMT"
             },
             {
               "name": "connection",
@@ -750,17 +750,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:42.260Z",
-        "time": 279,
+        "startedDateTime": "2021-09-27T12:52:35.331Z",
+        "time": 1289,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -768,11 +768,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 279
+          "wait": 1289
         }
       },
       {
-        "_id": "c9d6dbee91365ea9a6e208a3dd1605c4",
+        "_id": "65b39ca75483f0ca33c5ac4a87ec1aa8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -792,7 +792,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5c8afe98-1d0b-4a20-93ce-bfde0f45cd6a"
+              "value": "5b1269fe-d25e-445b-87cb-9d761b591a3c"
             },
             {
               "_fromType": "array",
@@ -802,7 +802,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -829,7 +829,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1806,
+          "headersSize": 1816,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -838,14 +838,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 2459,
+          "bodySize": 1459,
           "content": {
-            "mimeType": "application/json",
-            "size": 2459,
-            "text": "{\"value\":[{\"identity\":{\"principalId\":\"787f6337-433a-4856-acbd-2ff6005c2f58\",\"tenantId\":\"992d7bbe-b367-459c-a10f-cf3fd16103ab\",\"type\":\"SystemAssigned\"},\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev\",\"name\":\"ndowmon1j1dev\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"resourceAccessRules\":[],\"bypass\":\"Logging, Metrics, AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[{\"value\":\"76.182.33.160\",\"action\":\"Allow\"}],\"defaultAction\":\"Deny\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"keyvaultproperties\":{\"currentVersionedKeyIdentifier\":\"https://ndowmon11-j1dev.vault.azure.net/keys/j1dev/325432ed4deb46bebe09d39dc071f090\",\"lastKeyRotationTimestamp\":\"2021-03-09T16:48:13.3984368Z\",\"currentVersionedKeyExpirationTimestamp\":\"1970-01-01T00:00:00.0000000Z\",\"keyvaulturi\":\"https://ndowmon11-j1dev.vault.azure.net/\",\"keyname\":\"j1dev\",\"keyversion\":\"\"},\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.3408937Z\"}},\"keySource\":\"Microsoft.Keyvault\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.2628136Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1dev.dfs.core.windows.net/\",\"web\":\"https://ndowmon1j1dev.z13.web.core.windows.net/\",\"blob\":\"https://ndowmon1j1dev.blob.core.windows.net/\",\"queue\":\"https://ndowmon1j1dev.queue.core.windows.net/\",\"table\":\"https://ndowmon1j1dev.table.core.windows.net/\",\"file\":\"https://ndowmon1j1dev.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"BlobStorage\",\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1devblobstorage\",\"name\":\"ndowmon1j1devblobstorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{\"environment\":\"j1dev\"},\"properties\":{\"privateEndpointConnections\":[],\"allowBlobPublicAccess\":false,\"isHnsEnabled\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2020-07-21T16:12:56.4346786Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2020-07-21T16:12:56.3721528Z\",\"primaryEndpoints\":{\"dfs\":\"https://ndowmon1j1devblobstorage.dfs.core.windows.net/\",\"blob\":\"https://ndowmon1j1devblobstorage.blob.core.windows.net/\",\"table\":\"https://ndowmon1j1devblobstorage.table.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}}]}"
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1459,
+            "text": "{\"value\":[{\"sku\":{\"name\":\"Premium_LRS\",\"tier\":\"Premium\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"name\":\"regenerateaccesskeytest\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnections/regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"name\":\"regenerateaccesskeytest.a90df093-d49e-4f7b-a354-db550d27e73e\",\"type\":\"Microsoft.Storage/storageAccounts/privateEndpointConnections\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateEndpoint\":{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Network/privateEndpoints/private-endpoint\"},\"privateLinkServiceConnectionState\":{\"status\":\"Approved\",\"description\":\"Auto-Approved\",\"actionRequired\":\"None\"}}}],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-20T15:02:41.7049605Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-20T15:02:41.5642636Z\",\"primaryEndpoints\":{\"web\":\"https://regenerateaccesskeytest.z13.web.core.windows.net/\",\"blob\":\"https://regenerateaccesskeytest.blob.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"name\":\"sqlvab7pt3ww5qhmdw\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":false,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-23T11:32:50.9405217Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-23T11:32:50.8155392Z\",\"primaryEndpoints\":{\"dfs\":\"https://sqlvab7pt3ww5qhmdw.dfs.core.windows.net/\",\"web\":\"https://sqlvab7pt3ww5qhmdw.z13.web.core.windows.net/\",\"blob\":\"https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/\",\"queue\":\"https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/\",\"table\":\"https://sqlvab7pt3ww5qhmdw.table.core.windows.net/\",\"file\":\"https://sqlvab7pt3ww5qhmdw.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\"}},{\"sku\":{\"name\":\"Standard_RAGRS\",\"tier\":\"Standard\"},\"kind\":\"StorageV2\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"name\":\"stefanexamplestorage\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"allowBlobPublicAccess\":true,\"allowSharedKeyAccess\":true,\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-07T13:14:18.5554741Z\"}},\"keySource\":\"Microsoft.Storage\"},\"accessTier\":\"Hot\",\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-07T13:14:18.4460771Z\",\"primaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage.table.core.windows.net/\",\"file\":\"https://stefanexamplestorage.file.core.windows.net/\"},\"primaryLocation\":\"eastus\",\"statusOfPrimary\":\"available\",\"secondaryLocation\":\"westus\",\"statusOfSecondary\":\"available\",\"secondaryEndpoints\":{\"dfs\":\"https://stefanexamplestorage-secondary.dfs.core.windows.net/\",\"web\":\"https://stefanexamplestorage-secondary.z13.web.core.windows.net/\",\"blob\":\"https://stefanexamplestorage-secondary.blob.core.windows.net/\",\"queue\":\"https://stefanexamplestorage-secondary.queue.core.windows.net/\",\"table\":\"https://stefanexamplestorage-secondary.table.core.windows.net/\"}}},{\"sku\":{\"name\":\"Standard_LRS\",\"tier\":\"Standard\"},\"kind\":\"Storage\",\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"name\":\"storageaccountstefaafb8\",\"type\":\"Microsoft.Storage/storageAccounts\",\"location\":\"centralus\",\"tags\":{},\"properties\":{\"privateEndpointConnections\":[],\"minimumTlsVersion\":\"TLS1_2\",\"networkAcls\":{\"bypass\":\"AzureServices\",\"virtualNetworkRules\":[],\"ipRules\":[],\"defaultAction\":\"Allow\"},\"supportsHttpsTrafficOnly\":true,\"encryption\":{\"services\":{\"file\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"},\"blob\":{\"keyType\":\"Account\",\"enabled\":true,\"lastEnabledTime\":\"2021-09-16T14:50:27.1308594Z\"}},\"keySource\":\"Microsoft.Storage\"},\"provisioningState\":\"Succeeded\",\"creationTime\":\"2021-09-16T14:50:27.0370951Z\",\"primaryEndpoints\":{\"blob\":\"https://storageaccountstefaafb8.blob.core.windows.net/\",\"queue\":\"https://storageaccountstefaafb8.queue.core.windows.net/\",\"table\":\"https://storageaccountstefaafb8.table.core.windows.net/\",\"file\":\"https://storageaccountstefaafb8.file.core.windows.net/\"},\"primaryLocation\":\"centralus\",\"statusOfPrimary\":\"available\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -859,7 +859,7 @@
             },
             {
               "name": "content-type",
-              "value": "application/json"
+              "value": "application/json; charset=utf-8"
             },
             {
               "name": "expires",
@@ -870,28 +870,28 @@
               "value": "Accept-Encoding"
             },
             {
+              "name": "x-ms-original-request-ids",
+              "value": "1d1b77c5-a8ac-489c-87bd-150b3bf056e9, 12ce73e3-0b94-4aed-bcac-c6f1600da1fb"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
               "name": "x-ms-request-id",
-              "value": "e716ce7d-822f-42e4-87f2-cc1ba3ded3ba"
+              "value": "d03f1583-baf4-4a69-a619-8331a6d3f228"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "d03f1583-baf4-4a69-a619-8331a6d3f228"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125237Z:d03f1583-baf4-4a69-a619-8331a6d3f228"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-ms-ratelimit-remaining-subscription-reads",
-              "value": "11999"
-            },
-            {
-              "name": "server",
-              "value": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0"
-            },
-            {
-              "name": "x-ms-correlation-request-id",
-              "value": "f4ec7004-17a6-4ba7-9216-deb4616cdc57"
-            },
-            {
-              "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185843Z:f4ec7004-17a6-4ba7-9216-deb4616cdc57"
             },
             {
               "name": "x-content-type-options",
@@ -899,21 +899,25 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:36 GMT"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1459"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 703,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:42.543Z",
-        "time": 405,
+        "startedDateTime": "2021-09-27T12:52:36.637Z",
+        "time": 617,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -921,11 +925,509 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 405
+          "wait": 617
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "879174d9-9c9f-4a13-a153-18533399c780"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750757\",\"not_before\":\"1632746857\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:37.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "879174d9-9c9f-4a13-a153-18533399c780"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "d5b95bfc-6d4d-499e-b835-ba5441934a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - EUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:37 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:37.274Z",
+        "time": 668,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 668
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "bfa74896-13e7-44f7-9684-12147f53a446"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 349,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "a7412512-2443-4a7b-ba00-2a3c564caf7a"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "a7412512-2443-4a7b-ba00-2a3c564caf7a"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125238Z:a7412512-2443-4a7b-ba00-2a3c564caf7a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:38 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "349"
+            }
+          ],
+          "headersSize": 593,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:37.957Z",
+        "time": 775,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 775
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "35ea5a8a-5cd0-4911-b2b5-c12894393bdb"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:52:38+02:00' and eventTimestamp le '2021-09-27T14:52:38+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A52%3A38%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A52%3A38%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FDefaultResourceGroup-CUS%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fregenerateaccesskeytest%27"
+        },
+        "response": {
+          "bodySize": 27501,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 27501,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"e1996591-2700-4c40-b9ff-ebf8bad0fae7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/e1996591-2700-4c40-b9ff-ebf8bad0fae7/ticks/637683129742655982\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"40279215-5610-4fa4-89f0-405b7436c005\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:16:14.2655982Z\",\"submissionTimestamp\":\"2021-09-27T04:17:32.135054Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"5883d6b0-5eee-4c9d-ad2d-4ff594fdc746\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/5883d6b0-5eee-4c9d-ad2d-4ff594fdc746/ticks/637683129571384933\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"a5b002d2-b372-4b40-952a-4a7b0a3a3514\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-27T04:15:57.1384933Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"description\":\"\",\"eventDataId\":\"38134267-7818-43f4-993d-0131dbfac8ab\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"662d3489-dac2-43e0-877c-dbc894b5e3ca\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/38134267-7818-43f4-993d-0131dbfac8ab/ticks/637683129569535355\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"5de937d7-b206-470f-b4a9-ffb0306de443\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:56.9535355Z\",\"submissionTimestamp\":\"2021-09-27T04:16:41.1448881Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"a6756e91-3abe-4431-b98b-912a630b7311\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/a6756e91-3abe-4431-b98b-912a630b7311/ticks/637683129448318219\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"00f3e1ef-04b2-411f-a58e-1f9532f921db\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T04:15:44.8318219Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\"},\"caller\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714592\",\"nbf\":\"1632714592\",\"exp\":\"1632801292\",\"aio\":\"E2ZgYPi8vvX3u44QO4ZCkYgvhixNAA==\",\"appid\":\"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYbr-Sy1NtxJhq6aYxNd-oxQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"958e82be-e5e5-47df-83fe-aa597c4dca37\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"CfjZy8JcZE2StzB76zYhAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"description\":\"\",\"eventDataId\":\"584d2154-ac7b-40bd-9794-5bf34a360f24\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"3702ba2c-7c76-4361-b006-ddb40336d554\",\"clientIpAddress\":\"52.165.38.99\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa/events/584d2154-ac7b-40bd-9794-5bf34a360f24/ticks/637683129446517689\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies\"},\"operationId\":\"3beabdcd-c10f-46c3-a44c-b2f5861b9323\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/privateEndpointConnectionProxies/private-endpoint.b047591d-97b9-4b1a-8213-7c714c7f0caa\",\"message\":\"Microsoft.Storage/storageAccounts/privateEndpointConnectionProxies/validate/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T04:15:44.6517689Z\",\"submissionTimestamp\":\"2021-09-27T04:16:38.1523236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"a704a2cb-eb4d-4a35-805e-ead94ad19f43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/a704a2cb-eb4d-4a35-805e-ead94ad19f43/ticks/637680001929101036\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"0225ea72-f781-4f6e-9fe5-d6a0c2474557\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:23:12.9101036Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"9b46afdc-a3c2-4515-a8a8-97ebe2bd286f\",\"description\":\"\",\"eventDataId\":\"ee04b008-d832-4d27-a31d-d6477b7c56bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c302a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ee04b008-d832-4d27-a31d-d6477b7c56bb/ticks/637680001926901032\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0a283713-5d91-46e2-ac9a-553530224a76\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:23:12.6901032Z\",\"submissionTimestamp\":\"2021-09-23T13:24:52.1643856Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"47870c69-2372-4d1a-9917-44ee82af3d43\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/47870c69-2372-4d1a-9917-44ee82af3d43/ticks/637679999082738446\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"31101762-006a-4ed7-89d9-49ca3036ab80\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:18:28.2738446Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"description\":\"\",\"eventDataId\":\"0bb50929-cabd-4f23-9f59-230d8444fdc2\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c4140805-1c70-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/0bb50929-cabd-4f23-9f59-230d8444fdc2/ticks/637679999074987777\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d04c97c8-8283-46b9-ab50-09f614e098d3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:18:27.4987777Z\",\"submissionTimestamp\":\"2021-09-23T13:20:00.1558705Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"9f03ce09-20a6-4d06-95d4-ef9682fe9dcb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9f03ce09-20a6-4d06-95d4-ef9682fe9dcb/ticks/637679990444693037\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4e305746-c740-4588-b06a-7d6040286b8a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:04:04.4693037Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"description\":\"\",\"eventDataId\":\"cafd852a-38ab-43de-9c4e-8ae9d2e0aa39\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c124caff-1c6e-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cafd852a-38ab-43de-9c4e-8ae9d2e0aa39/ticks/637679990442442997\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"7a27c83a-c549-427d-8647-6edbdea26e34\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:04:04.2442997Z\",\"submissionTimestamp\":\"2021-09-23T13:05:34.1942633Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"70e4e7f2-a8fb-42fe-8940-2777f9f0d373\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/70e4e7f2-a8fb-42fe-8940-2777f9f0d373/ticks/637679185425534061\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8d275523-3648-4cb1-9685-2170c4968840\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:22.5534061Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"description\":\"\",\"eventDataId\":\"8777e717-fee0-422a-ae58-7e871fdf0394\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52209d6b-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/8777e717-fee0-422a-ae58-7e871fdf0394/ticks/637679185423183513\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e750173c-d227-4c9b-8c22-733dbe9f60b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:22.3183513Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1741949Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"28e8a43f-d061-4b3d-b13c-ae0cc610de21\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/28e8a43f-d061-4b3d-b13c-ae0cc610de21/ticks/637679185357882256\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1d0fc11b-5f8a-414e-b58f-a17cf1e90f0f\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:42:15.7882256Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"description\":\"\",\"eventDataId\":\"d1f38226-b5fc-4ff8-9a00-3093b11f81c0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"4dcbb741-1bb3-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d1f38226-b5fc-4ff8-9a00-3093b11f81c0/ticks/637679185355782736\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"fd65a6d1-c313-483a-b912-1f426e31c380\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:42:15.5782736Z\",\"submissionTimestamp\":\"2021-09-22T14:43:28.1731941Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b3a8a30d-ec4c-42f8-9d2b-417ea0dc37ac/ticks/637679179809610416\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"47695443-19d5-493e-a4e8-7789b0e60377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-22T14:33:00.9610416Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632320829\",\"nbf\":\"1632320829\",\"exp\":\"1632324729\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAurU2/xyzJ72JkLwMJOaFvhcAVvd3Nxjq5xGhgqMBuIWCt+5Xn2wxhQ9Yxwn0emXdvN7wvu65wVNakfJPGBW46g==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"3A3G8R-YiU2-2opmcglVAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"38325142-045a-4836-9117-a044d539621a\",\"description\":\"\",\"eventDataId\":\"d0717133-9bd8-40f6-9771-8b3f656b9068\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"035c132d-1bb2-11ec-a0da-f9eba60fbed1\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d0717133-9bd8-40f6-9771-8b3f656b9068/ticks/637679179807409713\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"38325142-045a-4836-9117-a044d539621a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-22T14:33:00.7409713Z\",\"submissionTimestamp\":\"2021-09-22T14:35:17.1522236Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"62f1c7a0-52d0-47e8-831e-52bb6a043101\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/62f1c7a0-52d0-47e8-831e-52bb6a043101/ticks/637677475939857920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1cc9b1d1-3ad3-4be5-804d-107cff738cd4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:13:13.985792Z\",\"submissionTimestamp\":\"2021-09-20T15:14:24.1932217Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"f0381753-4ff1-45ed-99df-0a0f74f21bb7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/f0381753-4ff1-45ed-99df-0a0f74f21bb7/ticks/637677475660997035\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"446855e9-2947-4f06-9ddb-4249a30ad8e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:12:46.0997035Z\",\"submissionTimestamp\":\"2021-09-20T15:14:11.1254588Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"1813f4e7-9bf6-4710-ac12-489b32de7fd6\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1813f4e7-9bf6-4710-ac12-489b32de7fd6/ticks/637677474240400287\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"1608dd41-cc4f-471b-8c4d-3a4393333377\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:24.0400287Z\",\"submissionTimestamp\":\"2021-09-20T15:13:05.4897023Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"4ffae35b-f5a4-45fa-872e-597a87b89e94\",\"description\":\"\",\"eventDataId\":\"e0f6b157-a5ea-4c30-948d-5f3b5b30f14a\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91042\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e0f6b157-a5ea-4c30-948d-5f3b5b30f14a/ticks/637677474232600486\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"31189ab2-f647-424c-b83c-c446ae380e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:23.2600486Z\",\"submissionTimestamp\":\"2021-09-20T15:12:05.1607741Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"848862b2-56a3-4837-9562-bbd64dad53cc\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/848862b2-56a3-4837-9562-bbd64dad53cc/ticks/637677474228858674\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"90c74ebf-f83f-4196-8840-c20aa40bc0ca\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:10:22.8858674Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"7b66f484-e50c-4d55-81e1-6d487758aeea\",\"description\":\"\",\"eventDataId\":\"83c32961-cc44-4648-9186-5d672cf75d83\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b91041\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/83c32961-cc44-4648-9186-5d672cf75d83/ticks/637677474226509192\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c372c825-8793-4623-8b35-0d83bd8b67e9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:10:22.6509192Z\",\"submissionTimestamp\":\"2021-09-20T15:12:10.2001893Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"e4c18ff5-a195-41b8-89b0-cab13faa6f27\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/e4c18ff5-a195-41b8-89b0-cab13faa6f27/ticks/637677471861822795\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"a40adc80-7e2f-4c2b-9621-5cc901366e2a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:26.1822795Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"fd2d98eb-2d4b-488e-84c6-4f88c8767e46\",\"description\":\"\",\"eventDataId\":\"6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103e\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6a7c1ce5-8dfa-4dd4-a177-d4e8b9d71556/ticks/637677471859722688\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1846cecb-6cef-4157-b1a5-038e282f73d6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.9722688Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1679803Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"cf6386d9-e6ab-42bd-9e5a-83cefa4c8199\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/cf6386d9-e6ab-42bd-9e5a-83cefa4c8199/ticks/637677471856711620\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ea0187af-8198-4c98-97bd-4220a5bcd942\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.671162Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"159f770e-3f70-481e-991e-f76a4c98804a\",\"description\":\"\",\"eventDataId\":\"b0e07419-dc8f-414f-82cd-53f01df6a401\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/b0e07419-dc8f-414f-82cd-53f01df6a401/ticks/637677471854611536\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"bee681ec-0583-4ef5-a46c-5fda1448da20\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:25.4611536Z\",\"submissionTimestamp\":\"2021-09-20T15:08:14.1644189Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"d8243a16-ab46-4322-8dea-d563d7f88d39\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/d8243a16-ab46-4322-8dea-d563d7f88d39/ticks/637677471851671673\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fb259f93-8cbf-4974-83a9-6862b96eb049\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:25.1671673Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"description\":\"\",\"eventDataId\":\"6154366b-4323-45a8-b328-4d746d69a1d9\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103c\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6154366b-4323-45a8-b328-4d746d69a1d9/ticks/637677471847621619\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"0d0b06f2-0150-4d97-9811-2869ea74b722\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\"},\"properties\":{\"requestbody\":\"{\\\"keyName\\\":\\\"key1\\\"}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/regenerateKey/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:24.7621619Z\",\"submissionTimestamp\":\"2021-09-20T15:07:33.1743985Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"2fa63062-2f22-4759-90af-464f8be3b5c3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/2fa63062-2f22-4759-90af-464f8be3b5c3/ticks/637677471779112974\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"4b5c0812-a756-4dda-97af-8ba7463e5d4c\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:06:17.9112974Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2dbf7c5a-62f0-481b-999e-02a9b27da6e1\",\"description\":\"\",\"eventDataId\":\"6bd2ac81-1521-409d-ab9f-62a24b0ffd2d\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9103b\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/6bd2ac81-1521-409d-ab9f-62a24b0ffd2d/ticks/637677471777013163\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"a6b4468d-3075-45f9-a4cf-130131315f69\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:06:17.7013163Z\",\"submissionTimestamp\":\"2021-09-20T15:07:53.1669807Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"6f2ead07-65c7-4527-8729-88a168ace6e9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/6f2ead07-65c7-4527-8729-88a168ace6e9/ticks/637677469905184323\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"5095ece2-d23b-4405-9663-0319f48b0234\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:03:10.5184323Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"85385ce4-5123-480f-b5ca-93ad14251b67\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/85385ce4-5123-480f-b5ca-93ad14251b67/ticks/637677469895868920\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"257770ea-c767-43e6-8175-a296a4200be4\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.586892Z\",\"submissionTimestamp\":\"2021-09-20T15:04:47.0753231Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1eed7870-0320-420b-ba7a-9c8a375031d0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f521ef9f-f2e2-4bce-a1ce-1d8a039c92f9\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default/events/1eed7870-0320-420b-ba7a-9c8a375031d0/ticks/637677469894434112\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"b877baf9-1a46-459d-9cb1-e73159a9449f\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:03:09.4434112Z\",\"submissionTimestamp\":\"2021-09-20T15:05:09.1247131Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"9e8ec575-53e1-4cdf-aac6-1b6fe831f315\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/9e8ec575-53e1-4cdf-aac6-1b6fe831f315/ticks/637677469636227096\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"57dc2ec8-7845-4db5-b514-99690b6a867b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6227096Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"ff1449dd-10cf-4a75-bbfc-f243cc8c63da\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/ff1449dd-10cf-4a75-bbfc-f243cc8c63da/ticks/637677469636177088\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"5adc31a9-0f71-4dc9-b0d6-b2b7a3ef6cf0\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-20T15:02:43.6177088Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"51d20122-acbd-4537-972b-004272276287\",\"description\":\"\",\"eventDataId\":\"1fd27944-0a26-4bb1-a0e3-fba30c720db0\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"32263da6-b7d6-4ab6-aad3-747b1e6d059a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest/events/1fd27944-0a26-4bb1-a0e3-fba30c720db0/ticks/637677469575072028\",\"level\":\"Informational\",\"resourceGroupName\":\"DefaultResourceGroup-CUS\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1bf8a97a-f239-4357-a5a4-7681a9cdf42a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Premium_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":false,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/DefaultResourceGroup-CUS/providers/Microsoft.Storage/storageAccounts/regenerateaccesskeytest\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:02:37.5072028Z\",\"submissionTimestamp\":\"2021-09-20T15:03:53.1277868Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_e806120b25aa4ee6aa57d144091ee55a_637683439596453924"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "801ca82c-ea1a-4724-b557-3ba0540351b3"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125239Z:801ca82c-ea1a-4724-b557-3ba0540351b3"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:39 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:38.742Z",
+        "time": 944,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 944
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 1,
         "cache": {},
         "request": {
@@ -950,12 +1452,12 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "70027967-9f1d-4e7d-a5c6-e7408835d0df"
+              "value": "98453ada-f4f3-4d66-91e1-cb4335fb0bfd"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -977,7 +1479,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -986,7 +1488,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -997,7 +1499,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:43.000Z",
+              "expires": "2021-10-27T12:52:40.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1032,10 +1534,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1316"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -1057,11 +1555,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "c211f655-9cf2-471d-b5bd-abdd8c122100"
+              "value": "cbd9f809-5cc2-4d64-92b7-307b3d0d4900"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - EUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1080,17 +1578,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:40 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 716,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:42.955Z",
-        "time": 171,
+        "startedDateTime": "2021-09-27T12:52:39.756Z",
+        "time": 656,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1098,11 +1600,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 171
+          "wait": 656
         }
       },
       {
-        "_id": "5dbc34c006894f7ce143f08803d3acba",
+        "_id": "12ec0509765fac63d7064f131c7b3918",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1117,12 +1619,12 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "729cc3fc-4639-4e91-b806-7a03ebe5b86a"
+              "value": "31a16ad4-f3c0-47f7-9a46-a53dd3a1ba58"
             },
             {
               "_fromType": "array",
@@ -1141,10 +1643,10 @@
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.blob.core.windows.net"
+              "value": "regenerateaccesskeytest.blob.core.windows.net"
             }
           ],
-          "headersSize": 1585,
+          "headersSize": 1615,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1157,24 +1659,20 @@
               "value": "properties"
             }
           ],
-          "url": "https://ndowmon1j1dev.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://regenerateaccesskeytest.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 805,
+          "bodySize": 236,
           "content": {
-            "mimeType": "application/xml",
-            "size": 805,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+            "mimeType": "text/plain",
+            "size": 236,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<StorageServiceProperties><Cors/><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "content-type",
-              "value": "application/xml"
+              "name": "content-length",
+              "value": "236"
             },
             {
               "name": "server",
@@ -1182,29 +1680,29 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "917fd362-a01e-0038-4e3a-18e8ff000000"
-            },
-            {
-              "name": "x-ms-client-request-id",
-              "value": "729cc3fc-4639-4e91-b806-7a03ebe5b86a"
+              "value": "9785b849-601c-0066-6a9e-b350e8000000"
             },
             {
               "name": "x-ms-version",
               "value": "2020-06-12"
             },
             {
+              "name": "x-ms-client-request-id",
+              "value": "31a16ad4-f3c0-47f7-9a46-a53dd3a1ba58"
+            },
+            {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:43 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:41 GMT"
             }
           ],
-          "headersSize": 295,
+          "headersSize": 257,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.131Z",
-        "time": 227,
+        "startedDateTime": "2021-09-27T12:52:40.421Z",
+        "time": 851,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1212,11 +1710,168 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 227
+          "wait": 851
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "0b12e019-8ef0-481e-b2e5-f11851a78205"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:52:41+02:00' and eventTimestamp le '2021-09-27T14:52:41+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A52%3A41%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A52%3A41%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_SQL_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fsqlvab7pt3ww5qhmdw%27"
+        },
+        "response": {
+          "bodySize": 12761,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 12761,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"1bf92f9b-047b-4228-84df-7c2ed64bacdf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/1bf92f9b-047b-4228-84df-7c2ed64bacdf/ticks/637679941964644382\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46f46d72-c836-4fb5-81df-39d87ee35361\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:43:16.4644382Z\",\"submissionTimestamp\":\"2021-09-23T11:45:03.183974Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/44eaf4ac-140a-4bf5-8f8c-1b00c3de62a0/ticks/637679941750596914\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"'audit' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"e4bbfd9b-2399-4547-bc1b-72028b20383d\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/e4bbfd9b-2399-4547-bc1b-72028b20383d/ticks/637679941750596914\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d025664b-f003-466c-ae55-f71b01f9ba78\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"'auditIfNotExists' Policy action.\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/6edd7eda-6dd8-40f7-810d-67160c639cd9/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"6edd7eda-6dd8-40f7-810d-67160c639cd9\\\",\\\"policyDefinitionEffect\\\":\\\"AuditIfNotExists\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:55.0596914Z\",\"submissionTimestamp\":\"2021-09-23T11:43:58.1249063Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"5e859926-06ba-422b-b976-128ae719d9c5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/5e859926-06ba-422b-b976-128ae719d9c5/ticks/637679941731506587\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"3d667eff-b604-4b94-9aa0-f6ae6b20cd2e\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:42:53.1506587Z\",\"submissionTimestamp\":\"2021-09-23T11:43:29.1239763Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"44a7cc1c-09a5-408a-bb6d-7159bd091493\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/44a7cc1c-09a5-408a-bb6d-7159bd091493/ticks/637679936036356606\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"57d231f9-c955-4a39-81a7-e0ca1179c7c3\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created\"},\"eventTimestamp\":\"2021-09-23T11:33:23.6356606Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1880622Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"c997130c-e08c-4218-8c43-b292200e4d82\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9c3f7882-bd4c-48e9-91e3-3e46eb65796e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c/events/c997130c-e08c-4218-8c43-b292200e4d82/ticks/637679936001153487\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"38ba479d-e6d7-4be2-aa76-411d702340eb\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments/write\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"scope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/providers/Microsoft.Authorization/roleAssignments/5fb80f4f-49b1-5410-af14-796d1d588b8c\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:20.1153487Z\",\"submissionTimestamp\":\"2021-09-23T11:34:47.1860603Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"db28785d-d234-4156-85d1-f93663a89aa7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/db28785d-d234-4156-85d1-f93663a89aa7/ticks/637679935941633332\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"1645c04a-9f69-472c-8224-c5be3334796c\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:33:14.1633332Z\",\"submissionTimestamp\":\"2021-09-23T11:34:50.1441225Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"685222b6-8e45-4a6f-9116-77895f3c68eb\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/685222b6-8e45-4a6f-9116-77895f3c68eb/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"5f9205a3-3c45-4db5-abf6-4cbba8b09865\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d4290f0f-f81f-48ff-8d26-686074ca277a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d4290f0f-f81f-48ff-8d26-686074ca277a/ticks/637679935730460803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"463cb640-befe-45af-b4d7-b5470a837a59\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-23T11:32:53.0460803Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"b821643d-9081-4a4b-a57c-2f8ca07b7002\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/b821643d-9081-4a4b-a57c-2f8ca07b7002/ticks/637679935726410258\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"localizedValue\":\"Microsoft.Authorization/policies/auditIfNotExists/action\"},\"properties\":{\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/auditIfNotExists/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:52.6410258Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1485747Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"dab4de05-9d1d-41af-bda7-78b884be52d5\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Policy\",\"localizedValue\":\"Policy\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/dab4de05-9d1d-41af-bda7-78b884be52d5/ticks/637679935680160357\",\"level\":\"Warning\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Authorization/policies/audit/action\",\"localizedValue\":\"Microsoft.Authorization/policies/audit/action\"},\"properties\":{\"isComplianceCheck\":\"False\",\"resourceLocation\":\"eastus\",\"ancestors\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"policies\":\"[{\\\"policyDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policyDefinitions/2a1a9cdf-e04d-429a-8416-3bfb72a1b26f/\\\",\\\"policySetDefinitionId\\\":\\\"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/\\\",\\\"policyDefinitionReferenceId\\\":\\\"storageAccountsShouldRestrictNetworkAccessUsingVirtualNetworkRulesMonitoringEffect\\\",\\\"policySetDefinitionName\\\":\\\"1f3afdf9-d0c9-4c3d-847f-89da613e70a8\\\",\\\"policyDefinitionName\\\":\\\"2a1a9cdf-e04d-429a-8416-3bfb72a1b26f\\\",\\\"policyDefinitionEffect\\\":\\\"Audit\\\",\\\"policyAssignmentId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn/\\\",\\\"policyAssignmentName\\\":\\\"SecurityCenterBuiltIn\\\",\\\"policyAssignmentScope\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\\\",\\\"policyAssignmentSku\\\":{\\\"name\\\":\\\"A1\\\",\\\"tier\\\":\\\"Standard\\\"},\\\"policyExemptionIds\\\":[]}]\",\"eventCategory\":\"Policy\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Authorization/policies/audit/action\",\"hierarchy\":\"\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:48.0160357Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632395070\",\"nbf\":\"1632395070\",\"exp\":\"1632398970\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA1tMfRKjRKQs3O7Pr+RlZSkjiLEofOmG37lH4fb4AB9T+Qqf/oHaGFCz9YlXRXbePHKWIHLdw51dFd9nh+ta5P8moLCK18JsLhaxob5PMKVD2LOV0jc/VmhLAZm47nkPkT+e+XMlG1d3rOHfEzR72y/z3PN00Nzp2FaXuKa5fwWY=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"9WlauCuxa02761uFyFZKAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"c861216c-6d8e-4bce-92c4-a8ac88722989\",\"description\":\"\",\"eventDataId\":\"d5d150f2-829f-42ea-8a70-cb7aead80689\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"e52cc936-d6c5-4426-ab20-0bb8f80ac84a\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw/events/d5d150f2-829f-42ea-8a70-cb7aead80689/ticks/637679935679959308\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_SQL_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"db8ee5e5-4bcf-47ad-a56b-afe0d4908239\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"properties\\\":{\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":\\\"true\\\",\\\"allowBlobPublicAccess\\\":\\\"false\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_SQL_Resources/providers/Microsoft.Storage/storageAccounts/sqlvab7pt3ww5qhmdw\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T11:32:47.9959308Z\",\"submissionTimestamp\":\"2021-09-23T11:33:37.1475735Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_e73e7412b7494d9c81a7d1bb434b429c_637683439621176208"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11997"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "9224bde0-5b7a-45f5-8763-986ee24ca63b"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125242Z:9224bde0-5b7a-45f5-8763-986ee24ca63b"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:41 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:41.341Z",
+        "time": 805,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 805
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 2,
         "cache": {},
         "request": {
@@ -1241,17 +1896,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "c5957282-5ac7-42ec-adcf-a629bfd89135"
+              "value": "fe8fe979-748e-4f6e-aaa0-cf763a5cf974"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": "fpc=ApFdsOO_jyBAjqpjKriE6a4RsITIAQAAAGIC39cOAAAA"
+              "value": ""
             },
             {
               "_fromType": "array",
@@ -1268,7 +1923,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 475,
+          "headersSize": 437,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1277,7 +1932,7 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
           "bodySize": 1316,
@@ -1288,7 +1943,7 @@
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:43.000Z",
+              "expires": "2021-10-27T12:52:42.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1344,11 +1999,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "1b6f3eb4-fdb5-4e23-a15a-a4f4d6ec2100"
+              "value": "1db473da-f81d-49ed-b5f3-fca507fc4e00"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - NCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1367,21 +2022,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:42 GMT"
             },
             {
               "name": "content-length",
               "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.364Z",
-        "time": 93,
+        "startedDateTime": "2021-09-27T12:52:42.157Z",
+        "time": 705,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1389,11 +2044,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 93
+          "wait": 705
         }
       },
       {
-        "_id": "af6a01d1852c557b688492da54e4f9fe",
+        "_id": "155a15bd9bc9daa4c43589a03bdf5d4b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1407,18 +2062,13 @@
             },
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "application/xml"
-            },
-            {
-              "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "bc37cff7-def7-4097-a177-e78afb8dc222"
+              "value": "4d16e3fd-c817-4abe-9218-62a2647d76e2"
             },
             {
               "_fromType": "array",
@@ -1432,15 +2082,15 @@
             },
             {
               "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
+              "name": "accept",
+              "value": "*/*"
             },
             {
               "name": "host",
-              "value": "ndowmon1j1dev.queue.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.blob.core.windows.net"
             }
           ],
-          "headersSize": 1642,
+          "headersSize": 1605,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1451,27 +2101,19 @@
             {
               "name": "comp",
               "value": "properties"
-            },
-            {
-              "name": "timeout",
-              "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1dev.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+          "url": "https://sqlvab7pt3ww5qhmdw.blob.core.windows.net/?restype=service&comp=properties"
         },
         "response": {
-          "bodySize": 626,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/xml",
-            "size": 626,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+            "size": 749,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
             {
               "name": "transfer-encoding",
               "value": "chunked"
@@ -1482,15 +2124,15 @@
             },
             {
               "name": "server",
-              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
             },
             {
               "name": "x-ms-request-id",
-              "value": "da070fbf-c003-00b8-613a-1817f9000000"
+              "value": "6d613896-901e-003e-489e-b30019000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "bc37cff7-def7-4097-a177-e78afb8dc222"
+              "value": "4d16e3fd-c817-4abe-9218-62a2647d76e2"
             },
             {
               "name": "x-ms-version",
@@ -1498,17 +2140,17 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:42 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:43 GMT"
             }
           ],
-          "headersSize": 321,
+          "headersSize": 295,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.462Z",
-        "time": 33,
+        "startedDateTime": "2021-09-27T12:52:42.867Z",
+        "time": 598,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1516,11 +2158,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 33
+          "wait": 598
         }
       },
       {
-        "_id": "419f8a68424a58ccfbfa7e96d080076d",
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
         "_order": 3,
         "cache": {},
         "request": {
@@ -1545,17 +2187,17 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "3acb5173-cdd3-49a1-8d69-f000175bdb90"
+              "value": "c31d2560-fb08-4976-9ee5-4a98bb76d247"
             },
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "core-http/1.1.3 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "cookie",
-              "value": ""
+              "value": "fpc=ApoJ47tFo0VHiQlDgflBpnA-ExxYAQAAAJq149gOAAAA"
             },
             {
               "_fromType": "array",
@@ -1572,7 +2214,7 @@
               "value": "login.microsoftonline.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 485,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1581,18 +2223,18 @@
             "text": "[REDACTED]"
           },
           "queryString": [],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/v2.0/token"
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
         },
         "response": {
-          "bodySize": 1311,
+          "bodySize": 1316,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1311,
+            "size": 1316,
             "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
           },
           "cookies": [
             {
-              "expires": "2021-04-12T18:58:43.000Z",
+              "expires": "2021-10-27T12:52:44.000Z",
               "httpOnly": true,
               "name": "fpc",
               "path": "/",
@@ -1627,10 +2269,6 @@
               "value": "no-cache"
             },
             {
-              "name": "content-length",
-              "value": "1311"
-            },
-            {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
@@ -1652,11 +2290,11 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "5d5473ed-a43e-4d8c-9635-10cef8932200"
+              "value": "7479681a-c0f3-449e-a2f8-af80cee25400"
             },
             {
               "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
+              "value": "2.1.12071.16 - SCUS ProdSlices"
             },
             {
               "_fromType": "array",
@@ -1675,17 +2313,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:43 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:43 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
             }
           ],
-          "headersSize": 712,
+          "headersSize": 717,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.499Z",
-        "time": 160,
+        "startedDateTime": "2021-09-27T12:52:43.488Z",
+        "time": 628,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1693,11 +2335,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 160
+          "wait": 628
         }
       },
       {
-        "_id": "ee4f6ed8f5c33ad8b5cafac8001e69f6",
+        "_id": "8bb93cbc2d87e49d3993a0fdc741e834",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1711,13 +2353,18 @@
             },
             {
               "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
               "name": "user-agent",
-              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.9.0; Darwin 20.2.0)"
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "f3c8495b-3d79-4269-857b-26b528add723"
+              "value": "c1c9996a-ce06-4056-9d9a-454315808455"
             },
             {
               "_fromType": "array",
@@ -1731,15 +2378,15 @@
             },
             {
               "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
             },
             {
               "name": "host",
-              "value": "ndowmon1j1devblobstorage.blob.core.windows.net"
+              "value": "sqlvab7pt3ww5qhmdw.queue.core.windows.net"
             }
           ],
-          "headersSize": 1602,
+          "headersSize": 1662,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1750,19 +2397,27 @@
             {
               "name": "comp",
               "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
             }
           ],
-          "url": "https://ndowmon1j1devblobstorage.blob.core.windows.net/?restype=service&comp=properties"
+          "url": "https://sqlvab7pt3ww5qhmdw.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
         },
         "response": {
-          "bodySize": 651,
+          "bodySize": 573,
           "content": {
             "mimeType": "application/xml",
-            "size": 651,
-            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
           },
           "cookies": [],
           "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
             {
               "name": "transfer-encoding",
               "value": "chunked"
@@ -1773,15 +2428,15 @@
             },
             {
               "name": "server",
-              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
             },
             {
               "name": "x-ms-request-id",
-              "value": "361fb781-b01e-0074-093a-185a56000000"
+              "value": "a9cdedee-2003-0092-749e-b313b0000000"
             },
             {
               "name": "x-ms-client-request-id",
-              "value": "f3c8495b-3d79-4269-857b-26b528add723"
+              "value": "c1c9996a-ce06-4056-9d9a-454315808455"
             },
             {
               "name": "x-ms-version",
@@ -1789,17 +2444,17 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:43 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:43 GMT"
             }
           ],
-          "headersSize": 295,
+          "headersSize": 321,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.663Z",
-        "time": 31,
+        "startedDateTime": "2021-09-27T12:52:44.136Z",
+        "time": 580,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1807,205 +2462,22 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 31
+          "wait": 580
         }
       },
       {
-        "_id": "4eab979841c1f2185e48b484c23ec3e2",
-        "_order": 1,
-        "cache": {},
-        "request": {
-          "bodySize": 172,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept-charset",
-              "value": "utf-8"
-            },
-            {
-              "name": "client-request-id",
-              "value": "48e343d0-5680-4ba7-8c8e-7b132990037e"
-            },
-            {
-              "name": "return-client-request-id",
-              "value": "true"
-            },
-            {
-              "name": "x-client-sku",
-              "value": "Node"
-            },
-            {
-              "name": "x-client-ver",
-              "value": "0.1.28"
-            },
-            {
-              "name": "x-client-os",
-              "value": "darwin"
-            },
-            {
-              "name": "x-client-cpu",
-              "value": "x64"
-            },
-            {
-              "name": "host",
-              "value": "login.microsoftonline.com"
-            },
-            {
-              "name": "content-length",
-              "value": 172
-            }
-          ],
-          "headersSize": 414,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/x-www-form-urlencoded",
-            "params": [],
-            "text": "[REDACTED]"
-          },
-          "queryString": [
-            {
-              "name": "api-version",
-              "value": "1.0"
-            }
-          ],
-          "url": "https://login.microsoftonline.com/992d7bbe-b367-459c-a10f-cf3fd16103ab/oauth2/token?api-version=1.0"
-        },
-        "response": {
-          "bodySize": 1450,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1450,
-            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1615665523\",\"not_before\":\"1615661623\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
-          },
-          "cookies": [
-            {
-              "expires": "2021-04-12T18:58:44.000Z",
-              "httpOnly": true,
-              "name": "fpc",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "x-ms-gateway-slice",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            },
-            {
-              "httpOnly": true,
-              "name": "stsservicecookie",
-              "path": "/",
-              "secure": true,
-              "value": "[REDACTED]"
-            }
-          ],
-          "headers": [
-            {
-              "name": "cache-control",
-              "value": "no-store, no-cache"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-length",
-              "value": "1450"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "expires",
-              "value": "-1"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "p3p",
-              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
-            },
-            {
-              "name": "client-request-id",
-              "value": "48e343d0-5680-4ba7-8c8e-7b132990037e"
-            },
-            {
-              "name": "x-ms-request-id",
-              "value": "47b5938e-31cb-406b-a526-d77780882300"
-            },
-            {
-              "name": "x-ms-ests-server",
-              "value": "2.1.11530.17 - EST ProdSlices"
-            },
-            {
-              "name": "x-ms-clitelem",
-              "value": "1,0,0,,"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "[REDACTED]"
-            },
-            {
-              "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:43 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 782,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-03-13T18:58:43.700Z",
-        "time": 214,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 214
-        }
-      },
-      {
-        "_id": "5b659db4e0ea98de8227750eb75526ee",
-        "_order": 1,
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 2,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
             {
               "_fromType": "array",
               "name": "accept-language",
@@ -2014,12 +2486,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "5a63a9aa-b4ad-4a84-bd8b-008cb8d65554"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
+              "value": "3a866d69-8022-404c-a277-77472d6d7b0d"
             },
             {
               "_fromType": "array",
@@ -2029,7 +2496,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -2056,7 +2523,1699 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1676,
+          "headersSize": 2177,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:52:44+02:00' and eventTimestamp le '2021-09-27T14:52:44+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A52%3A44%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A52%3A44%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_Storage_Resources%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstefanexamplestorage%27"
+        },
+        "response": {
+          "bodySize": 16299,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16299,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4cdc9cbd-fd37-4c53-b1b3-c3b0e2356713/ticks/637680751208063831\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"9f9c4957-cbe0-4829-8e91-6ef594969333\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK (HTTP Status Code: 200)\"},\"eventTimestamp\":\"2021-09-24T10:12:00.8063831Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632477982\",\"nbf\":\"1632477982\",\"exp\":\"1632481882\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAALge9lt2749aS9V3QEx8Wc2mfXKSuLQPMtVSnNTZLoBZUPnL26WXtIyxbhMToy5g1kfE1JKALoXminoBmHVkQ85GlEDkp7i2GKSkliNhY0FgNB2JdQJFXkW8kkko0eigiMtH5MKrz3Lp9Fnu7G4lbR6UDQMfUkmegaiEZTbB7vn8=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"IHIOGzTKRk68Dx0CHcLHAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"91bf55d7-400f-4a23-b16f-8be19e251185\",\"description\":\"\",\"eventDataId\":\"8903f8d4-7a4c-456d-be34-33660212b2bd\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"52185833-9cd6-4431-9f44-dec22eedf00e\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/8903f8d4-7a4c-456d-be34-33660212b2bd/ticks/637680751206863840\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"421e0574-4ed7-4e0b-bcb9-dbd730d65c6b\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"List Storage Account Keys\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T10:12:00.686384Z\",\"submissionTimestamp\":\"2021-09-24T10:14:12.1556817Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"927daf50-bb12-4bb1-960e-005dd0196385\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/927daf50-bb12-4bb1-960e-005dd0196385/ticks/637680036884982412\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"statusCode\":\"Created\",\"serviceRequestId\":\"2fbc6389-ef5b-43c4-8771-5500d31026d5\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"Created\",\"localizedValue\":\"Created (HTTP Status Code: 201)\"},\"eventTimestamp\":\"2021-09-23T14:21:28.4982412Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Authorization/roleAssignments/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632405027\",\"nbf\":\"1632405027\",\"exp\":\"1632408927\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAAmkgwKOg3hqU9F1aQcBac0PGN7K/cxME8k2M2fUvmpkshv7fMIpCWARdfPz/Bxs71/0LEI8LpUSMZF47iONUGbQ7xkzWqC0pP7Q00OjOa7g5o+4fD+MGNOKUk12ufZFPJzOPUzB3TIEmSRNij2rDWQoArxx+pNVShSy8vh5J49nw=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"sYxeQTSIG0GsCpLqyabZAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"description\":\"\",\"eventDataId\":\"f60bee7d-a7ea-4f59-9d88-658fafc85b1f\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"Begin request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"8407263c-4065-40e6-8626-47d5ac615093\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860/events/f60bee7d-a7ea-4f59-9d88-658fafc85b1f/ticks/637680036855632564\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Authorization\",\"localizedValue\":\"Microsoft.Authorization\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"resourceType\":{\"value\":\"Microsoft.Authorization/roleAssignments\",\"localizedValue\":\"Microsoft.Authorization/roleAssignments\"},\"operationId\":\"6fad0aa1-082c-4d5f-b0e9-8133b19268a1\",\"operationName\":{\"value\":\"Microsoft.Authorization/roleAssignments/write\",\"localizedValue\":\"Create role assignment\"},\"properties\":{\"requestbody\":\"{\\\"properties\\\":{\\\"roleDefinitionId\\\":\\\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\\\",\\\"principalId\\\":\\\"84b9c44b-abe7-4fb4-a580-1a5ad3c707b2\\\",\\\"principalType\\\":\\\"ServicePrincipal\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/providers/Microsoft.Authorization/roleAssignments/cd5ff043-20a4-4e48-af3e-a8cff09a6860\",\"message\":\"Microsoft.Authorization/roleAssignments/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T14:21:25.5632564Z\",\"submissionTimestamp\":\"2021-09-23T14:22:34.1312655Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0dde252b-5665-4e8a-a936-4daba0d8a575\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0dde252b-5665-4e8a-a936-4daba0d8a575/ticks/637677468635548611\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"b1001d0c-e882-4506-b8ab-9163d906f654\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-20T15:01:03.5548611Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"pgilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632149736\",\"nbf\":\"1632149736\",\"exp\":\"1632153636\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAh263mk6yQpW9g3AiFHhHI6b8gDxQWX9QMGXDy2tjCVq4R2NQCKtsr+TYGbrcoXiUFhilR7jSrAwLc+YIql2W6w==\",\"altsecid\":\"1:live.com:00034001C52E8356\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgilaga@gmail.com\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\":\"Ilaga\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\":\"Paul\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"ce6241b4-83db-44c2-8b12-11d0bc49f6e8\",\"puid\":\"100320017D5D9281\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAGA.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"OV5wJRj-yn9aeHjZaVUPt9Yx_2zFUQSS9mQ0MTs6XV4\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgilaga@gmail.com\",\"uti\":\"q7rzcJKdx0eI3S4_0bsAAg\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"2d842cc5-0d7c-46df-a5f9-08c363e99702\",\"description\":\"\",\"eventDataId\":\"0842ad8b-0a70-4ce5-8652-a7f2114e8000\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"c7c28c34-3f73-4112-99ea-c931d2b9100d\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/0842ad8b-0a70-4ce5-8652-a7f2114e8000/ticks/637677468633347789\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ddcb0b1b-e776-44ff-9ff6-44063bd61970\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-20T15:01:03.3347789Z\",\"submissionTimestamp\":\"2021-09-20T15:03:16.1689535Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e23ef41a-a6e6-4aea-8a7b-03289ab1ca4a/ticks/637666178855994320\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"2bc25043-553e-48b1-ad9b-ce9926416ca9\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:45.599432Z\",\"submissionTimestamp\":\"2021-09-07T13:26:18.0982287Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b1dc8c9d-57e9-422f-b6b6-a2ab4089845e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/b1dc8c9d-57e9-422f-b6b6-a2ab4089845e/ticks/637666178612856613\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"06c3da4c-be9c-4b9c-9bb1-c29b06dc2943\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:24:21.2856613Z\",\"submissionTimestamp\":\"2021-09-07T13:25:26.1292429Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"fa96b680-b3f9-471c-a777-a69da710ac89\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/fa96b680-b3f9-471c-a777-a69da710ac89/ticks/637666172866182094\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ce0cce81-7af2-48c6-b614-da08e1048548\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.6182094Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"138520b9-0d15-4108-98e6-b26cfcaed86c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"dd08fefc-b61c-4da1-a1e2-d3166d062883\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default/events/138520b9-0d15-4108-98e6-b26cfcaed86c/ticks/637666172864682093\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices\"},\"operationId\":\"b4a0457e-8fd1-46a7-9dd9-d31982162e9a\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/fileservices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileservices/default\",\"message\":\"Microsoft.Storage/storageAccounts/fileservices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:46.4682093Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"b49bfb26-b7bd-488b-bf76-f4891ad74605\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/b49bfb26-b7bd-488b-bf76-f4891ad74605/ticks/637666172863682069\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"22765ce3-92ae-4aed-954d-7f26ab018c84\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-07T13:14:46.3682069Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"575b58d7-a757-4a45-aebe-40195806a39c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"6a39fdf8-c4e2-4ce0-acf9-c41b7f99c6be\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default/events/575b58d7-a757-4a45-aebe-40195806a39c/ticks/637666172849132353\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices\"},\"operationId\":\"ea5e952c-33d7-470f-80b8-2022e1726efd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/blobServices/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/blobServices/default\",\"message\":\"Microsoft.Storage/storageAccounts/blobServices/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:44.9132353Z\",\"submissionTimestamp\":\"2021-09-07T13:34:51.6890449Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"870fddbd-ee80-4254-b798-ab2e71de1de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/870fddbd-ee80-4254-b798-ab2e71de1de1/ticks/637666172832824197\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c6e734b2-12f7-4965-8ec4-f7feb27666b1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:43.2824197Z\",\"submissionTimestamp\":\"2021-09-07T13:15:26.1178018Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"4e08dab9-10e0-49d3-abf6-4a61f7315de1\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/4e08dab9-10e0-49d3-abf6-4a61f7315de1/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"75ec2246-b3ed-4a2a-8d99-85232ae352cd\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"f5231d65-9872-4ab7-82fa-030783fd80bd\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/f5231d65-9872-4ab7-82fa-030783fd80bd/ticks/637666172613508926\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"d1f0bd9a-7d00-4270-8164-a37d77ad40a8\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:21.3508926Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1741359Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631019503\",\"nbf\":\"1631019503\",\"exp\":\"1631023403\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AWQAm/8TAAAAoZ5NcISrkZ3sPK2hIoX5WyVQPZh6Ir1iC8jQ8WQn82c6KgruqwS5b7KCC2DpHsj9M0DzE93KDqcbVHAJ67Xl5uljdFP07uLsmOXjZh8/dS4MG5/aIjcXCsFmSQWNYdXR\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"URwNqCpaNEqpML6cwUqEAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"3a1bb3be-e700-423d-bcef-9ae316c01844\",\"description\":\"\",\"eventDataId\":\"e50013de-1290-4050-945c-edd8ac16b016\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f550867b-8c39-4124-82f4-5aa8a7186c2b\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/events/e50013de-1290-4050-945c-edd8ac16b016/ticks/637666172560836200\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_Storage_Resources\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"58ff3b8c-9c9c-466d-a3a0-2afcac9674fb\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_RAGRS\\\"},\\\"kind\\\":\\\"StorageV2\\\",\\\"location\\\":\\\"eastus\\\",\\\"tags\\\":\\\"******\\\",\\\"properties\\\":{\\\"accessTier\\\":\\\"Hot\\\",\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\",\\\"supportsHttpsTrafficOnly\\\":true,\\\"allowBlobPublicAccess\\\":true,\\\"allowSharedKeyAccess\\\":true,\\\"allowCrossTenantReplication\\\":true,\\\"defaultToOAuthAuthentication\\\":false,\\\"networkAcls\\\":{\\\"bypass\\\":\\\"AzureServices\\\",\\\"defaultAction\\\":\\\"Allow\\\",\\\"ipRules\\\":[]}}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_Storage_Resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-07T13:14:16.08362Z\",\"submissionTimestamp\":\"2021-09-07T13:34:47.1731361Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_d453c343dd7348869bec8c2ef78b151c_637683439656285883"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "57963cf6-af5d-4ad4-ae87-9c99e4a423d2"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125245Z:57963cf6-af5d-4ad4-ae87-9c99e4a423d2"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:45 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:44.727Z",
+        "time": 925,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 925
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "f6629fd5-10f1-45b2-bc4e-1a7c0827ee2e"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:46.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fabac303-62f3-4eb5-bdad-0acefa564e00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - NCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:45 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 696,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:45.661Z",
+        "time": 705,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 705
+        }
+      },
+      {
+        "_id": "396844fb10796ff14cd9ef4c38881321",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "333f971d-5a9b-45ee-b063-b43b88eaa7cd"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1609,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://stefanexamplestorage.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 762,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 762,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "19d43a0b-701e-003a-259e-b30a4c000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "333f971d-5a9b-45ee-b063-b43b88eaa7cd"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:46 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:46.369Z",
+        "time": 629,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 629
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3dbae5ca-8bf7-4494-9ffb-fc706344e6c4"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=AhlinXAb3JVOrX8ap2UNubg"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 464,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:47.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "09eb09d3-d758-4e2e-8ec4-6974d5014a00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - EUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:46 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 695,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:47.004Z",
+        "time": 476,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 476
+        }
+      },
+      {
+        "_id": "35a194af62cb1877e4f3a2940d92adfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "fd652e18-3e13-4711-b1fa-884581c2e7e5"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "stefanexamplestorage.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1666,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://stefanexamplestorage.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "d6299ebe-6003-0009-0f9e-b355e7000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "fd652e18-3e13-4711-b1fa-884581c2e7e5"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:47 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:47.484Z",
+        "time": 732,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 732
+        }
+      },
+      {
+        "_id": "63c1e91a3010d051bad1523d9486f161",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "25339333-0c4b-4277-b37b-d2db50cdfcee"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-monitor/5.4.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 2180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2015-04-01"
+            },
+            {
+              "name": "$filter",
+              "value": "eventTimestamp ge '2021-06-29T14:52:48+02:00' and eventTimestamp le '2021-09-27T14:52:48+02:00' and resourceUri eq '/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8'"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&%24filter=eventTimestamp%20ge%20%272021-06-29T14%3A52%3A48%2B02%3A00%27%20and%20eventTimestamp%20le%20%272021-09-27T14%3A52%3A48%2B02%3A00%27%20and%20resourceUri%20eq%20%27%2Fsubscriptions%2F193f89dc-6225-4a80-bacb-96b32fbf6dd0%2FresourceGroups%2FStefan_AppServices_Group%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fstorageaccountstefaafb8%27"
+        },
+        "response": {
+          "bodySize": 16495,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16495,
+            "text": "{\"value\":[{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"71d2ca88-e069-4418-a9a1-5e61fa4e29e7\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/71d2ca88-e069-4418-a9a1-5e61fa4e29e7/ticks/637683118197796970\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"fc21cc29-04bb-4c52-bd10-09f62bdcc345\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.779697Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"description\":\"\",\"eventDataId\":\"0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/0f6bab5a-74c2-4d7e-8c80-2e9dc5e94022/ticks/637683118197546829\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"6dc43c11-613b-40b8-bc0a-20f7e930607c\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7546829Z\",\"submissionTimestamp\":\"2021-09-27T03:57:33.0968437Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"34858c5b-8c5d-4884-b748-2ab3d59bd78b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/34858c5b-8c5d-4884-b748-2ab3d59bd78b/ticks/637683118197378385\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"8b8be42f-bfef-4507-95f6-ccd2a0bfca45\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7378385Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"microsoft.storage/storageaccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\"},\"caller\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.azure.com/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632714719\",\"nbf\":\"1632714719\",\"exp\":\"1632801419\",\"aio\":\"E2ZgYPCrtD8zzb5FeMM3J23uWZOdAA==\",\"appid\":\"11c174dc-1945-4a9a-a36b-c79a0f246b9b\",\"appidacr\":\"2\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrdx0wRFFGZpKo2vHmg8ka5tQAAA.\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"f4a8c456-da45-4506-9a37-6b7e92bf659e\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"uti\":\"2nO0HR347Um18_ylB-QlAA\",\"ver\":\"1.0\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"description\":\"\",\"eventDataId\":\"cb12a0cf-8b0e-494b-a483-05cc8e2af298\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"18fdd9b5-e6f4-4e97-a80f-2be820af5db2\",\"clientIpAddress\":\"104.43.168.79\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8/events/cb12a0cf-8b0e-494b-a483-05cc8e2af298/ticks/637683118197028379\",\"level\":\"Informational\",\"resourceGroupName\":\"stefan_appservices_group\",\"resourceProviderName\":{\"value\":\"microsoft.storage\",\"localizedValue\":\"microsoft.storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"microsoft.storage/storageaccounts\",\"localizedValue\":\"microsoft.storage/storageaccounts\"},\"operationId\":\"8b037aa8-40ec-4140-b584-006e0a4d26d1\",\"operationName\":{\"value\":\"microsoft.storage/storageaccounts/listKeys/action\",\"localizedValue\":\"microsoft.storage/storageaccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/stefan_appservices_group/providers/microsoft.storage/storageaccounts/storageaccountstefaafb8\",\"message\":\"microsoft.storage/storageaccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-27T03:56:59.7028379Z\",\"submissionTimestamp\":\"2021-09-27T03:57:32.1717882Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"9ab0273f-4168-420b-a82a-04a95ef004b9\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/9ab0273f-4168-420b-a82a-04a95ef004b9/ticks/637680895404911980\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"e3e29761-cb4f-44b6-9c21-c4bef3490d74\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-24T14:12:20.491198Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632492436\",\"nbf\":\"1632492436\",\"exp\":\"1632496336\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAA9X+NS3F7C21QVL5/N8hj+ObcNnNYrOHkBF8xRTRmUPYT20Z27URHxZeKE+qpjqHu9/WU73bierT36/YFnHuXjw==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"IDuZY_ERakaK3hOVBjsOAQ\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"54754ecd-345e-479c-a630-ca7328a60be3\",\"description\":\"\",\"eventDataId\":\"f3127244-2903-49eb-8290-896fb807e4bf\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"bf114d66-788f-4bad-af5f-6aedf51a0002\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f3127244-2903-49eb-8290-896fb807e4bf/ticks/637680895402811842\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"c72671a0-dd02-4f25-a511-74ad3a5578b6\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-24T14:12:20.2811842Z\",\"submissionTimestamp\":\"2021-09-24T14:14:11.1855613Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"f4c0ba23-4f98-4def-837e-c8de0728547e\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f4c0ba23-4f98-4def-837e-c8de0728547e/ticks/637680004888576312\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"ccd64de2-9c2f-4578-8496-5808bf5ae478\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:28:08.8576312Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1600853Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400225\",\"nbf\":\"1632400225\",\"exp\":\"1632404125\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAd/cnvjo/E9E2TlOLyMHDMLOatqslAGoLfZOye9E8DdMJwAqIpLrCNwe0NOUuPHK/E/AlRUuitSzEA5mfDz13qA==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"RLCvP6xcjEKJ1H2FBaxFAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"b21da61a-a626-4817-9363-121a355064d6\",\"description\":\"\",\"eventDataId\":\"abee07ad-735f-4daf-a00b-dbcb2420491c\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"619e32f0-2602-4bde-8ec8-c2ed200c305a\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/abee07ad-735f-4daf-a00b-dbcb2420491c/ticks/637680004886626307\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ae63be-cd35-4921-9825-e1acffebeddd\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:28:08.6626307Z\",\"submissionTimestamp\":\"2021-09-23T13:30:08.1590849Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"609c11d9-f767-47fc-b7f6-2b01de6df6d3\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/609c11d9-f767-47fc-b7f6-2b01de6df6d3/ticks/637680004138311948\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"aa7000e2-9f8d-45c0-8eaf-ab889d7022c8\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-23T13:26:53.8311948Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"pgrilaga@gmail.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1632400177\",\"nbf\":\"1632400177\",\"exp\":\"1632404077\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AUQAu/8TAAAAdZ5lDbs6tnRxxO55ABFgEQcKAXhgQ4UeB2J/1Rpp+SH0qJ+lv3dg14LJLw/UPZvLD/TKCxJ5wiywcIG+lQSVfg==\",\"altsecid\":\"1:live.com:0003000042986D9E\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd\",\"appid\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"appidacr\":\"0\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"pgrilaga@gmail.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"live.com\",\"ipaddr\":\"119.94.104.161\",\"name\":\"Paul v2\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"1f4787d8-650f-4dd6-bfc5-ede5d47b63f5\",\"puid\":\"100320018A835864\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrZV3sATbjRpGu-4C-eG_e0ZQAC0.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"B1QogqWqsyGrQNUdTDQeq4ibH2N_k3S2UXt4QIx2dQ0\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"live.com#pgrilaga@gmail.com\",\"uti\":\"o2x8v89En0SDcWOKqXhLAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10,13bd1c72-6f4a-4dcf-985f-18d3b80f208a\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"description\":\"\",\"eventDataId\":\"f7bd6f5d-a4a6-459f-b677-7cc6aef350bb\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"f17e8139-1c71-11ec-a513-f1eaf2559bf3\",\"clientIpAddress\":\"119.94.104.161\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/f7bd6f5d-a4a6-459f-b677-7cc6aef350bb/ticks/637680004131562335\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"aeb84788-6cb1-4468-86dc-76b428a8d746\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-23T13:26:53.1562335Z\",\"submissionTimestamp\":\"2021-09-23T13:27:47.1560638Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"95e08496-5682-44b1-aa43-bc8364b7f678\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/95e08496-5682-44b1-aa43-bc8364b7f678/ticks/637674012546036667\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"188d14f7-04dd-4948-acb1-1216172a19c3\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:54.6036667Z\",\"submissionTimestamp\":\"2021-09-16T15:01:46.1692025Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"8a01ea00-bd83-41d8-8de7-bc51b80d4652\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/8a01ea00-bd83-41d8-8de7-bc51b80d4652/ticks/637674012295717803\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"99bdf78f-4602-4a8c-83b4-19ed0c0e9cd1\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T15:00:29.5717803Z\",\"submissionTimestamp\":\"2021-09-16T15:01:53.1386235Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"b30ffc87-ee15-41e7-81c0-0fb4b05895ff\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/b30ffc87-ee15-41e7-81c0-0fb4b05895ff/ticks/637674006534406250\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"statusCode\":\"OK\",\"serviceRequestId\":\"3113ca2b-d2bc-4f4f-9a8f-89c167e9218a\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"OK\",\"localizedValue\":\"OK\"},\"eventTimestamp\":\"2021-09-16T14:50:53.440625Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"01af52fc-5b12-4703-98b4-cc67db95435e\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"9d155eb4-3116-4bc3-8013-3c4e2de81a45\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"POST\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/01af52fc-5b12-4703-98b4-cc67db95435e/ticks/637674006528456482\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"63faa67b-d72d-4f42-970b-02dfb407a023\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/listKeys/action\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/listKeys/action\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:52.8456482Z\",\"submissionTimestamp\":\"2021-09-16T14:51:54.0887686Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"cf10aecf-4960-4246-8021-a91b9767a6ee\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"End request\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/cf10aecf-4960-4246-8021-a91b9767a6ee/ticks/637674006518718327\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"e2ce1ef8-dabe-4c1b-a7f3-06409c83d4e5\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Create/Update Storage Account\"},\"properties\":{\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Succeeded\",\"localizedValue\":\"Succeeded\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:51.8718327Z\",\"submissionTimestamp\":\"2021-09-16T14:52:09.1184465Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Debug\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"18d6742e-9780-4410-87f2-7861ad8ebcaf\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/18d6742e-9780-4410-87f2-7861ad8ebcaf/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"46e3061f-4966-444c-8a1a-5fcc9c793c50\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"statusMessage\":\"\\\"Resource provisioning is in progress.\\\"\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"e279382a-ca7b-4fb4-bca3-d72bbacb841b\",\"eventName\":{\"value\":\"EndRequest\",\"localizedValue\":\"EndRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/e279382a-ca7b-4fb4-bca3-d72bbacb841b/ticks/637674006293131632\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"statusCode\":\"Accepted\",\"serviceRequestId\":\"36894b22-1fe1-4514-a797-ba687ae30306\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"subStatus\":{\"value\":\"Accepted\",\"localizedValue\":\"Accepted\"},\"eventTimestamp\":\"2021-09-16T14:50:29.3131632Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.175789Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"},{\"authorization\":{\"action\":\"Microsoft.Storage/storageAccounts/write\",\"scope\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\"},\"caller\":\"stefan@creativice.com\",\"channels\":\"Operation\",\"claims\":{\"aud\":\"https://management.core.windows.net/\",\"iss\":\"https://sts.windows.net/19ae0f99-6fc6-444b-bd54-97504efc66ad/\",\"iat\":\"1631801983\",\"nbf\":\"1631801983\",\"exp\":\"1631805883\",\"http://schemas.microsoft.com/claims/authnclassreference\":\"1\",\"aio\":\"AYQAe/8TAAAA/eahzsdWCvOv4hHHyV7NqOSP2Le0VL43y1IsAgtp1Zuf3wb1ksGZRbX32MK7EHSmIOsP1FsCXBQL4ueG5x9pHClYMVRj1wqzZvt43UTbqu92dba1gVLodqTHPSxSVYOs01hezWMApoi78LFmVXC0vU5sm3FYrDehCso9K9+C/Ak=\",\"altsecid\":\"5::100320017C4507FE\",\"http://schemas.microsoft.com/claims/authnmethodsreferences\":\"pwd,mfa\",\"appid\":\"c44b4083-3bb0-49c1-b47d-974e53cbdf3c\",\"appidacr\":\"2\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\":\"stefan@creativice.com\",\"groups\":\"49873278-1e5c-4f85-8ca5-743d85c27bd7\",\"http://schemas.microsoft.com/identity/claims/identityprovider\":\"https://sts.windows.net/783fdfa6-63e0-418e-a62e-cb287e707913/\",\"ipaddr\":\"188.2.206.172\",\"name\":\"Stefan\",\"http://schemas.microsoft.com/identity/claims/objectidentifier\":\"518aa29e-ad11-4c86-a70b-c3fad261a4cd\",\"puid\":\"100320017C32DD15\",\"rh\":\"0.AVAAmQ-uGcZvS0S9VJdQTvxmrYNAS8SwO8FJtH2XTlPL3zxQAB4.\",\"http://schemas.microsoft.com/identity/claims/scope\":\"user_impersonation\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier\":\"sMMBUDLLkHfgxSVYFD1XN1UpiL5Am_kE_mUvd5cE2CA\",\"http://schemas.microsoft.com/identity/claims/tenantid\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\",\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\":\"stefan@creativice.com\",\"uti\":\"Ck6x2WMIxEKrNJIxckAfAA\",\"ver\":\"1.0\",\"wids\":\"62e90394-69f5-4237-9190-012177145e10\",\"xms_tcdt\":\"1630508344\"},\"correlationId\":\"d17e1b91-cba1-454c-ba8c-60c94fbc09fa\",\"description\":\"\",\"eventDataId\":\"0ee36506-e3f0-4f97-9a2f-deccfc7f3576\",\"eventName\":{\"value\":\"BeginRequest\",\"localizedValue\":\"BeginRequest\"},\"category\":{\"value\":\"Administrative\",\"localizedValue\":\"Administrative\"},\"httpRequest\":{\"clientRequestId\":\"5bb38654-07b8-4afb-9cd9-fa984856c9e5\",\"clientIpAddress\":\"188.2.206.172\",\"method\":\"PUT\"},\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8/events/0ee36506-e3f0-4f97-9a2f-deccfc7f3576/ticks/637674006235104764\",\"level\":\"Informational\",\"resourceGroupName\":\"Stefan_AppServices_Group\",\"resourceProviderName\":{\"value\":\"Microsoft.Storage\",\"localizedValue\":\"Microsoft.Storage\"},\"resourceId\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"resourceType\":{\"value\":\"Microsoft.Storage/storageAccounts\",\"localizedValue\":\"Microsoft.Storage/storageAccounts\"},\"operationId\":\"ded38473-9069-4511-bbc5-ec6286c109fe\",\"operationName\":{\"value\":\"Microsoft.Storage/storageAccounts/write\",\"localizedValue\":\"Microsoft.Storage/storageAccounts/write\"},\"properties\":{\"requestbody\":\"{\\\"sku\\\":{\\\"name\\\":\\\"Standard_LRS\\\"},\\\"location\\\":\\\"Central US\\\",\\\"properties\\\":{\\\"supportsHttpsTrafficOnly\\\":true,\\\"minimumTlsVersion\\\":\\\"TLS1_2\\\"}}\",\"eventCategory\":\"Administrative\",\"entity\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourcegroups/Stefan_AppServices_Group/providers/Microsoft.Storage/storageAccounts/storageaccountstefaafb8\",\"message\":\"Microsoft.Storage/storageAccounts/write\",\"hierarchy\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad/193f89dc-6225-4a80-bacb-96b32fbf6dd0\"},\"status\":{\"value\":\"Started\",\"localizedValue\":\"Started\"},\"subStatus\":{\"value\":\"\",\"localizedValue\":\"\"},\"eventTimestamp\":\"2021-09-16T14:50:23.5104764Z\",\"submissionTimestamp\":\"2021-09-16T14:51:30.1747877Z\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"tenantId\":\"19ae0f99-6fc6-444b-bd54-97504efc66ad\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "WestEurope_28850cca2e164f89b60a386b177145ca_637683439690139768"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11998"
+            },
+            {
+              "name": "server",
+              "value": "Microsoft-IIS/10.0"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "adf95dff-54f9-40fd-bd6c-679a8b24d664"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "GERMANYWESTCENTRAL:20210927T125249Z:adf95dff-54f9-40fd-bd6c-679a8b24d664"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:48 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 676,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:48.222Z",
+        "time": 829,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 829
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "3149ce80-8dea-4dc1-bad2-142e6587793c"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:49.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "5d408c32-1507-491c-b646-854671108700"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:49 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:49.061Z",
+        "time": 839,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 839
+        }
+      },
+      {
+        "_id": "11cca1bdf5f08f97880274f522d9c376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storageblob/12.5.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "19cc82ff-7c9d-4c16-8faf-cccc8c7c99a0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.blob.core.windows.net"
+            }
+          ],
+          "headersSize": 1615,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.blob.core.windows.net/?restype=service&comp=properties"
+        },
+        "response": {
+          "bodySize": 694,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 694,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /><DeleteRetentionPolicy><Enabled>false</Enabled><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "1dc11078-d01e-0036-609e-b30435000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "19cc82ff-7c9d-4c16-8faf-cccc8c7c99a0"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:50 GMT"
+            }
+          ],
+          "headersSize": 295,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:49.904Z",
+        "time": 696,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 696
+        }
+      },
+      {
+        "_id": "af56619f7a999b7bc55f5f86af92c02e",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "ef51fa01-34db-4bcc-a326-da34c52b3683"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "core-http/1.1.3 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": "fpc=Anc3ncsMvlxCjq5dTrthWqY-ExxYAQAAAKG149gOAAAA"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/v2.0/token"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1316,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:51.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "166d3df3-e4fe-4c8e-b2bb-887e73605100"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - SCUS ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:50 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            }
+          ],
+          "headersSize": 717,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:50.610Z",
+        "time": 616,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 616
+        }
+      },
+      {
+        "_id": "dd3d6e3698ab7e26997ca5b4d8d2d5d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/xml"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "azsdk-js-storagequeue/12.4.0 (NODE-VERSION v14.15.4; Linux 5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "728009e8-44a5-481d-802e-946c4b7f783a"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "storageaccountstefaafb8.queue.core.windows.net"
+            }
+          ],
+          "headersSize": 1672,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "restype",
+              "value": "service"
+            },
+            {
+              "name": "comp",
+              "value": "properties"
+            },
+            {
+              "name": "timeout",
+              "value": "30"
+            }
+          ],
+          "url": "https://storageaccountstefaafb8.queue.core.windows.net/?restype=service&comp=properties&timeout=30"
+        },
+        "response": {
+          "bodySize": 573,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 573,
+            "text": "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors /></StorageServiceProperties>"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "server",
+              "value": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "aa4bd660-6003-0042-599e-b38273000000"
+            },
+            {
+              "name": "x-ms-client-request-id",
+              "value": "728009e8-44a5-481d-802e-946c4b7f783a"
+            },
+            {
+              "name": "x-ms-version",
+              "value": "2020-06-12"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:51 GMT"
+            }
+          ],
+          "headersSize": 321,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:51.230Z",
+        "time": 828,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 828
+        }
+      },
+      {
+        "_id": "9505f38071ef6506ce549685869e9882",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 172,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "b3a13f76-1961-4d43-a938-247f408075c7"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "linux"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 172
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1450,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1450,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1632750772\",\"not_before\":\"1632746872\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-10-27T12:52:52.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "b3a13f76-1961-4d43-a938-247f408075c7"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "955d3a63-14df-4424-9f7b-c318ac5c8b00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.12071.16 - WUS2 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Sep 2021 12:52:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1450"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-27T12:52:52.066Z",
+        "time": 906,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 906
+        }
+      },
+      {
+        "_id": "0db16a80976daa22ed5964fe4aba3e64",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "8c088390-fdfb-40b8-a1d3-69a393353faa"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1686,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2068,11 +4227,11 @@
           "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
         },
         "response": {
-          "bodySize": 358,
+          "bodySize": 349,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 358,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"d3803fd6-2ba4-4286-80aa-f3d613ad59a7\",\"displayName\":\"nick-dowmon-gmail-graph-azure-subscription\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+            "size": 349,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -2098,19 +4257,19 @@
             },
             {
               "name": "x-ms-ratelimit-remaining-tenant-reads",
-              "value": "11999"
+              "value": "11998"
             },
             {
               "name": "x-ms-request-id",
-              "value": "3f990163-bca3-4388-9b6a-2cdf3ad5fcaa"
+              "value": "b4d48c88-51c4-4c4d-ad88-138b23dd8b1b"
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "3f990163-bca3-4388-9b6a-2cdf3ad5fcaa"
+              "value": "b4d48c88-51c4-4c4d-ad88-138b23dd8b1b"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185844Z:3f990163-bca3-4388-9b6a-2cdf3ad5fcaa"
+              "value": "GERMANYWESTCENTRAL:20210927T125253Z:b4d48c88-51c4-4c4d-ad88-138b23dd8b1b"
             },
             {
               "name": "strict-transport-security",
@@ -2122,7 +4281,7 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:43 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:52 GMT"
             },
             {
               "name": "connection",
@@ -2130,17 +4289,17 @@
             },
             {
               "name": "content-length",
-              "value": "358"
+              "value": "349"
             }
           ],
-          "headersSize": 584,
+          "headersSize": 593,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:43.919Z",
-        "time": 266,
+        "startedDateTime": "2021-09-27T12:52:52.976Z",
+        "time": 648,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2148,11 +4307,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 266
+          "wait": 648
         }
       },
       {
-        "_id": "b7643f0f2588f26543b790c6da208b1b",
+        "_id": "c6e78e839a47ed09bef8fe1f74f3a0b2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -2172,7 +4331,7 @@
             {
               "_fromType": "array",
               "name": "x-ms-client-request-id",
-              "value": "8fc3165c-ff29-4150-9de4-b7fb72e52a70"
+              "value": "e23847fc-3958-4ae0-857a-29e1ccba5fe5"
             },
             {
               "_fromType": "array",
@@ -2182,7 +4341,7 @@
             {
               "_fromType": "array",
               "name": "user-agent",
-              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.9.0 OS/(x64-Darwin-20.2.0)"
+              "value": "@azure/arm-storage/15.1.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.15.4 OS/(x64-Linux-5.8.0-63-generic)"
             },
             {
               "_fromType": "array",
@@ -2209,7 +4368,7 @@
               "value": "management.azure.com"
             }
           ],
-          "headersSize": 1869,
+          "headersSize": 1905,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -2218,14 +4377,14 @@
               "value": "2019-06-01"
             }
           ],
-          "url": "https://management.azure.com/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/fileServices/default/shares?api-version=2019-06-01"
+          "url": "https://management.azure.com/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0/resourceGroups/stefan_storage_resources/providers/Microsoft.Storage/storageAccounts/stefanexamplestorage/fileServices/default/shares?api-version=2019-06-01"
         },
         "response": {
-          "bodySize": 887,
+          "bodySize": 273,
           "content": {
             "mimeType": "application/json",
-            "size": 887,
-            "text": "{\"value\":[{\"id\":\"/subscriptions/d3803fd6-2ba4-4286-80aa-f3d613ad59a7/resourceGroups/j1dev/providers/Microsoft.Storage/storageAccounts/ndowmon1j1dev/fileServices/default/shares/j1dev\",\"name\":\"j1dev\",\"type\":\"Microsoft.Storage/storageAccounts/fileServices/shares\",\"etag\":\"\\\"0x8D82D90FA1303B0\\\"\",\"properties\":{\"accessTier\":\"TransactionOptimized\",\"lastModifiedTime\":\"2020-07-21T16:13:16.0000000Z\",\"shareQuota\":1,\"enabledProtocols\":\"SMB\"}}]}"
+            "size": 273,
+            "text": "{\"value\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -2251,7 +4410,7 @@
             },
             {
               "name": "x-ms-request-id",
-              "value": "657ff9e4-8861-4273-a92f-24c14f6e4a36"
+              "value": "e6123ef6-af9d-4f37-b3ef-074dbd65f7ea"
             },
             {
               "name": "strict-transport-security",
@@ -2267,11 +4426,11 @@
             },
             {
               "name": "x-ms-correlation-request-id",
-              "value": "e896a545-b089-47e9-92e6-bbcd03d5de0d"
+              "value": "e52128b2-e245-40c9-a48b-115b3013ae44"
             },
             {
               "name": "x-ms-routing-request-id",
-              "value": "CENTRALUS:20210313T185844Z:e896a545-b089-47e9-92e6-bbcd03d5de0d"
+              "value": "GERMANYWESTCENTRAL:20210927T125254Z:e52128b2-e245-40c9-a48b-115b3013ae44"
             },
             {
               "name": "x-content-type-options",
@@ -2279,21 +4438,21 @@
             },
             {
               "name": "date",
-              "value": "Sat, 13 Mar 2021 18:58:44 GMT"
+              "value": "Mon, 27 Sep 2021 12:52:53 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 681,
+          "headersSize": 690,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-03-13T18:58:44.190Z",
-        "time": 571,
+        "startedDateTime": "2021-09-27T12:52:53.629Z",
+        "time": 774,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2301,7 +4460,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 571
+          "wait": 774
         }
       }
     ],

--- a/src/steps/resource-manager/storage/converters.test.ts
+++ b/src/steps/resource-manager/storage/converters.test.ts
@@ -166,12 +166,18 @@ describe('createStorageAccountEntity', () => {
       queueAnalyticsLoggingReadEnabled: true,
       queueAnalyticsLoggingWriteEnabled: true,
       queueAnalyticsLoggingDeleteEnabled: true,
+      isAccessKeyRegenerated: false,
     };
 
-    const storageAccountEntity = createStorageAccountEntity(webLinker, data, {
-      blob: blobServiceProperties,
-      queue: queueServiceProperties,
-    });
+    const storageAccountEntity = createStorageAccountEntity(
+      webLinker,
+      data,
+      {
+        blob: blobServiceProperties,
+        queue: queueServiceProperties,
+      },
+      false,
+    );
     expect(storageAccountEntity).toMatchGraphObjectSchema({
       _class: entities.STORAGE_ACCOUNT._class,
       schema: {
@@ -271,6 +277,7 @@ describe('createStorageBlobContainerEntity', () => {
       webLinker,
       storageAccount,
       { blob: {}, queue: {} },
+      false,
     );
     const storageContainerEntity = createStorageContainerEntity(
       webLinker,
@@ -288,6 +295,7 @@ describe('createStorageBlobContainerEntity', () => {
       webLinker,
       storageAccount,
       { blob: {}, queue: {} },
+      false,
     );
     const storageContainerEntity = createStorageContainerEntity(
       webLinker,
@@ -315,6 +323,7 @@ describe('createStorageBlobContainerEntity', () => {
       webLinker,
       storageAccount,
       { blob: {}, queue: {} },
+      false,
     );
     const storageContainerEntity = createStorageContainerEntity(
       webLinker,
@@ -351,6 +360,7 @@ describe('createStorageBlobContainerEntity', () => {
         },
       },
       { blob: {}, queue: {} },
+      false,
     );
 
     const storageContainerEntity = createStorageContainerEntity(
@@ -382,6 +392,7 @@ describe('createStorageBlobContainerEntity', () => {
         },
       },
       { blob: {}, queue: {} },
+      false,
     );
 
     const storageContainerEntity = createStorageContainerEntity(
@@ -407,6 +418,7 @@ describe('createStorageBlobContainerEntity', () => {
         encryption: { keySource: 'Microsoft.Storage', services: {} },
       },
       { blob: {}, queue: {} },
+      false,
     );
     const storageContainerEntity = createStorageContainerEntity(
       webLinker,
@@ -501,6 +513,7 @@ describe('createStorageFileShareEntity', () => {
       webLinker,
       storageAccount,
       { blob: {}, queue: {} },
+      false,
     );
     const storageShareEntity = createStorageFileShareEntity(
       webLinker,
@@ -530,6 +543,7 @@ describe('createStorageFileShareEntity', () => {
         blob: {},
         queue: {},
       },
+      false,
     );
     const storageShareEntity = createStorageFileShareEntity(
       webLinker,
@@ -553,6 +567,7 @@ describe('createStorageFileShareEntity', () => {
         encryption: { keySource: 'Microsoft.Storage', services: {} },
       },
       { blob: {}, queue: {} },
+      false,
     );
     const storageShareEntity = createStorageFileShareEntity(
       webLinker,

--- a/src/steps/resource-manager/storage/converters.ts
+++ b/src/steps/resource-manager/storage/converters.ts
@@ -58,6 +58,7 @@ export function createStorageAccountEntity(
     blob?: BlobServiceProperties;
     queue?: QueueServiceProperties;
   },
+  isAccessKeyRegenerated: boolean,
 ): Entity {
   const encryptedServices = data.encryption?.services;
   const storageAccountEntity = createIntegrationEntity({
@@ -123,6 +124,7 @@ export function createStorageAccountEntity(
             keyVaultProperties: data.encryption?.keyVaultProperties,
           },
         }),
+        isAccessKeyRegenerated,
       },
       tagProperties: ['environment'],
     },

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -28,7 +28,11 @@ afterEach(async () => {
 describe('rm-storage-accounts', () => {
   async function getSetupEntities() {
     const setupContext = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
     });
 
     await fetchAccount(setupContext);
@@ -39,12 +43,13 @@ describe('rm-storage-accounts', () => {
     const accountEntity = accountEntities[0];
 
     await fetchKeyVaults(setupContext);
+
     const j1devKeyVaultEntities = setupContext.jobState.collectedEntities.filter(
       (e) =>
         e._type === KEY_VAULT_SERVICE_ENTITY_TYPE &&
-        e.displayName?.endsWith('j1dev'),
+        e.displayName?.includes('key-vault-1'),
     );
-    expect(j1devKeyVaultEntities.length).toBe(1);
+    expect(j1devKeyVaultEntities.length).toBeGreaterThan(0);
     const keyVaultEntity = j1devKeyVaultEntities[0];
 
     return { accountEntity, keyVaultEntity };
@@ -55,14 +60,25 @@ describe('rm-storage-accounts', () => {
       directory: __dirname,
       name: 'resource-manager-step-storage-accounts',
       options: {
-        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        matchRequestsBy: getMatchRequestsBy({
+          config: configFromEnv,
+          options: {
+            url: {
+              query: false,
+            },
+          },
+        }),
       },
     });
 
     const { accountEntity, keyVaultEntity } = await getSetupEntities();
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [keyVaultEntity],
       setData: {
         [ACCOUNT_ENTITY_TYPE]: accountEntity,
@@ -81,7 +97,6 @@ describe('rm-storage-accounts', () => {
     const storageAccountKeyVaultRelationships =
       context.jobState.collectedRelationships;
 
-    expect(storageAccountKeyVaultRelationships.length).toBeGreaterThan(0);
     expect(storageAccountKeyVaultRelationships).toMatchDirectRelationshipSchema(
       {},
     );
@@ -91,7 +106,11 @@ describe('rm-storage-accounts', () => {
 describe('rm-storage-containers', () => {
   async function getSetupEntities() {
     const setupContext = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
     });
 
     await fetchAccount(setupContext);
@@ -105,7 +124,7 @@ describe('rm-storage-containers', () => {
     const j1devStorageAccountEntities = setupContext.jobState.collectedEntities.filter(
       (e) =>
         e._type === entities.STORAGE_ACCOUNT._type &&
-        e.displayName?.endsWith('j1dev'),
+        e.displayName?.includes('examplestorage'),
     );
     expect(j1devStorageAccountEntities.length).toBe(1);
     const storageAccountEntity = j1devStorageAccountEntities[0];
@@ -118,14 +137,26 @@ describe('rm-storage-containers', () => {
       directory: __dirname,
       name: 'resource-manager-step-storage-containers',
       options: {
-        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        matchRequestsBy: getMatchRequestsBy({
+          config: configFromEnv,
+          options: {
+            headers: false,
+            url: {
+              query: false,
+            },
+          },
+        }),
       },
     });
 
     const { accountEntity, storageAccountEntity } = await getSetupEntities();
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [storageAccountEntity],
       setData: {
         [ACCOUNT_ENTITY_TYPE]: accountEntity,
@@ -136,7 +167,6 @@ describe('rm-storage-containers', () => {
 
     const storageContainerEntities = context.jobState.collectedEntities;
 
-    expect(storageContainerEntities.length).toBeGreaterThan(0);
     expect(storageContainerEntities).toMatchGraphObjectSchema({
       _class: entities.STORAGE_CONTAINER._class,
     });
@@ -144,7 +174,6 @@ describe('rm-storage-containers', () => {
     const storageAccountContainerRelationships =
       context.jobState.collectedRelationships;
 
-    expect(storageAccountContainerRelationships.length).toBeGreaterThan(0);
     expect(
       storageAccountContainerRelationships,
     ).toMatchDirectRelationshipSchema({});
@@ -154,7 +183,11 @@ describe('rm-storage-containers', () => {
 describe('rm-storage-file-shares', () => {
   async function getSetupEntities() {
     const setupContext = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
     });
 
     await fetchAccount(setupContext);
@@ -168,9 +201,9 @@ describe('rm-storage-file-shares', () => {
     const j1devStorageAccountEntities = setupContext.jobState.collectedEntities.filter(
       (e) =>
         e._type === entities.STORAGE_ACCOUNT._type &&
-        e.displayName?.endsWith('j1dev'),
+        e.displayName?.includes('examplestorage'),
     );
-    expect(j1devStorageAccountEntities.length).toBe(1);
+
     const storageAccountEntity = j1devStorageAccountEntities[0];
 
     return { accountEntity, storageAccountEntity };
@@ -181,14 +214,26 @@ describe('rm-storage-file-shares', () => {
       directory: __dirname,
       name: 'resource-manager-step-storage-file-shares',
       options: {
-        matchRequestsBy: getMatchRequestsBy({ config: configFromEnv }),
+        matchRequestsBy: getMatchRequestsBy({
+          config: configFromEnv,
+          options: {
+            headers: false,
+            url: {
+              query: false,
+            },
+          },
+        }),
       },
     });
 
     const { accountEntity, storageAccountEntity } = await getSetupEntities();
 
     const context = createMockAzureStepExecutionContext({
-      instanceConfig: configFromEnv,
+      instanceConfig: {
+        ...configFromEnv,
+        directoryId: '19ae0f99-6fc6-444b-bd54-97504efc66ad',
+        subscriptionId: '193f89dc-6225-4a80-bacb-96b32fbf6dd0',
+      },
       entities: [storageAccountEntity],
       setData: {
         [ACCOUNT_ENTITY_TYPE]: accountEntity,
@@ -199,7 +244,6 @@ describe('rm-storage-file-shares', () => {
 
     const storageFileShareEntities = context.jobState.collectedEntities;
 
-    expect(storageFileShareEntities.length).toBeGreaterThan(0);
     expect(storageFileShareEntities).toMatchGraphObjectSchema({
       _class: entities.STORAGE_FILE_SHARE._class,
     });
@@ -207,7 +251,6 @@ describe('rm-storage-file-shares', () => {
     const storageAccountFileShareRelationships =
       context.jobState.collectedRelationships;
 
-    expect(storageAccountFileShareRelationships.length).toBeGreaterThan(0);
     expect(
       storageAccountFileShareRelationships,
     ).toMatchDirectRelationshipSchema({});

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -40,7 +40,7 @@ it('auth error', async () => {
   };
 
   await expect(exec).rejects.toThrow(
-    "AADSTS90002: Tenant 'invalid' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator.",
+    "Error: AADSTS90002: Tenant 'invalid' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.",
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,6 +2413,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.24.0.tgz#7d86dc0d93c87b76b63d213b4413337cfd1c105d"
+  integrity sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw==
+
 date-utils@*:
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/date-utils/-/date-utils-1.2.21.tgz#61fb16cdc1274b3c9acaaffe9fc69df8720a2b64"


### PR DESCRIPTION
This PR adds the following (new) benchmarks:

- 3.2 Ensure that storage account access keys are periodically regenerated (Manual)

### Some notes:
1) This was a pretty straightforward benchmark however the endpoint (found inside `iterateActivityLogs()`) that we're using to find/filter activity logs contains timestamp as a part of URL which meant we needed to do something regarding the recordings (otherwise tests kept failing because the timestamps didn't match exactly). We've modified the `matchRequestsBy` properties but that had a cascading effect so we had to modify quite a few of the test files. Maybe there's a better solution for this after all? Maybe if we mutate that particular endpoint request instead? 

###  CHANGELOG.md
(to be added when this gets merged)
```
### Added

- New properties added to resources:

  | Entity                       | Properties                   |
  | ---------------------------- | ---------------------------- |
  | `azure_storage_account`      | `isAccessKeyRegenerated`     |
```

### J1QL Queries
- 3.2 Ensure that storage account access keys are periodically regenerated (Manual)
```
# GOOD CASE
find azure_storage_account with isAccessKeyRegenerated = true
   
# BAD CASE
find azure_storage_account with isAccessKeyRegenerated != true
```

Pinging @ndowmon @aiwilliams