### PR TITLE
Stop using the ContainerServiceClient.managedClusters.list(callback) interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [5.35.2] - 2021-11-08
+
 ### Fixed
 
 - Stopped using the `callback` version of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped using the `callback` version of the
+  `ContainerServiceClient.managedClusters.list(callback)` API
+
 ## [5.35.1] - 2021-11-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-azure",
-  "version": "5.35.1",
+  "version": "5.35.2",
   "description": "A graph conversion tool for https://azure.microsoft.com/.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/steps/resource-manager/container-services/client.ts
+++ b/src/steps/resource-manager/container-services/client.ts
@@ -16,10 +16,7 @@ export class ContainerServicesClient extends Client {
     return iterateAllResources({
       logger: this.logger,
       serviceClient,
-      resourceEndpoint: {
-        list: () => serviceClient.managedClusters.list(callback),
-        listNext: serviceClient.managedClusters.listNext,
-      },
+      resourceEndpoint: serviceClient.managedClusters,
       resourceDescription: 'containerServices.clusters',
       callback,
     });

--- a/src/steps/resource-manager/container-services/index.ts
+++ b/src/steps/resource-manager/container-services/index.ts
@@ -24,18 +24,6 @@ export async function fetchClusters(
   const client = new ContainerServicesClient(instance.config, logger);
 
   await client.iterateClusters(async (cluster) => {
-    if (!cluster.id) {
-      logger.warn(
-        {
-          id: cluster.id,
-          location: cluster.location,
-          name: cluster.name,
-          type: cluster.type,
-        },
-        'Azure managed cluster has no "id" property',
-      );
-      return;
-    }
     const clusterEntity = createClusterEntitiy(webLinker, cluster);
     await jobState.addEntity(clusterEntity);
 


### PR DESCRIPTION
```
### Fixed

- Stopped using the `callback` version of the
  `ContainerServiceClient.managedClusters.list(callback)` API
