### PR TITLE
Add mgmt group -> subscription mapped relationship metadata

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -452,10 +452,11 @@ The following relationships are created:
 
 The following mapped relationships are created:
 
-| Source Entity `_type`   | Relationship `_class` | Target Entity `_type` | Direction |
-| ----------------------- | --------------------- | --------------------- | --------- |
-| `azure_network_watcher` | **HAS**               | `*azure_location*`    | REVERSE   |
-| `azure_subscription`    | **USES**              | `*azure_location*`    | FORWARD   |
+| Source Entity `_type`    | Relationship `_class` | Target Entity `_type`  | Direction |
+| ------------------------ | --------------------- | ---------------------- | --------- |
+| `azure_network_watcher`  | **HAS**               | `*azure_location*`     | REVERSE   |
+| `azure_management_group` | **HAS**               | `*azure_subscription*` | FORWARD   |
+| `azure_subscription`     | **USES**              | `*azure_location*`     | FORWARD   |
 
 <!--
 ********************************************************************************

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -2,6 +2,25 @@
 sourceId: managed:azure
 integrationDefinitionId: '${integration_definition_id}'
 questions:
+  - id: integration-question-azure-tenant-member-subscriptions
+    title: Which azure subscriptions are members of the same tenant?
+    description:
+      Returns a graph showing the relationships between azure_account (tenant), azure_management_group, and azure_subscription. Captures all subscriptions that are nested under three or fewer levels of management groups.
+    queries:
+      - name: Subscriptions that are part of the same tenant
+        resultsAre: Informative
+        query: |
+          FIND
+            azure_subscription 
+            (THAT HAS azure_management_group)?
+            (THAT HAS azure_management_group)?
+            THAT HAS azure_management_group
+            THAT HAS azure_account WITH 
+              id = '{{tenantId}}'
+          RETURN 
+            TREE
+    tags:
+      - azure
   - id: integration-question-azure-networking-internet-access
     title: What Azure resources are allow access to or from the Internet?
     description:

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -8,7 +8,7 @@ questions:
       Returns a graph showing the relationships between azure_account (tenant), azure_management_group, and azure_subscription. Captures all subscriptions that are nested under three or fewer levels of management groups.
     queries:
       - name: Subscriptions that are part of the same tenant
-        resultsAre: Informative
+        resultsAre: INFORMATIVE
         query: |
           FIND
             azure_subscription 

--- a/src/steps/resource-manager/management-groups/constants.ts
+++ b/src/steps/resource-manager/management-groups/constants.ts
@@ -1,5 +1,9 @@
-import { RelationshipClass } from '@jupiterone/integration-sdk-core';
+import {
+  RelationshipClass,
+  RelationshipDirection,
+} from '@jupiterone/integration-sdk-core';
 import { ACCOUNT_ENTITY_TYPE } from '../../active-directory/constants';
+import { entities } from '../subscriptions/constants';
 
 export const ManagementGroupSteps = {
   MANAGEMENT_GROUPS: 'rm-management-groups',
@@ -25,5 +29,15 @@ export const ManagementGroupRelationships = {
     sourceType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
     _class: RelationshipClass.CONTAINS,
     targetType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
+  },
+};
+
+export const ManagementGroupMappedRelationships = {
+  MANAGEMENT_GROUP_HAS_SUBSCRIPTION: {
+    _type: 'azure_management_group_has_subscription',
+    sourceType: ManagementGroupEntities.MANAGEMENT_GROUP._type,
+    _class: RelationshipClass.HAS,
+    targetType: entities.SUBSCRIPTION._type,
+    direction: RelationshipDirection.FORWARD,
   },
 };

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -16,6 +16,7 @@ import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ManagementGroupClient } from './client';
 import {
   ManagementGroupEntities,
+  ManagementGroupMappedRelationships,
   ManagementGroupRelationships,
   ManagementGroupSteps,
 } from './constants';
@@ -145,7 +146,10 @@ export const managementGroupSteps: Step<
     relationships: [
       ManagementGroupRelationships.ACCOUNT_HAS_ROOT_MANAGEMENT_GROUP,
       ManagementGroupRelationships.MANAGEMENT_GROUP_CONTAINS_MANAGEMENT_GROUP,
-    ], // TODO add support for mapped relationship documentation
+    ],
+    mappedRelationships: [
+      ManagementGroupMappedRelationships.MANAGEMENT_GROUP_HAS_SUBSCRIPTION,
+    ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchManagementGroups,
   },


### PR DESCRIPTION
Although we have long been creating relationships between `azure_management_group` and `azure_subscription`, the SDK recently added support for documenting mapped relationships produced by integration steps. 

---
### Mapped Relationships

The following mapped relationships are created:

| Source Entity `_type`    | Relationship `_class` | Target Entity `_type`  | Direction |
| ------------------------ | --------------------- | ---------------------- | --------- |
| `azure_management_group` | **HAS**               | `*azure_subscription*` | FORWARD   |