### PR TITLE
Fixing Cosmosdb account bug

### DIFF
--- a/src/steps/resource-manager/cosmosdb/converters.test.ts
+++ b/src/steps/resource-manager/cosmosdb/converters.test.ts
@@ -93,6 +93,7 @@ describe('createAccountEntity', () => {
         },
       ],
       _type: 'azure_cosmosdb_account',
+      function: ['database'],
       id:
         '/subscriptions/dccea45f-7035-4a17-8731-1fd46aaa74a0/resourceGroups/j1dev/providers/Microsoft.DocumentDB/databaseAccounts/j1dev',
       createdOn: undefined,

--- a/src/steps/resource-manager/cosmosdb/converters.ts
+++ b/src/steps/resource-manager/cosmosdb/converters.ts
@@ -27,6 +27,7 @@ export function createAccountEntity(
         _key: data.id!,
         _type: RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
         _class: RM_COSMOSDB_ACCOUNT_ENTITY_CLASS,
+        function: ['cosmosdb-account'],
         webLink: webLinker.portalResourceUrl(data.id),
         region: normalizeLocation(data.location),
         resourceGroup: resourceGroupName(data.id),

--- a/src/steps/resource-manager/cosmosdb/converters.ts
+++ b/src/steps/resource-manager/cosmosdb/converters.ts
@@ -27,7 +27,7 @@ export function createAccountEntity(
         _key: data.id!,
         _type: RM_COSMOSDB_ACCOUNT_ENTITY_TYPE,
         _class: RM_COSMOSDB_ACCOUNT_ENTITY_CLASS,
-        function: ['cosmosdb-account'],
+        function: ['database'],
         webLink: webLinker.portalResourceUrl(data.id),
         region: normalizeLocation(data.location),
         resourceGroup: resourceGroupName(data.id),

--- a/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
+++ b/src/steps/resource-manager/utils/createResourceGroupResourceRelationship.test.ts
@@ -92,7 +92,7 @@ describe('#createResourceGroupResourceRelationship', () => {
       entities: [],
     });
 
-    const loggerErrorSpy = spyOn(context.logger, 'error');
+    const loggerErrorSpy = jest.spyOn(context.logger, 'error');
 
     const resourceEntity: Entity = {
       _class: ['Service'],


### PR DESCRIPTION
added a 'function' property to the cosmosdb step to conform with the 'Service' class

example error:
```
(stepId=rm-cosmosdb-sql-databases, errorId=01aa7a34-9efb-41d5-81ea-6d72377fa61e)
  Error: Entity fails to validate as class 'Service':

  [
    {
      "instancePath": "",
      "schemaPath": "#/allOf/1/required",
      "keyword": "required",
      "params": {
        "missingProperty": "function"
      },
      "message": "must have required property 'function'"
    }
  ]
      at Object.validateEntityWithSchema (/Users/jfisher/Tools/graph-azure/node_modules/@jupiterone/data-model/src/validateEntityWithSchema.ts:15:13)
      at Object.createIntegrationEntity (/Users/jfisher/Tools/graph-azure/node_modules/@jupiterone/integration-sdk-core/src/data/createIntegrationEntity.ts:103:5)
      at Object.createAccountEntity (/Users/jfisher/Tools/graph-azure/src/steps/resource-manager/cosmosdb/converters.ts:23:10)
      at /Users/jfisher/Tools/graph-azure/src/steps/resource-manager/cosmosdb/index.ts:38:29
      at Object.iterateAllResources (/Users/jfisher/Tools/graph-azure/src/azure/resource-manager/client.ts:366:15)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at Object.fetchCosmosDBSqlDatabases [as executionHandler] (/Users/jfisher/Tools/graph-azure/src/steps/resource-manager/cosmosdb/index.ts:37:3)
```