### PR TITLE
INT-3890 Do not log reports errors to users

### DIFF
--- a/src/steps/active-directory/client.ts
+++ b/src/steps/active-directory/client.ts
@@ -129,7 +129,7 @@ export class DirectoryGraphClient extends GraphClient {
       const resourceUrl = '/reports/credentialUserRegistrationDetails';
       this.logger.info('Iterating credential user registration details.');
 
-      return this.iterateResources({
+      return await this.iterateResources({
         resourceUrl,
         options: { useBeta: true },
         callback,

--- a/src/steps/active-directory/index.test.ts
+++ b/src/steps/active-directory/index.test.ts
@@ -175,7 +175,7 @@ describe.skip('ad-user-registration-details', () => {
       },
     });
 
-    await expect(fetchUserRegistrationDetails(context)).rejects.toThrow(
+    await expect(fetchUserRegistrationDetails(context)).resolves.not.toThrow(
       IntegrationProviderAuthorizationError,
     );
   });

--- a/src/steps/active-directory/index.test.ts
+++ b/src/steps/active-directory/index.test.ts
@@ -155,7 +155,7 @@ describe.skip('ad-user-registration-details', () => {
     });
   });
 
-  test.only('403', async () => {
+  test('403', async () => {
     recording = setupAzureRecording({
       directory: __dirname,
       name: 'ad-user-registration-details-403',


### PR DESCRIPTION
The /reports/credentialUserRegistrationDetails endpoint is only available to
premium azure instances. If the instance is not premium, users should not
see the error in their job logs. They currently are because we were not
awaiting the response from the endpoint.