### PR TITLE
Azure FetchSubscriptions Pagination

### DIFF
--- a/src/steps/resource-manager/subscriptions/client.ts
+++ b/src/steps/resource-manager/subscriptions/client.ts
@@ -72,20 +72,31 @@ export class J1SubscriptionClient extends Client {
         passSubscriptionId: false,
       },
     );
-    const subscriptions = await request(
-      // Need API version to 2020-01-01 in order to return subscription tags
-      // serviceClient.subscriptions.list() does not work because the api version is too old
-      // sendOperationRequest was the only way I found to change the API version with this sdk
-      async () =>
-        await serviceClient.sendOperationRequest(
-          {},
-          listSubscripsionsOperationSpec,
-        ),
-      this.logger,
-      'subscription',
-      FIVE_MINUTES,
-    );
-    return subscriptions?._response?.parsedBody;
+    let allSubscriptions: any[] = [];
+    let nextLink;
+    do {
+      const subscriptions = await request(
+        // Need API version to 2020-01-01 in order to return subscription tags
+        // serviceClient.subscriptions.list() does not work because the api version is too old
+        // sendOperationRequest was the only way I found to change the API version with this sdk
+        async () =>
+          await serviceClient.sendOperationRequest(
+            {},
+            nextLink
+              ? getNextOperationSpec(nextLink)
+              : listSubscripsionsOperationSpec,
+          ),
+        this.logger,
+        'subscription',
+        FIVE_MINUTES,
+      );
+      allSubscriptions = [
+        ...allSubscriptions,
+        ...subscriptions?._response?.parsedBody,
+      ];
+      nextLink = subscriptions?._response?.parsedBody.nextLink;
+    } while (nextLink);
+    return allSubscriptions;
   }
 
   public async fetchSubscription(
@@ -105,6 +116,10 @@ export class J1SubscriptionClient extends Client {
     );
     return subscription?._response?.parsedBody;
   }
+}
+function getNextOperationSpec(nextLink: string): msRest.OperationSpec {
+  nextPageLink.parameterPath = nextLink;
+  return listNextOperationSpec;
 }
 
 /**
@@ -136,6 +151,33 @@ const listSubscripsionsOperationSpec: msRest.OperationSpec = {
   httpMethod: 'GET',
   path: 'subscriptions',
   queryParameters: [apiVersion2020],
+  headerParameters: [acceptLanguage],
+  responses: {
+    200: {
+      bodyMapper: SubscriptionMappers.LocationListResult,
+    },
+    default: {
+      bodyMapper: SubscriptionMappers.CloudError,
+    },
+  },
+  serializer: new msRest.Serializer(SubscriptionMappers),
+};
+const nextPageLink: msRest.OperationURLParameter = {
+  parameterPath: 'nextPageLink',
+  mapper: {
+    required: true,
+    serializedName: 'nextLink',
+    type: {
+      name: 'String',
+    },
+  },
+  skipEncoding: true,
+};
+const listNextOperationSpec: msRest.OperationSpec = {
+  httpMethod: 'GET',
+  baseUrl: 'https://management.azure.com',
+  path: '{nextLink}',
+  urlParameters: [nextPageLink],
   headerParameters: [acceptLanguage],
   responses: {
     200: {

--- a/src/steps/resource-manager/subscriptions/client.ts
+++ b/src/steps/resource-manager/subscriptions/client.ts
@@ -72,7 +72,7 @@ export class J1SubscriptionClient extends Client {
         passSubscriptionId: false,
       },
     );
-    let allSubscriptions: any[] = [];
+    let allSubscriptions: Subscription[] = [];
     let nextLink;
     do {
       const subscriptions = await request(

--- a/src/steps/resource-manager/subscriptions/client.ts
+++ b/src/steps/resource-manager/subscriptions/client.ts
@@ -90,10 +90,9 @@ export class J1SubscriptionClient extends Client {
         'subscription',
         FIVE_MINUTES,
       );
-      allSubscriptions = [
-        ...allSubscriptions,
-        ...subscriptions?._response?.parsedBody,
-      ];
+      allSubscriptions = allSubscriptions.concat(
+        subscriptions?._response?.parsedBody,
+      );
       nextLink = subscriptions?._response?.parsedBody.nextLink;
     } while (nextLink);
     return allSubscriptions;


### PR DESCRIPTION
Added support for pagination of the API that fetches all subscriptions from a specific Active Directory.
This allows to fetch more than just a single page of subscriptions (1000 subscriptions).
It is used by the instances that have Configure Subscription instances set on instance setup.