### PR TITLE
Changelog for CIS 8.3-8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added support for ingesting the following **new** resources:
+
+  | Service                  | Resource / Entity          |
+  | ------------------------ | -------------------------- |
+  | Azure Kubernetes Cluster | `azure_kubernetes_cluster` |
+  | Resource Lock            | `azure_resource_lock`      |
+
+- Added support for ingesting the following **new** relationships:
+
+  | Source                 | \_class | Target                     |
+  | ---------------------- | ------- | -------------------------- |
+  | `azure_resource_group` | `HAS`   | `azure_kubernetes_cluster` |
+  | `azure_resource_lock`  | `HAS`   | `ANY_SCOPE`                |
+
+- New properties added to resources:
+
+  | Entity                   | Properties                                  |
+  | ------------------------ | ------------------------------------------- |
+  | `azure_keyvault_service` | `enableSoftDelete`, `enablePurgeProtection` |
+
 ## [5.34.0] - 2021-11-01
 
 ### Added

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -2659,10 +2659,10 @@ questions:
     queries:
     - name: good
       query: |
-        FIND * with tag.classification = 'critical' THAT HAS azure_resource_lock
+        FIND * WITH _integrationType = 'azure' AND tag.classification = 'critical' THAT HAS azure_resource_lock
     - name: bad
       query: |
-        FIND * with tag.classification = 'critical' THAT !HAS azure_resource_lock
+        FIND * WITH _integrationType = 'azure' AND tag.classification = 'critical' THAT !HAS azure_resource_lock
     tags:
     - azure
     - data

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -2659,10 +2659,10 @@ questions:
     queries:
     - name: good
       query: |
-        FIND * with tag.SensitiveAzureResource = true THAT HAS azure_resource_lock
+        FIND * with tag.classification = 'critical' THAT HAS azure_resource_lock
     - name: bad
       query: |
-        FIND * with tag.SensitiveAzureResource = true THAT !HAS azure_resource_lock
+        FIND * with tag.classification = 'critical' THAT !HAS azure_resource_lock
     tags:
     - azure
     - data

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -15,27 +15,27 @@ import {
   STEP_AD_USERS,
   STEP_AD_SERVICE_PRINCIPALS,
   STEP_AD_USER_REGISTRATION_DETAILS,
-} from './steps/active-directory';
+} from './steps/active-directory/constants';
 import {
   STEP_RM_COMPUTE_VIRTUAL_MACHINE_DISKS,
   STEP_RM_COMPUTE_VIRTUAL_MACHINE_IMAGES,
   STEP_RM_COMPUTE_VIRTUAL_MACHINES,
   steps as computeSteps,
-} from './steps/resource-manager/compute';
-import { STEP_RM_COSMOSDB_SQL_DATABASES } from './steps/resource-manager/cosmosdb';
+} from './steps/resource-manager/compute/constants';
+import { STEP_RM_COSMOSDB_SQL_DATABASES } from './steps/resource-manager/cosmosdb/constants';
 import {
   STEP_RM_DATABASE_MARIADB_DATABASES,
   STEP_RM_DATABASE_MYSQL_DATABASES,
-} from './steps/resource-manager/databases';
+} from './steps/resource-manager/databases/constants';
 import { steps as postgreSqlDatabaseSteps } from './steps/resource-manager/databases/postgresql/constants';
 import { steps as sqlDatabaseSteps } from './steps/resource-manager/databases/sql/constants';
-import { STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS } from './steps/resource-manager/interservice';
+import { STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS } from './steps/resource-manager/interservice/constants';
 import {
   STEP_RM_KEYVAULT_VAULTS,
   STEP_RM_KEYVAULT_KEYS,
   STEP_RM_KEYVAULT_SECRETS,
   KeyVaultStepIds,
-} from './steps/resource-manager/key-vault';
+} from './steps/resource-manager/key-vault/constants';
 import {
   STEP_RM_NETWORK_INTERFACES,
   STEP_RM_NETWORK_LOAD_BALANCERS,
@@ -51,8 +51,8 @@ import {
   STEP_RM_NETWORK_PRIVATE_ENDPOINT_SUBNET_RELATIONSHIPS,
   STEP_RM_NETWORK_PRIVATE_ENDPOINTS_NIC_RELATIONSHIPS,
   STEP_RM_NETWORK_PRIVATE_ENDPOINTS_RESOURCE_RELATIONSHIPS,
-} from './steps/resource-manager/network';
-import { steps as storageSteps } from './steps/resource-manager/storage';
+} from './steps/resource-manager/network/constants';
+import { steps as storageSteps } from './steps/resource-manager/storage/constants';
 import { IntegrationConfig } from './types';
 import { steps as authorizationSteps } from './steps/resource-manager/authorization/constants';
 import {
@@ -64,49 +64,49 @@ import { steps as subscriptionSteps } from './steps/resource-manager/subscriptio
 import {
   STEP_RM_API_MANAGEMENT_SERVICES,
   STEP_RM_API_MANAGEMENT_APIS,
-} from './steps/resource-manager/api-management';
+} from './steps/resource-manager/api-management/constants';
 import {
   STEP_RM_DNS_ZONES,
   STEP_RM_DNS_RECORD_SETS,
-} from './steps/resource-manager/dns';
+} from './steps/resource-manager/dns/constants';
 import {
   STEP_RM_PRIVATE_DNS_ZONES,
   STEP_RM_PRIVATE_DNS_RECORD_SETS,
-} from './steps/resource-manager/private-dns';
+} from './steps/resource-manager/private-dns/constants';
 import {
   STEP_RM_CONTAINER_REGISTRIES,
   STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
-} from './steps/resource-manager/container-registry';
+} from './steps/resource-manager/container-registry/constants';
 import {
   STEP_RM_SERVICE_BUS_NAMESPACES,
   STEP_RM_SERVICE_BUS_SUBSCRIPTIONS,
   STEP_RM_SERVICE_BUS_QUEUES,
   STEP_RM_SERVICE_BUS_TOPICS,
-} from './steps/resource-manager/service-bus';
+} from './steps/resource-manager/service-bus/constants';
 import {
   STEP_RM_CDN_PROFILE,
   STEP_RM_CDN_ENDPOINTS,
-} from './steps/resource-manager/cdn';
+} from './steps/resource-manager/cdn/constants';
 import {
   STEP_RM_BATCH_ACCOUNT,
   STEP_RM_BATCH_POOL,
   STEP_RM_BATCH_APPLICATION,
   STEP_RM_BATCH_CERTIFICATE,
-} from './steps/resource-manager/batch';
+} from './steps/resource-manager/batch/constants';
 import {
   STEP_RM_REDIS_CACHES,
   STEP_RM_REDIS_FIREWALL_RULES,
   STEP_RM_REDIS_LINKED_SERVERS,
-} from './steps/resource-manager/redis-cache';
-import { STEP_RM_CONTAINER_GROUPS } from './steps/resource-manager/container-instance';
+} from './steps/resource-manager/redis-cache/constants';
+import { STEP_RM_CONTAINER_GROUPS } from './steps/resource-manager/container-instance/constants';
 import {
   STEP_RM_EVENT_GRID_DOMAINS,
   STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
   STEP_RM_EVENT_GRID_DOMAIN_TOPIC_SUBSCRIPTIONS,
   STEP_RM_EVENT_GRID_TOPICS,
   STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS,
-} from './steps/resource-manager/event-grid';
-import { AdvisorSteps } from './steps/resource-manager/advisor';
+} from './steps/resource-manager/event-grid/constants';
+import { AdvisorSteps } from './steps/resource-manager/advisor/constants';
 import { SecuritySteps } from './steps/resource-manager/security/constants';
 import { PolicySteps } from './steps/resource-manager/policy/constants';
 import { MonitorSteps } from './steps/resource-manager/monitor/constants';

--- a/src/steps/active-directory/index.ts
+++ b/src/steps/active-directory/index.ts
@@ -40,8 +40,6 @@ import {
   createServicePrincipalEntity,
 } from './converters';
 
-export * from './constants';
-
 export async function getAccountEntity(jobState: JobState): Promise<Entity> {
   const accountEntity = await jobState.getData<Entity>(ACCOUNT_ENTITY_TYPE);
 

--- a/src/steps/resource-manager/advisor/index.test.ts
+++ b/src/steps/resource-manager/advisor/index.test.ts
@@ -3,13 +3,13 @@ import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { AdvisorEntities, AdvisorRelationships } from './constants';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   KEY_VAULT_SERVICE_ENTITY_TYPE,
   KEY_VAULT_SERVICE_ENTITY_CLASS,
-} from '../key-vault';
+} from '../key-vault/constants';
 import { entities as subscriptionEntities } from '../subscriptions/constants';
-import { entities as storageEntities } from '../storage';
+import { entities as storageEntities } from '../storage/constants';
 import { SecurityEntities } from '../security/constants';
 import { ResourceRecommendationBase } from '@azure/arm-advisor/esm/models';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';

--- a/src/steps/resource-manager/advisor/index.ts
+++ b/src/steps/resource-manager/advisor/index.ts
@@ -6,7 +6,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { AdvisorClient } from './client';
 import {
   AdvisorEntities,
@@ -16,7 +17,6 @@ import {
 import { createRecommendationEntity } from './converters';
 import { SecuritySteps } from '../security/constants';
 import { getResourceManagerSteps } from '../../../getStepStartStates';
-export * from './constants';
 
 export async function fetchRecommendations(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/api-management/index.test.ts
+++ b/src/steps/resource-manager/api-management/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { ApiManagementEntities } from './constants';
 
 let recording: Recording;

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1ApiManagementClient } from './client';
 import {
   ApiManagementEntities,
@@ -26,7 +27,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-export * from './constants';
 
 export async function fetchApiManagementServices(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/appservice/index.test.ts
+++ b/src/steps/resource-manager/appservice/index.test.ts
@@ -10,7 +10,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { AppServiceEntities, AppServiceRelationships } from './constants';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
 import {

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -10,7 +10,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { AppServiceClient } from './client';
 import {
   AppServiceEntities,

--- a/src/steps/resource-manager/authorization/constants.ts
+++ b/src/steps/resource-manager/authorization/constants.ts
@@ -6,7 +6,7 @@ import {
   STEP_AD_USERS,
   SERVICE_PRINCIPAL_ENTITY_TYPE,
   STEP_AD_SERVICE_PRINCIPALS,
-} from '../../active-directory';
+} from '../../active-directory/constants';
 import {
   generateRelationshipType,
   StepRelationshipMetadata,

--- a/src/steps/resource-manager/authorization/converters.ts
+++ b/src/steps/resource-manager/authorization/converters.ts
@@ -15,7 +15,7 @@ import {
 
 import { AzureWebLinker } from '../../../azure';
 import { entities, relationships } from './constants';
-import { USER_ENTITY_TYPE } from '../../active-directory';
+import { USER_ENTITY_TYPE } from '../../active-directory/constants';
 
 export function createClassicAdministratorEntity(): Entity {
   return createIntegrationEntity({

--- a/src/steps/resource-manager/authorization/index.test.ts
+++ b/src/steps/resource-manager/authorization/index.test.ts
@@ -14,14 +14,16 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import {
-  USER_ENTITY_TYPE,
-  ACCOUNT_ENTITY_TYPE,
-  GROUP_ENTITY_TYPE,
-  SERVICE_PRINCIPAL_ENTITY_TYPE,
   fetchUsers,
   fetchGroups,
   fetchServicePrincipals,
 } from '../../active-directory';
+import {
+  USER_ENTITY_TYPE,
+  ACCOUNT_ENTITY_TYPE,
+  GROUP_ENTITY_TYPE,
+  SERVICE_PRINCIPAL_ENTITY_TYPE,
+} from '../../active-directory/constants';
 import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault/constants';
 import { entities as SubscriptionEntities } from '../subscriptions/constants';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -10,7 +10,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   steps as subscriptionSteps,
   entities as subscriptionEntities,

--- a/src/steps/resource-manager/batch/index.test.ts
+++ b/src/steps/resource-manager/batch/index.test.ts
@@ -11,7 +11,7 @@ import {
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { BatchEntities } from './constants';
 
 let recording: Recording;

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -6,7 +6,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   RESOURCE_GROUP_ENTITY,
   STEP_RM_RESOURCES_RESOURCE_GROUPS,
@@ -33,8 +34,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-
-export * from './constants';
 
 export async function fetchBatchAccounts(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/cdn/index.test.ts
+++ b/src/steps/resource-manager/cdn/index.test.ts
@@ -7,7 +7,7 @@ import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { CdnEntities } from './constants';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 
 let recording: Recording;
 let instanceConfig: IntegrationConfig;

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { CdnClient } from './client';
 import {
   CdnEntities,
@@ -23,7 +24,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-export * from './constants';
 
 export async function fetchProfiles(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/compute/constants.ts
+++ b/src/steps/resource-manager/compute/constants.ts
@@ -2,7 +2,7 @@ import {
   generateRelationshipType,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { SERVICE_PRINCIPAL_ENTITY_TYPE } from '../../active-directory';
+import { SERVICE_PRINCIPAL_ENTITY_TYPE } from '../../active-directory/constants';
 
 import { entities as storageEntities } from '../storage/constants';
 import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';

--- a/src/steps/resource-manager/compute/index.test.ts
+++ b/src/steps/resource-manager/compute/index.test.ts
@@ -27,11 +27,11 @@ import {
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationConfig } from '../../../types';
+import { fetchServicePrincipals } from '../../active-directory';
 import {
   ACCOUNT_ENTITY_TYPE,
-  fetchServicePrincipals,
   SERVICE_PRINCIPAL_ENTITY_TYPE,
-} from '../../active-directory';
+} from '../../active-directory/constants';
 import { createStorageAccountEntity } from '../storage/converters';
 import {
   entities,

--- a/src/steps/resource-manager/compute/index.ts
+++ b/src/steps/resource-manager/compute/index.ts
@@ -13,11 +13,11 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { getAccountEntity } from '../../active-directory';
 import {
-  getAccountEntity,
   SERVICE_PRINCIPAL_ENTITY_TYPE,
   STEP_AD_ACCOUNT,
-} from '../../active-directory';
+} from '../../active-directory/constants';
 import { ComputeClient } from './client';
 import {
   DISK_ENTITY_TYPE,
@@ -59,8 +59,6 @@ import {
   steps as storageSteps,
 } from '../storage/constants';
 import { StorageAccount } from '@azure/arm-storage/esm/models';
-
-export * from './constants';
 
 export async function fetchGalleries(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/container-instance/constants.ts
+++ b/src/steps/resource-manager/container-instance/constants.ts
@@ -2,7 +2,7 @@ import {
   generateRelationshipType,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { entities as storageEntities } from '../storage';
+import { entities as storageEntities } from '../storage/constants';
 import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
 
 export const STEP_RM_CONTAINER_GROUPS = 'rm-container-groups';

--- a/src/steps/resource-manager/container-instance/index.test.ts
+++ b/src/steps/resource-manager/container-instance/index.test.ts
@@ -6,7 +6,7 @@ import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { fetchContainerGroups } from '.';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 
 const instanceConfig: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',

--- a/src/steps/resource-manager/container-instance/index.ts
+++ b/src/steps/resource-manager/container-instance/index.ts
@@ -7,7 +7,8 @@ import {
   JobState,
 } from '@jupiterone/integration-sdk-core';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { createAzureWebLinker } from '../../../azure';
 import {
   RESOURCE_GROUP_ENTITY,
@@ -26,8 +27,10 @@ import {
   STEP_RM_CONTAINER_GROUPS,
 } from './constants';
 import { Volume } from '@azure/arm-containerinstance/esm/models';
-import { steps as storageSteps, entities as storageEntities } from '../storage';
-export * from './constants';
+import {
+  steps as storageSteps,
+  entities as storageEntities,
+} from '../storage/constants';
 
 interface VolumeRelationshipStrategy {
   shouldAddRelationship: (volume: Volume) => Boolean;

--- a/src/steps/resource-manager/container-registry/index.test.ts
+++ b/src/steps/resource-manager/container-registry/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { ContainerRegistryEntities } from './constants';
 
 let recording: Recording;

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1ContainerRegistryManagementClient } from './client';
 import {
   ContainerRegistryEntities,
@@ -26,7 +27,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-export * from './constants';
 
 export async function fetchContainerRegistries(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/container-services/index.test.ts
+++ b/src/steps/resource-manager/container-services/index.test.ts
@@ -6,7 +6,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 
 let recording: Recording;
 

--- a/src/steps/resource-manager/container-services/index.ts
+++ b/src/steps/resource-manager/container-services/index.ts
@@ -4,7 +4,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationConfig, IntegrationStepContext } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { ContainerServicesClient } from './client';
 import {

--- a/src/steps/resource-manager/cosmosdb/index.ts
+++ b/src/steps/resource-manager/cosmosdb/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { CosmosDBClient } from './client';
 import {
   RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
@@ -23,8 +24,6 @@ import createResourceGroupResourceRelationship, {
   createResourceGroupResourceRelationshipMetadata,
 } from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
-
-export * from './constants';
 
 export async function fetchCosmosDBSqlDatabases(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -1,18 +1,12 @@
-import { STEP_AD_ACCOUNT } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   STEP_RM_DATABASE_MARIADB_DATABASES,
   STEP_RM_DATABASE_MYSQL_DATABASES,
 } from './constants';
-import {
-  fetchMariaDBDatabases,
-  MariaDBEntities,
-  MariaDBRelationships,
-} from './mariadb';
-import {
-  fetchMySQLDatabases,
-  MySQLEntities,
-  MySQLRelationships,
-} from './mysql';
+import { fetchMariaDBDatabases } from './mariadb';
+import { MariaDBEntities, MariaDBRelationships } from './mariadb/constants';
+import { fetchMySQLDatabases } from './mysql';
+import { MySQLEntities, MySQLRelationships } from './mysql/constants';
 import { postgreSqlSteps } from './postgresql';
 import { sqlSteps } from './sql';
 import {
@@ -25,8 +19,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-
-export * from './constants';
 
 export const databaseSteps: Step<
   IntegrationStepExecutionContext<IntegrationConfig>

--- a/src/steps/resource-manager/databases/mariadb/index.test.ts
+++ b/src/steps/resource-manager/databases/mariadb/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { setupAzureRecording } from '../../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../../test/createMockAzureStepExecutionContext';
 import { IntegrationConfig } from '../../../../types';
-import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory/constants';
 import { fetchMariaDBDatabases } from '.';
 import { MariaDBEntities, MariaDBRelationships } from './constants';
 

--- a/src/steps/resource-manager/databases/mariadb/index.ts
+++ b/src/steps/resource-manager/databases/mariadb/index.ts
@@ -12,8 +12,6 @@ import { MariaDBEntities } from './constants';
 import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 import { createDiagnosticSettingsEntitiesAndRelationshipsForResource } from '../../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 
-export * from './constants';
-
 export async function fetchMariaDBDatabases(
   executionContext: IntegrationStepContext,
 ): Promise<void> {

--- a/src/steps/resource-manager/databases/mysql/index.test.ts
+++ b/src/steps/resource-manager/databases/mysql/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { setupAzureRecording } from '../../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../../test/createMockAzureStepExecutionContext';
 import { IntegrationConfig } from '../../../../types';
-import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory/constants';
 import { fetchMySQLDatabases } from '.';
 import { MySQLEntities, MySQLRelationships } from './constants';
 

--- a/src/steps/resource-manager/databases/mysql/index.ts
+++ b/src/steps/resource-manager/databases/mysql/index.ts
@@ -12,8 +12,6 @@ import { MySQLEntities } from './constants';
 import createResourceGroupResourceRelationship from '../../utils/createResourceGroupResourceRelationship';
 import { createDiagnosticSettingsEntitiesAndRelationshipsForResource } from '../../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 
-export * from './constants';
-
 export async function fetchMySQLDatabases(
   executionContext: IntegrationStepContext,
 ): Promise<void> {

--- a/src/steps/resource-manager/databases/postgresql/index.test.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../../test/createMockAzureStepExecutionContext';
 import { IntegrationConfig } from '../../../../types';
-import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory/constants';
 import {
   fetchPostgreSQLDatabases,
   fetchPostgreSQLServers,

--- a/src/steps/resource-manager/databases/postgresql/index.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.ts
@@ -8,7 +8,8 @@ import {
 
 import { createAzureWebLinker } from '../../../../azure';
 import { IntegrationConfig, IntegrationStepContext } from '../../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../../active-directory';
+import { getAccountEntity } from '../../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
 import { createDatabaseEntity, createDbServerEntity } from '../converters';
 import { PostgreSQLClient } from './client';
 import {

--- a/src/steps/resource-manager/databases/sql/index.test.ts
+++ b/src/steps/resource-manager/databases/sql/index.test.ts
@@ -4,7 +4,7 @@ import {
   setupAzureRecording,
 } from '../../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../../active-directory/constants';
 import {
   fetchSQLDatabases,
   fetchSQLServerActiveDirectoryAdmins,

--- a/src/steps/resource-manager/databases/sql/index.ts
+++ b/src/steps/resource-manager/databases/sql/index.ts
@@ -8,7 +8,8 @@ import {
 
 import { createAzureWebLinker } from '../../../../azure';
 import { IntegrationConfig, IntegrationStepContext } from '../../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../../active-directory';
+import { getAccountEntity } from '../../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
 import { createDatabaseEntity, createDbServerEntity } from '../converters';
 import { SQLClient } from './client';
 import { steps, entities, relationships } from './constants';

--- a/src/steps/resource-manager/dns/index.test.ts
+++ b/src/steps/resource-manager/dns/index.test.ts
@@ -7,9 +7,9 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
-import { PrivateDnsEntities } from '../private-dns';
+import { PrivateDnsEntities } from '../private-dns/constants';
 import { getMockAccountEntity } from '../../../../test/helpers/getMockEntity';
 let recording: Recording;
 

--- a/src/steps/resource-manager/dns/index.ts
+++ b/src/steps/resource-manager/dns/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1DnsManagementClient } from './client';
 import {
   DnsEntities,
@@ -19,7 +20,6 @@ import { createDnsZoneEntity, createDnsRecordSetEntity } from './converters';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
 import { ResourcesClient } from '../resources/client';
-export * from './constants';
 
 export async function fetchZones(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/event-grid/index.test.ts
+++ b/src/steps/resource-manager/event-grid/index.test.ts
@@ -14,7 +14,7 @@ import {
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { EventGridEntities } from './constants';
 
 let recording: Recording;

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -6,7 +6,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   RESOURCE_GROUP_ENTITY,
   STEP_RM_RESOURCES_RESOURCE_GROUPS,
@@ -37,8 +38,6 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-
-export * from './constants';
 
 export async function fetchEventGridDomains(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/interservice/constants.ts
+++ b/src/steps/resource-manager/interservice/constants.ts
@@ -3,7 +3,7 @@ import {
   generateRelationshipType,
 } from '@jupiterone/integration-sdk-core';
 import { NetworkEntities } from '../network/constants';
-import { VIRTUAL_MACHINE_ENTITY_TYPE } from '../compute';
+import { VIRTUAL_MACHINE_ENTITY_TYPE } from '../compute/constants';
 
 // Step IDs
 export const STEP_RM_COMPUTE_NETWORK_RELATIONSHIPS =

--- a/src/steps/resource-manager/interservice/converters.ts
+++ b/src/steps/resource-manager/interservice/converters.ts
@@ -10,7 +10,7 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
-import { VIRTUAL_MACHINE_ENTITY_TYPE } from '../compute';
+import { VIRTUAL_MACHINE_ENTITY_TYPE } from '../compute/constants';
 import { NetworkEntities } from '../network/constants';
 import { VIRTUAL_MACHINE_NIC_RELATIONSHIP_TYPE } from './constants';
 

--- a/src/steps/resource-manager/interservice/index.ts
+++ b/src/steps/resource-manager/interservice/index.ts
@@ -10,11 +10,11 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { STEP_AD_ACCOUNT } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   STEP_RM_COMPUTE_VIRTUAL_MACHINES,
   VIRTUAL_MACHINE_ENTITY_TYPE,
-} from '../compute';
+} from '../compute/constants';
 import {
   STEP_RM_NETWORK_INTERFACES,
   STEP_RM_NETWORK_PUBLIC_IP_ADDRESSES,
@@ -34,8 +34,6 @@ import {
   createVirtualMachineNetworkInterfaceRelationship,
   createVirtualMachinePublicIPAddressRelationship,
 } from './converters';
-
-export * from './constants';
 
 export async function buildComputeNetworkRelationships(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/key-vault/index.test.ts
+++ b/src/steps/resource-manager/key-vault/index.test.ts
@@ -6,14 +6,16 @@ import {
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import {
-  ACCOUNT_ENTITY_TYPE,
   fetchGroups,
   fetchServicePrincipals,
   fetchUsers,
+} from '../../active-directory';
+import {
+  ACCOUNT_ENTITY_TYPE,
   GROUP_ENTITY_TYPE,
   SERVICE_PRINCIPAL_ENTITY_TYPE,
   USER_ENTITY_TYPE,
-} from '../../active-directory';
+} from '../../active-directory/constants';
 import {
   buildKeyVaultAccessPolicyRelationships,
   fetchKeyVaultKeys,

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -42,8 +42,6 @@ import {
 import { getAccountEntity } from '../../active-directory';
 import { Vault } from '@azure/arm-keyvault/esm/models';
 
-export * from './constants';
-
 export async function fetchKeyVaults(
   executionContext: IntegrationStepContext,
 ): Promise<void> {

--- a/src/steps/resource-manager/management-groups/constants.ts
+++ b/src/steps/resource-manager/management-groups/constants.ts
@@ -1,5 +1,5 @@
 import { RelationshipClass } from '@jupiterone/integration-sdk-core';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 
 export const ManagementGroupSteps = {
   MANAGEMENT_GROUPS: 'rm-management-groups',

--- a/src/steps/resource-manager/management-groups/index.test.ts
+++ b/src/steps/resource-manager/management-groups/index.test.ts
@@ -5,7 +5,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   fetchManagementGroups,
   validateManagementGroupStepInvocation,

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -11,7 +11,8 @@ import {
 
 import { AzureWebLinker, createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ManagementGroupClient } from './client';
 import {
   ManagementGroupEntities,

--- a/src/steps/resource-manager/monitor/index.test.ts
+++ b/src/steps/resource-manager/monitor/index.test.ts
@@ -5,7 +5,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   buildActivityLogScopeRelationships,
   fetchActivityLogAlerts,

--- a/src/steps/resource-manager/monitor/index.ts
+++ b/src/steps/resource-manager/monitor/index.ts
@@ -7,7 +7,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { steps as storageSteps } from '../storage/constants';
 import { steps as subscriptionSteps } from '../subscriptions/constants';
 import {

--- a/src/steps/resource-manager/network/constants.ts
+++ b/src/steps/resource-manager/network/constants.ts
@@ -3,7 +3,7 @@ import {
   generateRelationshipType,
 } from '@jupiterone/integration-sdk-core';
 import { ANY_RESOURCE } from '../constants';
-import { entities as storageEntities } from '../storage';
+import { entities as storageEntities } from '../storage/constants';
 import { entities as subscriptionEntities } from '../subscriptions/constants';
 import { createResourceGroupResourceRelationshipMetadata } from '../utils/createResourceGroupResourceRelationship';
 

--- a/src/steps/resource-manager/network/index.test.ts
+++ b/src/steps/resource-manager/network/index.test.ts
@@ -31,7 +31,7 @@ import {
 } from './';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import { IntegrationConfig } from '../../../types';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { NetworkEntities, NetworkRelationships } from './constants';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
 import {
@@ -41,11 +41,8 @@ import {
 import { fetchResourceGroups } from '../resources';
 import { RESOURCE_GROUP_ENTITY } from '../resources/constants';
 import { filterGraphObjects } from '../../../../test/helpers/filterGraphObjects';
-import {
-  entities,
-  entities as storageEntities,
-  fetchStorageAccounts,
-} from '../storage';
+import { entities as storageEntities } from '../storage/constants';
+import { fetchStorageAccounts } from '../storage';
 import { fetchLocations, fetchSubscription } from '../subscriptions';
 import { setDataKeys as subscriptionSetDataKeys } from '../subscriptions/constants';
 import { createAzureWebLinker } from '../../../azure';
@@ -1329,7 +1326,7 @@ describe('rm-network-private-endpoint-resource-relationships', () => {
 
     await fetchStorageAccounts(context);
     const storageAccountEntities = context.jobState.collectedEntities.filter(
-      (e) => e._type === entities.STORAGE_ACCOUNT._type,
+      (e) => e._type === storageEntities.STORAGE_ACCOUNT._type,
     );
 
     await fetchPrivateEndpoints(context);

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -19,7 +19,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { NetworkClient } from './client';
 import {
   STEP_RM_NETWORK_INTERFACES,
@@ -70,7 +71,7 @@ import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
-import { steps as storageSteps } from '../storage';
+import { steps as storageSteps } from '../storage/constants';
 import {
   setDataKeys as subscriptionsSetDataKeys,
   SetDataTypes as SubscriptionSetDataTypes,
@@ -78,8 +79,6 @@ import {
 } from '../subscriptions/constants';
 import { ResourceGroup } from '@azure/arm-resources/esm/models';
 import { getResourceManagerSteps } from '../../../getStepStartStates';
-
-export * from './constants';
 
 type SubnetSecurityGroupMap = {
   [subnetId: string]: NetworkSecurityGroup;

--- a/src/steps/resource-manager/policy-insights/index.test.ts
+++ b/src/steps/resource-manager/policy-insights/index.test.ts
@@ -5,7 +5,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   buildPolicyStateAssignmentRelationships,
   buildPolicyStateDefinitionRelationships,
@@ -20,7 +20,8 @@ import {
   fetchPolicyDefinitionsForAssignments,
 } from '../policy';
 import { PolicyEntities } from '../policy/constants';
-import { fetchKeyVaults, KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
+import { fetchKeyVaults } from '../key-vault';
+import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault/constants';
 
 let recording: Recording;
 

--- a/src/steps/resource-manager/policy-insights/index.ts
+++ b/src/steps/resource-manager/policy-insights/index.ts
@@ -7,7 +7,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   PolicyInsightEntities,
   PolicyInsightRelationships,

--- a/src/steps/resource-manager/policy/index.test.ts
+++ b/src/steps/resource-manager/policy/index.test.ts
@@ -5,7 +5,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   fetchPolicyAssignments,
   fetchPolicyDefinitionsForAssignments,

--- a/src/steps/resource-manager/policy/index.ts
+++ b/src/steps/resource-manager/policy/index.ts
@@ -7,7 +7,8 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { PolicyEntities, PolicyRelationships, PolicySteps } from './constants';
 import { AzurePolicyClient } from './client';
 import { createPolicyAssignmentEntity } from './converters';

--- a/src/steps/resource-manager/private-dns/index.test.ts
+++ b/src/steps/resource-manager/private-dns/index.test.ts
@@ -7,9 +7,9 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
-import { DnsEntities } from '../dns';
+import { DnsEntities } from '../dns/constants';
 import { getMockAccountEntity } from '../../../../test/helpers/getMockEntity';
 let recording: Recording;
 

--- a/src/steps/resource-manager/private-dns/index.ts
+++ b/src/steps/resource-manager/private-dns/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1PrivateDnsManagementClient } from './client';
 import {
   PrivateDnsEntities,
@@ -22,7 +23,6 @@ import {
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
 import { ResourcesClient } from '../resources/client';
-export * from './constants';
 
 export async function fetchPrivateZones(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/redis-cache/index.test.ts
+++ b/src/steps/resource-manager/redis-cache/index.test.ts
@@ -7,7 +7,7 @@ import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 
 const instanceConfig: IntegrationConfig = {
   clientId: process.env.CLIENT_ID || 'clientId',

--- a/src/steps/resource-manager/redis-cache/index.ts
+++ b/src/steps/resource-manager/redis-cache/index.ts
@@ -5,7 +5,8 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { RedisCacheClient } from './client';
 import { createAzureWebLinker } from '../../../azure';
 import {
@@ -28,7 +29,6 @@ import {
 import { resourceGroupName } from '../../../azure/utils';
 import { RedisLinkedServerWithProperties } from '@azure/arm-rediscache/esm/models';
 const SECONDARY_SERVER_ROLE = 'Secondary';
-export * from './constants';
 
 export async function fetchRedisCaches(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/resources/index.test.ts
+++ b/src/steps/resource-manager/resources/index.test.ts
@@ -21,7 +21,7 @@ import {
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import {
   getMockAccountEntity,
   getMockResourceGroupEntity,

--- a/src/steps/resource-manager/resources/index.ts
+++ b/src/steps/resource-manager/resources/index.ts
@@ -11,7 +11,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ResourcesClient } from './client';
 import {
   STEP_RM_RESOURCES_RESOURCE_GROUPS,

--- a/src/steps/resource-manager/security/index.test.ts
+++ b/src/steps/resource-manager/security/index.test.ts
@@ -12,7 +12,7 @@ import {
   setupAzureRecording,
 } from '../../../../test/helpers/recording';
 import { entities as subscriptionEntities } from '../subscriptions/constants';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { SecurityEntities, SecurityRelationships } from './constants';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';

--- a/src/steps/resource-manager/security/index.ts
+++ b/src/steps/resource-manager/security/index.ts
@@ -6,7 +6,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { SecurityClient } from './client';
 import {
   SecurityEntities,

--- a/src/steps/resource-manager/service-bus/index.test.ts
+++ b/src/steps/resource-manager/service-bus/index.test.ts
@@ -8,7 +8,7 @@ import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 let recording: Recording;
 
 afterEach(async () => {

--- a/src/steps/resource-manager/service-bus/index.ts
+++ b/src/steps/resource-manager/service-bus/index.ts
@@ -7,7 +7,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ServiceBusClient } from './client';
 import {
   ServiceBusEntities,
@@ -26,7 +27,6 @@ import {
 } from './converters';
 import createResourceGroupResourceRelationship from '../utils/createResourceGroupResourceRelationship';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
-export * from './constants';
 
 export async function fetchServiceBusNamespaces(
   executionContext: IntegrationStepContext,

--- a/src/steps/resource-manager/storage/index.test.ts
+++ b/src/steps/resource-manager/storage/index.test.ts
@@ -12,9 +12,11 @@ import {
   getMatchRequestsBy,
 } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE, fetchAccount } from '../../active-directory';
+import { fetchAccount } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { configFromEnv } from '../../../../test/integrationInstanceConfig';
-import { fetchKeyVaults, KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault';
+import { fetchKeyVaults } from '../key-vault';
+import { KEY_VAULT_SERVICE_ENTITY_TYPE } from '../key-vault/constants';
 import { entities } from './constants';
 
 let recording: Recording;

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -10,7 +10,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { StorageClient, createStorageAccountServiceClient } from './client';
 import { steps, entities, relationships } from './constants';
 import {
@@ -29,7 +30,6 @@ import {
   STEP_RM_KEYVAULT_VAULTS,
 } from '../key-vault/constants';
 import { Vault } from '@azure/arm-keyvault/esm/models';
-export * from './constants';
 // import { MonitorClient } from '../monitor/client';
 // import { compareAsc } from 'date-fns';
 

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -9,7 +9,8 @@ import {
 
 import { createAzureWebLinker } from '../../../azure';
 import { IntegrationStepContext, IntegrationConfig } from '../../../types';
-import { getAccountEntity, STEP_AD_ACCOUNT } from '../../active-directory';
+import { getAccountEntity } from '../../active-directory';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
   createDiagnosticSettingsEntitiesAndRelationshipsForResource,
   diagnosticSettingsEntitiesForResource,

--- a/src/steps/resource-manager/utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource.test.ts
+++ b/src/steps/resource-manager/utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource.test.ts
@@ -2,12 +2,12 @@ import { Recording } from '@jupiterone/integration-sdk-testing';
 import { IntegrationConfig } from '../../../types';
 import { setupAzureRecording } from '../../../../test/helpers/recording';
 import { createMockAzureStepExecutionContext } from '../../../../test/createMockAzureStepExecutionContext';
-import { ACCOUNT_ENTITY_TYPE } from '../../active-directory';
+import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
 import { createDiagnosticSettingsEntitiesAndRelationshipsForResource } from './createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import {
   KEY_VAULT_SERVICE_ENTITY_CLASS,
   KEY_VAULT_SERVICE_ENTITY_TYPE,
-} from '../key-vault';
+} from '../key-vault/constants';
 import { Entity } from '@jupiterone/integration-sdk-core';
 import { MonitorEntities, MonitorRelationships } from '../monitor/constants';
 import { separateDiagnosticSettingsRelationships } from '../../../../test/helpers/filterGraphObjects';


### PR DESCRIPTION
This change also ships a CIS question:

## 8.3 Ensure that Resource Locks are set for mission critical Azure resources (Manual)

```
  - id: integration-question-azure-misc-resource-locks
    title: Are all critical resources protected by resource locks?
    description:
      Checks if all critical resources have resources locks set. 
    queries:
    - name: good
      query: |
        FIND * with tag.SensitiveAzureResource = true THAT HAS azure_resource_lock
    - name: bad
      query: |
        FIND * with tag.SensitiveAzureResource = true THAT !HAS azure_resource_lock
```

---

How should we determine whether resources are mission critical? I think tagging is a good solution, but not sure `tag.SensitiveAzureResource` is the right tag to use.