### PR TITLE
Stop creating azure_kubernetes_cluster entities with no id property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped creating `azure_kubernetes_cluster` entities that have no `id`
+  property
+
 ## [5.35.0] - 2021-11-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [5.35.1] - 2021-11-08
+
 ### Fixed
 
 - Stopped creating `azure_kubernetes_cluster` entities that have no `id`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.35.0",
+  "version": "5.35.1",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/steps/resource-manager/container-services/converters.ts
+++ b/src/steps/resource-manager/container-services/converters.ts
@@ -14,7 +14,7 @@ export function createClusterEntitiy(
     entityData: {
       source: data,
       assign: {
-        _key: data.id as string,
+        _key: data.id,
         _type: ContainerServicesEntities.KUBERNETES_CLUSTER._type,
         _class: ContainerServicesEntities.KUBERNETES_CLUSTER._class,
         id: data.id,

--- a/src/steps/resource-manager/container-services/index.ts
+++ b/src/steps/resource-manager/container-services/index.ts
@@ -24,6 +24,18 @@ export async function fetchClusters(
   const client = new ContainerServicesClient(instance.config, logger);
 
   await client.iterateClusters(async (cluster) => {
+    if (!cluster.id) {
+      logger.warn(
+        {
+          id: cluster.id,
+          location: cluster.location,
+          name: cluster.name,
+          type: cluster.type,
+        },
+        'Azure managed cluster has no "id" property',
+      );
+      return;
+    }
     const clusterEntity = createClusterEntitiy(webLinker, cluster);
     await jobState.addEntity(clusterEntity);
 


### PR DESCRIPTION
Introduced with the recent `azure_kubernetes_cluster` entities.

```
### Fixed

- Stopped creating `azure_kubernetes_cluster` entities that have no `id`
  property
```