### PR TITLE
INT-2777 - Fix for subnet has vm duplicate key in relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a problem related to subnet and virtual machine relationships that was
+  causing the same subnet to be used more than once resulting in duplicate key
+  error.
+
 ## [5.36.1] - 2022-03-02
 
 ### Removed


### PR DESCRIPTION
The finding/reasoning is described in-depth in the associated [Jira ticket](https://jupiterone.atlassian.net/browse/INT-2777).

This PR prevents multiple use of the same subnet thus not letting the duplicate key error occur.