### PR TITLE
Bump @jupiterone/integration-sdk-*@6.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
-## [5.31.6] - 2021-10-04
+## [5.31.7] - 2021-10-04
 
 ### Changed
 
 - Bumped `@jupiterone/integration-sdk-*@6.22.1`. This included new functionality
   to the `IntegrationError` classes that better segregates errors coming from
   different steps
+
+## [5.31.6] - 2021-10-01
+
+### Fixed
+
+- Stop throwing
+  `Provider API failed at storage.*: AccountIsDisabled The specified account is disabled.`
+  on storage blob/queue/table/file steps
 
 ## [5.31.5] - 2021-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [5.31.6] - 2021-10-04
+
+### Changed
+
+- Bumped `@jupiterone/integration-sdk-*@6.22.1`. This included new functionality
+  to the `IntegrationError` classes that better segregates errors coming from
+  different steps
+
 ## [5.31.5] - 2021-10-01
 
 ### Fixed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -173,7 +173,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 ********************************************************************************
 -->
 
@@ -279,7 +279,7 @@ The following entities are created:
 
 ### Relationships
 
-The following relationships are created/mapped:
+The following relationships are created:
 
 | Source Entity `_type`              | Relationship `_class` | Target Entity `_type`                             |
 | ---------------------------------- | --------------------- | ------------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "@azure/ms-rest-js": "^2.0.0"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0"
+    "@jupiterone/integration-sdk-core": "^6.22.1"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
-    "@jupiterone/integration-sdk-dev-tools": "^6.10.0",
-    "@jupiterone/integration-sdk-testing": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
+    "@jupiterone/integration-sdk-dev-tools": "^6.22.1",
+    "@jupiterone/integration-sdk-testing": "^6.22.1",
     "@types/lodash.map": "^4.6.13",
     "@types/lodash.snakecase": "^4.1.6",
     "@types/node": "^13.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.31.6",
+  "version": "5.31.7",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-azure",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,44 +1016,46 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupiterone/data-model@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.32.0.tgz#2d2fae02b6c077b30f567d76989fc1c9bee1e51a"
-  integrity sha512-QORfi+8fIrbxHbLoc/v1y2vR0grC7qy8dt/jhRhncGHVyTwuruagqaKsJrKmv1BHbUzrkmOTIMRbeBEf5Gw/vw==
+"@jupiterone/data-model@^0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.39.0.tgz#3fa750480bc2dd63c9cbf37fa08cdb17cc74bd26"
+  integrity sha512-AZjDtRC1LlWtJGHqTthVfUSS6PBrDeNMXV4zMN42m5mFdYoDZ7OXXVxzXCtt0nlwK1zpBCClMUn5qIDeBtFR9A==
   dependencies:
     ajv "^8.0.0"
     ajv-formats "^2.0.0"
 
-"@jupiterone/integration-sdk-cli@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-6.10.0.tgz#9696244632ab5fedfc047951b058fc843739450f"
-  integrity sha512-DyCv21DGzX/KDGb98PHp4sTeS+wBeuGV0cD6u9wvdSzmWnlTQYfzcmSe1RY2BjTJaoszHTCwht0codAd18tVCQ==
+"@jupiterone/integration-sdk-cli@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-6.22.1.tgz#34c078d7c09829a8cb5743ac347d706fff25c123"
+  integrity sha512-zQiOfTiJ3DvUgYgRxWumA6Ez1j+VuSWxIVjOab9MyPEBQ5u3a+8nG4IgnW5qwUUgVG2iRpy0V0tNM8vStSbH9A==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^6.10.0"
+    "@jupiterone/integration-sdk-runtime" "^6.22.1"
     commander "^5.0.0"
     globby "^11.0.0"
+    js-yaml "^4.1.0"
     json-diff "^0.5.4"
     lodash "^4.17.19"
     markdown-table "^2.0.0"
+    runtypes "5.1.0"
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-6.10.0.tgz#72f634395369200548ff69eb0167f9b1866a3b83"
-  integrity sha512-HtGiN8mUbiYhLUOuypBzvI9L2vw0eIuuCrvhFkR8QuunIIFXDuAgOxT64Hu+NCDSvM06s+fuqNcDovcBQFsufw==
+"@jupiterone/integration-sdk-core@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-6.22.1.tgz#5d60e281eb43c6d4d55982268d5b91fe03c9335d"
+  integrity sha512-cXaD7O0PcgrW+SINWN+dtLaST0Dz3RB/o96CA+pHEY2bxBcbNHB7w6I4mkmCcJFWGMIWuwXkwNTmywNB2Mp8Xw==
   dependencies:
-    "@jupiterone/data-model" "^0.32.0"
+    "@jupiterone/data-model" "^0.39.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
-"@jupiterone/integration-sdk-dev-tools@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-6.10.0.tgz#8157a6d3aa9e57f496334499b2f33d86a0f09560"
-  integrity sha512-HDo30MCkLMx/nZe9Pt/oMbxkTZ3g2Ya7pTJmY0kkC6J6W8pp+8R35aHWyeoPHZnN5eLoRtF+S2QL5l1GSLohDw==
+"@jupiterone/integration-sdk-dev-tools@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-6.22.1.tgz#4dd9684017eb41a4e3564906c61dfa504e800c0b"
+  integrity sha512-fV4AuyZ11HKXLqPvbx3vXWAtRL1GThC8lSURazObqvlcVidUSaRrmGVGhH83bX/bX8SgPeJtMJ0xhYEvmlklBA==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^6.10.0"
-    "@jupiterone/integration-sdk-testing" "^6.10.0"
+    "@jupiterone/integration-sdk-cli" "^6.22.1"
+    "@jupiterone/integration-sdk-testing" "^6.22.1"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^4.22.0"
@@ -1069,12 +1071,12 @@
     ts-node "^9.1.1"
     typescript "^4.2.4"
 
-"@jupiterone/integration-sdk-runtime@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-6.10.0.tgz#cd6e6e66a0a961613c016606e58559c23f1dbb9b"
-  integrity sha512-GLhcr7r2ac9hNjiESJn7r40UbcpcaG84TPQHQJ+yPtOKNCqfk1hgyjVH9pT+MwvVFh5wpR6+UrKP2IfUrH45Mw==
+"@jupiterone/integration-sdk-runtime@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-6.22.1.tgz#46ce267bc815f6993d375840e4a691f692331a16"
+  integrity sha512-jnZyDs7cgpx0JT5h2H6sdoTKu+7DazwdCZ/0epR25bEpuoOKnrjFoue+Ei/rRrX5nibNItNdXhna1qsVz5MNjQ==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^6.10.0"
+    "@jupiterone/integration-sdk-core" "^6.22.1"
     "@lifeomic/alpha" "^1.4.0"
     "@lifeomic/attempt" "^3.0.0"
     async-sema "^3.1.0"
@@ -1092,13 +1094,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-6.10.0.tgz#f41404da14f769862b2621409dbe3042501076e5"
-  integrity sha512-DRs5eV0HPITYJsfSCCxO0WybjgAweh+Ku47NJK3djZSE7mXk9zDUNl8sVfqpei4Xyfp519JYbI4XCc3lCFuisQ==
+"@jupiterone/integration-sdk-testing@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-6.22.1.tgz#53c9a70ed4aca89711ad79cd24509ec7c60b1d1f"
+  integrity sha512-qAs9eeGk6mUvrUFOXT5Si6jIKcjjziwdzrZUkQHyZQzl2XE5pQMWKyiMJR4UgV4+0DZo8BfZCCcaIk/cXrKlEg==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^6.10.0"
-    "@jupiterone/integration-sdk-runtime" "^6.10.0"
+    "@jupiterone/integration-sdk-core" "^6.22.1"
+    "@jupiterone/integration-sdk-runtime" "^6.22.1"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"
@@ -1765,6 +1767,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4248,6 +4255,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5460,6 +5474,11 @@ run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+
+runtypes@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-5.1.0.tgz#a1f2501b5ca8fda47d51ea15b6ccca45e924a8c3"
+  integrity sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ==
 
 rxjs@^6.5.5:
   version "6.5.5"


### PR DESCRIPTION
```
## [5.31.6] - 2021-10-04

### Changed

- Bumped `@jupiterone/integration-sdk-*@6.22.1`. This included new functionality
  to the `IntegrationError` classes that better segregates errors coming from
  different steps
```