### PR TITLE
Stop printing 'UNREGISTERED_PROVIDER' messages in DNS Zone steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - Set API response log level from info -> debug
+- Stopped printing `UNREGISTERED_PROVIDER` messages in DNS Zone steps
 
 ## [5.39.1] - 2022-06-28
 

--- a/src/steps/resource-manager/dns/index.test.ts
+++ b/src/steps/resource-manager/dns/index.test.ts
@@ -86,13 +86,7 @@ describe('rm-dns-zones', () => {
       },
     });
 
-    const publishEventSpy = jest.spyOn(context.logger, 'publishEvent');
-
     await expect(fetchZones(context)).resolves.not.toThrow();
-    expect(publishEventSpy).toHaveBeenCalledWith({
-      name: 'UNREGISTERED_PROVIDER',
-      description: `The subscription ${configFromEnv.subscriptionId} must have the "Microsoft.Network" Resource Provider registered in order to ingest DNS zones. The "Microsoft.Network" resource provider has a registration state of "NotRegistered".`,
-    });
   }, 10_000);
 });
 

--- a/src/steps/resource-manager/dns/index.ts
+++ b/src/steps/resource-manager/dns/index.ts
@@ -30,10 +30,13 @@ export async function fetchZones(
     'Microsoft.Network',
   );
   if (registrationState !== 'Registered') {
-    logger.publishEvent({
-      name: 'UNREGISTERED_PROVIDER',
-      description: `The subscription ${instance.config.subscriptionId} must have the "Microsoft.Network" Resource Provider registered in order to ingest DNS zones. The "Microsoft.Network" resource provider has a registration state of "${registrationState}".`,
-    });
+    logger.info(
+      {
+        registrationState,
+        subscriptionId: instance.config.subscriptionId,
+      },
+      'Registration state !== "Registered"',
+    );
     return;
   }
 

--- a/src/steps/resource-manager/private-dns/index.test.ts
+++ b/src/steps/resource-manager/private-dns/index.test.ts
@@ -86,13 +86,7 @@ describe('rm-private-dns-zones', () => {
       },
     });
 
-    const publishEventSpy = jest.spyOn(context.logger, 'publishEvent');
-
     await expect(fetchPrivateZones(context)).resolves.not.toThrow();
-    expect(publishEventSpy).toHaveBeenCalledWith({
-      name: 'UNREGISTERED_PROVIDER',
-      description: `The subscription ${configFromEnv.subscriptionId} must have the "Microsoft.Network" Resource Provider registered in order to ingest private DNS zones. The "Microsoft.Network" resource provider has a registration state of "NotRegistered".`,
-    });
   }, 10_000);
 });
 

--- a/src/steps/resource-manager/private-dns/index.ts
+++ b/src/steps/resource-manager/private-dns/index.ts
@@ -33,10 +33,13 @@ export async function fetchPrivateZones(
     'Microsoft.Network',
   );
   if (registrationState !== 'Registered') {
-    logger.publishEvent({
-      name: 'UNREGISTERED_PROVIDER',
-      description: `The subscription ${instance.config.subscriptionId} must have the "Microsoft.Network" Resource Provider registered in order to ingest private DNS zones. The "Microsoft.Network" resource provider has a registration state of "${registrationState}".`,
-    });
+    logger.info(
+      {
+        registrationState,
+        subscriptionId: instance.config.subscriptionId,
+      },
+      'Registration state !== "Registered"',
+    );
     return;
   }
   const accountEntity = await getAccountEntity(jobState);


### PR DESCRIPTION
Looks like it’s not possible to have DNS zones if the subscription has not registered the Microsoft.Network resource provider. I confirmed this by doing the following:

1. Unregister the Microsoft.Network provider from an active Azure subscription
2. Add a DNS Zone resource to the Azure subscription
  a. I noticed that the Microsoft.Network provider was automatically switched from status Unregistered → Registered
3. Tried again to switch the Microsoft.Network provider status from Registered → Unregistered. It would not allow me to unregister while there were existing resources for the provider. (**`Error unregistering resource provider`**`The subscription cannot be unregistered from resource namespace 'microsoft.network'. Please delete existing resources for the provider.`)

Since that’s true, it doesn’t make sense to ask our customers to enable a provider that they otherwise do not have. Instead of updating documentation, we should update the integration to remove this messaging, which can confuse our users into believing that they’re missing resources in J1 (they’re not).