### PR TITLE
fix(int-6429): update routing rule to rule class

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -211,7 +211,7 @@ The following entities are created:
 | FrontDoor                                      | `azure_frontdoor`                                 | `Service`                          |
 | FrontDoor Backend Pool                         | `azure_frontdoor_backend_pool`                    | `Configuration`                    |
 | FrontDoor Frontend Endpoint                    | `azure_frontdoor_frontend_endpoint`               | `Gateway`                          |
-| FrontDoor Routing Rule                         | `azure_frontdoor_routing_rule`                    | `Route`                            |
+| FrontDoor Routing Rule                         | `azure_frontdoor_routing_rule`                    | `Rule`                             |
 | FrontDoor Rules Engine                         | `azure_frontdoor_rules_engine`                    | `Ruleset`                          |
 | [AD] Account                                   | `azure_account`                                   | `Account`                          |
 | [AD] Group                                     | `azure_user_group`                                | `UserGroup`                        |

--- a/src/steps/resource-manager/frontdoor/constants.ts
+++ b/src/steps/resource-manager/frontdoor/constants.ts
@@ -22,7 +22,7 @@ export const FrontDoorEntities = {
   },
   ROUTING_RULE: {
     resourceName: 'FrontDoor Routing Rule',
-    _class: ['Route'],
+    _class: ['Rule'],
     _type: 'azure_frontdoor_routing_rule',
   },
   BACKEND_POOL: {


### PR DESCRIPTION
# Description

This PR fixes a bug with the `azure_frontdoor_routing_rule`. This entity was previously using the `Route` class which is not in the data-model.

This causes an error to be thrown and the step to fail. The entity has been updated to use the `Rule` class. This isn't a breaking change since previously this entity would have never been able to be created.
