### PR TITLE
Azure permission documentation part 1: Added permissions to each step

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -532,3 +532,104 @@ END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
 [2]:
   https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-api-authentication
 [3]: https://docs.microsoft.com/en-us/graph/api/organization-get
+
+<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_START} -->
+<!-- {J1_PERMISSIONS_DOCUMENTATION_ROLE_PERMISSIONS_START} -->
+
+| Role Permissions List                                                                           |
+| ----------------------------------------------------------------------------------------------- |
+| `Microsoft.Advisor/recommendations/read`                                                        |
+| `Microsoft.Advisor/recommendations/suppressions/read`                                           |
+| `Microsoft.ApiManagement/service/apis/read`                                                     |
+| `Microsoft.ApiManagement/service/read`                                                          |
+| `Microsoft.Authorization/classicAdministrators/read`                                            |
+| `Microsoft.Authorization/locks/read`                                                            |
+| `Microsoft.Authorization/policyAssignments/read`                                                |
+| `Microsoft.Authorization/policyDefinitions/read`                                                |
+| `Microsoft.Authorization/roleAssignments/read`                                                  |
+| `Microsoft.Authorization/roleDefinitions/read`                                                  |
+| `Microsoft.Batch/batchAccounts/applications/read`                                               |
+| `Microsoft.Batch/batchAccounts/certificates/read`                                               |
+| `Microsoft.Batch/batchAccounts/pools/read`                                                      |
+| `Microsoft.Batch/batchAccounts/read`                                                            |
+| `Microsoft.Cache/redis/firewallRules/read`                                                      |
+| `Microsoft.Cache/redis/linkedServers/read`                                                      |
+| `Microsoft.Cache/redis/read`                                                                    |
+| `Microsoft.Cdn/profiles/endpoints/read`                                                         |
+| `Microsoft.Cdn/profiles/read`                                                                   |
+| `Microsoft.Compute/disks/read`                                                                  |
+| `Microsoft.Compute/galleries/images/read`                                                       |
+| `Microsoft.Compute/galleries/images/versions/read`                                              |
+| `Microsoft.Compute/galleries/read`                                                              |
+| `Microsoft.Compute/images/read`                                                                 |
+| `Microsoft.Compute/virtualMachines/extensions/read`                                             |
+| `Microsoft.Compute/virtualMachines/read`                                                        |
+| `Microsoft.ContainerInstance/containerGroups/read`                                              |
+| `Microsoft.ContainerRegistry/registries/read`                                                   |
+| `Microsoft.ContainerRegistry/registries/webhooks/read`                                          |
+| `Microsoft.ContainerService/managedClusters/read`                                               |
+| `Microsoft.DBforMariaDB/servers/databases/read`                                                 |
+| `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/read`                                       |
+| `Microsoft.EventGrid/domains/read`                                                              |
+| `Microsoft.EventGrid/domains/topics/eventSubscriptions/read`                                    |
+| `Microsoft.EventGrid/domains/topics/read`                                                       |
+| `Microsoft.EventGrid/topics/eventSubscriptions/read`                                            |
+| `Microsoft.EventGrid/topics/read`                                                               |
+| `Microsoft.Insights/ActivityLogAlerts/Read`                                                     |
+| `Microsoft.Insights/LogProfiles/Read`                                                           |
+| `Microsoft.KeyVault/vaults/keys/read`                                                           |
+| `Microsoft.KeyVault/vaults/read`                                                                |
+| `Microsoft.KeyVault/vaults/secrets/read`                                                        |
+| `Microsoft.Management/managementGroups/read`                                                    |
+| `Microsoft.Network/azurefirewalls/read`                                                         |
+| `Microsoft.Network/dnszones/read`                                                               |
+| `Microsoft.Network/dnszones/recordsets/read`                                                    |
+| `Microsoft.Network/frontDoors/backendPools/read`                                                |
+| `Microsoft.Network/frontDoors/frontendEndpoints/read`                                           |
+| `Microsoft.Network/frontDoors/read`                                                             |
+| `Microsoft.Network/frontDoors/routingRules/read`                                                |
+| `Microsoft.Network/frontDoors/rulesEngines/read`                                                |
+| `Microsoft.Network/loadBalancers/read`                                                          |
+| `Microsoft.Network/networkInterfaces/read`                                                      |
+| `Microsoft.Network/networkSecurityGroups/read`                                                  |
+| `Microsoft.Network/networkWatchers/flowLogs/read`                                               |
+| `Microsoft.Network/networkWatchers/read`                                                        |
+| `Microsoft.Network/privateDnsZones/read`                                                        |
+| `Microsoft.Network/privateDnsZones/recordsets/read`                                             |
+| `Microsoft.Network/privateEndpoints/read`                                                       |
+| `Microsoft.Network/publicIPAddresses/read`                                                      |
+| `Microsoft.Network/virtualNetworks/read`                                                        |
+| `Microsoft.OperationalInsights/workspaces/providers/Microsoft.Insights/diagnosticSettings/Read` |
+| `Microsoft.PolicyInsights/policyStates/summarize/read`                                          |
+| `Microsoft.Resources/subscriptions/locations/read`                                              |
+| `Microsoft.Resources/subscriptions/read`                                                        |
+| `Microsoft.Resources/subscriptions/resourceGroups/read`                                         |
+| `Microsoft.Security/assessments/read`                                                           |
+| `Microsoft.Security/autoProvisioningSettings/read`                                              |
+| `Microsoft.Security/pricings/read`                                                              |
+| `Microsoft.Security/securityContacts/read`                                                      |
+| `Microsoft.ServiceBus/namespaces/queues/read`                                                   |
+| `Microsoft.ServiceBus/namespaces/read`                                                          |
+| `Microsoft.ServiceBus/namespaces/topics/read`                                                   |
+| `Microsoft.ServiceBus/namespaces/topics/subscriptions/read`                                     |
+| `Microsoft.Storage/storageAccounts/blobServices/containers/read`                                |
+| `Microsoft.Storage/storageAccounts/fileServices/shares/read`                                    |
+| `Microsoft.Storage/storageAccounts/queueServices/read`                                          |
+| `Microsoft.Storage/storageAccounts/read`                                                        |
+| `Microsoft.Web/serverfarms/Read`                                                                |
+| `Microsoft.Web/sites/config/list/action`                                                        |
+| `Microsoft.Web/sites/config/Read`                                                               |
+| `Microsoft.Web/sites/Read`                                                                      |
+
+<!-- {J1_PERMISSIONS_DOCUMENTATION_ROLE_PERMISSIONS_END} -->
+<!-- {J1_PERMISSIONS_DOCUMENTATION_API_PERMISSIONS_START} -->
+
+| API Permissions List |
+| -------------------- |
+| `Directory.Read.All` |
+| `Policy.Read.All`    |
+| `Reports.Read.All`   |
+| `User.Read`          |
+
+<!-- {J1_PERMISSIONS_DOCUMENTATION_API_PERMISSIONS_END} -->
+<!-- {J1_PERMISSIONS_DOCUMENTATION_MARKER_END} -->

--- a/src/steps/active-directory/index.ts
+++ b/src/steps/active-directory/index.ts
@@ -208,7 +208,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     ],
     relationships: [],
     executionHandler: fetchAccount,
-    permissions: ['Directory.Read.All', 'Policy.Read.All'],
+    apiPermissions: ['Directory.Read.All', 'Policy.Read.All'],
   },
   {
     id: STEP_AD_USER_REGISTRATION_DETAILS,
@@ -217,7 +217,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [],
     executionHandler: fetchUserRegistrationDetails,
-    permissions: ['Reports.Read.All'],
+    apiPermissions: ['Reports.Read.All'],
   },
   {
     id: STEP_AD_USERS,
@@ -239,7 +239,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_AD_USER_REGISTRATION_DETAILS],
     executionHandler: fetchUsers,
-    permissions: ['User.Read'],
+    apiPermissions: ['User.Read'],
   },
   {
     id: STEP_AD_GROUPS,
@@ -261,7 +261,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchGroups,
-    permissions: ['Directory.Read.All'],
+    apiPermissions: ['Directory.Read.All'],
   },
   {
     id: STEP_AD_GROUP_MEMBERS,
@@ -295,7 +295,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_GROUPS, STEP_AD_USERS],
     executionHandler: fetchGroupMembers,
-    permissions: ['Directory.Read.All'],
+    apiPermissions: ['Directory.Read.All'],
   },
   {
     id: STEP_AD_SERVICE_PRINCIPALS,
@@ -310,6 +310,6 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchServicePrincipals,
-    permissions: ['Directory.Read.All'],
+    apiPermissions: ['Directory.Read.All'],
   },
 ];

--- a/src/steps/active-directory/index.ts
+++ b/src/steps/active-directory/index.ts
@@ -1,14 +1,12 @@
 import {
   Entity,
-  Step,
-  IntegrationStepExecutionContext,
   RelationshipClass,
   JobState,
   IntegrationError,
   createDirectRelationship,
 } from '@jupiterone/integration-sdk-core';
 
-import { IntegrationStepContext, IntegrationConfig } from '../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../types';
 import {
   CredentialUserRegistrationDetails,
   DirectoryGraphClient,
@@ -197,9 +195,7 @@ export async function fetchServicePrincipals(
   });
 }
 
-export const activeDirectorySteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const activeDirectorySteps: AzureIntegrationStep[] = [
   {
     id: STEP_AD_ACCOUNT,
     name: 'Active Directory Info',
@@ -212,6 +208,7 @@ export const activeDirectorySteps: Step<
     ],
     relationships: [],
     executionHandler: fetchAccount,
+    permissions: ['Directory.Read.All', 'Policy.Read.All'],
   },
   {
     id: STEP_AD_USER_REGISTRATION_DETAILS,
@@ -220,6 +217,7 @@ export const activeDirectorySteps: Step<
     relationships: [],
     dependsOn: [],
     executionHandler: fetchUserRegistrationDetails,
+    permissions: ['Reports.Read.All'],
   },
   {
     id: STEP_AD_USERS,
@@ -241,6 +239,7 @@ export const activeDirectorySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_AD_USER_REGISTRATION_DETAILS],
     executionHandler: fetchUsers,
+    permissions: ['User.Read'],
   },
   {
     id: STEP_AD_GROUPS,
@@ -262,6 +261,7 @@ export const activeDirectorySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchGroups,
+    permissions: ['Directory.Read.All'],
   },
   {
     id: STEP_AD_GROUP_MEMBERS,
@@ -295,6 +295,7 @@ export const activeDirectorySteps: Step<
     ],
     dependsOn: [STEP_AD_GROUPS, STEP_AD_USERS],
     executionHandler: fetchGroupMembers,
+    permissions: ['Directory.Read.All'],
   },
   {
     id: STEP_AD_SERVICE_PRINCIPALS,
@@ -309,5 +310,6 @@ export const activeDirectorySteps: Step<
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchServicePrincipals,
+    permissions: ['Directory.Read.All'],
   },
 ];

--- a/src/steps/active-directory/index.ts
+++ b/src/steps/active-directory/index.ts
@@ -239,7 +239,7 @@ export const activeDirectorySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_AD_USER_REGISTRATION_DETAILS],
     executionHandler: fetchUsers,
-    apiPermissions: ['User.Read'],
+    apiPermissions: ['Directory.Read.All'],
   },
   {
     id: STEP_AD_GROUPS,

--- a/src/steps/resource-manager/advisor/index.ts
+++ b/src/steps/resource-manager/advisor/index.ts
@@ -1,11 +1,7 @@
-import {
-  Step,
-  IntegrationStepExecutionContext,
-  createDirectRelationship,
-} from '@jupiterone/integration-sdk-core';
+import { createDirectRelationship } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { AdvisorClient } from './client';
@@ -69,9 +65,7 @@ export async function fetchRecommendations(
   });
 }
 
-export const advisorSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const advisorSteps: AzureIntegrationStep[] = [
   {
     id: AdvisorSteps.RECOMMENDATIONS,
     name: 'Recommendations',
@@ -86,5 +80,9 @@ export const advisorSteps: Step<
       ...getResourceManagerSteps().executeFirstSteps,
     ],
     executionHandler: fetchRecommendations,
+    permissions: [
+      'Microsoft.Advisor/recommendations/read',
+      'Microsoft.Advisor/recommendations/suppressions/read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/advisor/index.ts
+++ b/src/steps/resource-manager/advisor/index.ts
@@ -80,9 +80,6 @@ export const advisorSteps: AzureIntegrationStep[] = [
       ...getResourceManagerSteps().executeFirstSteps,
     ],
     executionHandler: fetchRecommendations,
-    rolePermissions: [
-      'Microsoft.Advisor/recommendations/read',
-      'Microsoft.Advisor/recommendations/suppressions/read',
-    ],
+    rolePermissions: ['Microsoft.Advisor/recommendations/read'],
   },
 ];

--- a/src/steps/resource-manager/advisor/index.ts
+++ b/src/steps/resource-manager/advisor/index.ts
@@ -80,7 +80,7 @@ export const advisorSteps: AzureIntegrationStep[] = [
       ...getResourceManagerSteps().executeFirstSteps,
     ],
     executionHandler: fetchRecommendations,
-    permissions: [
+    rolePermissions: [
       'Microsoft.Advisor/recommendations/read',
       'Microsoft.Advisor/recommendations/suppressions/read',
     ],

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -99,7 +99,10 @@ export const apiManagementSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApiManagementServices,
-    rolePermissions: ['Microsoft.ApiManagement/service/read'],
+    rolePermissions: [
+      'Microsoft.ApiManagement/service/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_API_MANAGEMENT_APIS,

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -99,7 +99,7 @@ export const apiManagementSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApiManagementServices,
-    permissions: ['Microsoft.ApiManagement/service/read'],
+    rolePermissions: ['Microsoft.ApiManagement/service/read'],
   },
   {
     id: STEP_RM_API_MANAGEMENT_APIS,
@@ -108,6 +108,6 @@ export const apiManagementSteps: AzureIntegrationStep[] = [
     relationships: [ApiManagementRelationships.SERVICE_HAS_API],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_API_MANAGEMENT_SERVICES],
     executionHandler: fetchApiManagementApis,
-    permissions: ['Microsoft.ApiManagement/service/apis/read'],
+    rolePermissions: ['Microsoft.ApiManagement/service/apis/read'],
   },
 ];

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1ApiManagementClient } from './client';
@@ -85,9 +83,7 @@ export async function fetchApiManagementApis(
   );
 }
 
-export const apiManagementSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const apiManagementSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_API_MANAGEMENT_SERVICES,
     name: 'API Management Services',
@@ -103,6 +99,7 @@ export const apiManagementSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApiManagementServices,
+    permissions: ['Microsoft.ApiManagement/service/read'],
   },
   {
     id: STEP_RM_API_MANAGEMENT_APIS,
@@ -111,5 +108,6 @@ export const apiManagementSteps: Step<
     relationships: [ApiManagementRelationships.SERVICE_HAS_API],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_API_MANAGEMENT_SERVICES],
     executionHandler: fetchApiManagementApis,
+    permissions: ['Microsoft.ApiManagement/service/apis/read'],
   },
 ];

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -1,6 +1,4 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   StepEntityMetadata,
   IntegrationLogger,
   getRawData,
@@ -9,7 +7,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { AppServiceClient } from './client';
@@ -176,9 +174,7 @@ export async function buildAppToPlanRelationships(
   }
 }
 
-export const appServiceSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const appServiceSteps: AzureIntegrationStep[] = [
   {
     id: AppServiceSteps.APPS,
     name: 'App Service Apps',
@@ -189,6 +185,11 @@ export const appServiceSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApps,
+    permissions: [
+      'Microsoft.Web/sites/Read',
+      'Microsoft.Web/sites/config/Read',
+      'Microsoft.Web/sites/config/list/action',
+    ],
   },
   {
     id: AppServiceSteps.APP_SERVICE_PLANS,
@@ -199,6 +200,7 @@ export const appServiceSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAppServicePlans,
+    permissions: ['Microsoft.Web/serverfarms/Read'],
   },
   {
     id: AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS,

--- a/src/steps/resource-manager/appservice/index.ts
+++ b/src/steps/resource-manager/appservice/index.ts
@@ -185,7 +185,7 @@ export const appServiceSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApps,
-    permissions: [
+    rolePermissions: [
       'Microsoft.Web/sites/Read',
       'Microsoft.Web/sites/config/Read',
       'Microsoft.Web/sites/config/list/action',
@@ -200,7 +200,7 @@ export const appServiceSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAppServicePlans,
-    permissions: ['Microsoft.Web/serverfarms/Read'],
+    rolePermissions: ['Microsoft.Web/serverfarms/Read'],
   },
   {
     id: AppServiceSteps.APP_TO_SERVICE_RELATIONSHIPS,

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -2,14 +2,12 @@ import {
   Entity,
   createDirectRelationship,
   createMappedRelationship,
-  Step,
-  IntegrationStepExecutionContext,
   RelationshipClass,
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
@@ -256,9 +254,7 @@ export async function fetchClassicAdministrators(
   });
 }
 
-export const authorizationSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const authorizationSteps: AzureIntegrationStep[] = [
   {
     id: steps.ROLE_ASSIGNMENTS,
     name: 'Role Assignments',
@@ -266,6 +262,7 @@ export const authorizationSteps: Step<
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT, steps.ROLE_DEFINITIONS],
     executionHandler: fetchRoleAssignments,
+    permissions: ['Microsoft.Authorization/roleAssignments/read'],
   },
   {
     id: steps.ROLE_ASSIGNMENT_PRINCIPALS,
@@ -293,6 +290,7 @@ export const authorizationSteps: Step<
     relationships: [relationships.SUBSCRIPTION_CONTAINS_ROLE_DEFINITION],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchRoleDefinitions,
+    permissions: ['Microsoft.Authorization/roleDefinitions/read'],
   },
   {
     id: steps.ROLE_ASSIGNMENT_DEFINITIONS,
@@ -309,5 +307,6 @@ export const authorizationSteps: Step<
     relationships: [relationships.CLASSIC_ADMIN_GROUP_HAS_USER],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchClassicAdministrators,
+    permissions: ['Microsoft.Authorization/classicAdministrators/read'],
   },
 ];

--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -262,7 +262,7 @@ export const authorizationSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT, steps.ROLE_DEFINITIONS],
     executionHandler: fetchRoleAssignments,
-    permissions: ['Microsoft.Authorization/roleAssignments/read'],
+    rolePermissions: ['Microsoft.Authorization/roleAssignments/read'],
   },
   {
     id: steps.ROLE_ASSIGNMENT_PRINCIPALS,
@@ -290,7 +290,7 @@ export const authorizationSteps: AzureIntegrationStep[] = [
     relationships: [relationships.SUBSCRIPTION_CONTAINS_ROLE_DEFINITION],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchRoleDefinitions,
-    permissions: ['Microsoft.Authorization/roleDefinitions/read'],
+    rolePermissions: ['Microsoft.Authorization/roleDefinitions/read'],
   },
   {
     id: steps.ROLE_ASSIGNMENT_DEFINITIONS,
@@ -307,6 +307,6 @@ export const authorizationSteps: AzureIntegrationStep[] = [
     relationships: [relationships.CLASSIC_ADMIN_GROUP_HAS_USER],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchClassicAdministrators,
-    permissions: ['Microsoft.Authorization/classicAdministrators/read'],
+    rolePermissions: ['Microsoft.Authorization/classicAdministrators/read'],
   },
 ];

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -204,7 +204,10 @@ export const batchSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchBatchAccounts,
-    rolePermissions: ['Microsoft.Batch/batchAccounts/read'],
+    rolePermissions: [
+      'Microsoft.Batch/batchAccounts/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_BATCH_POOL,

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
@@ -190,9 +188,7 @@ export async function fetchBatchCertificates(
   );
 }
 
-export const batchSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const batchSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_BATCH_ACCOUNT,
     name: 'Batch Accounts',
@@ -208,6 +204,7 @@ export const batchSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchBatchAccounts,
+    permissions: ['Microsoft.Batch/batchAccounts/read'],
   },
   {
     id: STEP_RM_BATCH_POOL,
@@ -220,6 +217,7 @@ export const batchSteps: Step<
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchPools,
+    permissions: ['Microsoft.Batch/batchAccounts/pools/read'],
   },
   {
     id: STEP_RM_BATCH_APPLICATION,
@@ -234,6 +232,7 @@ export const batchSteps: Step<
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchApplications,
+    permissions: ['Microsoft.Batch/batchAccounts/applications/read'],
   },
   {
     id: STEP_RM_BATCH_CERTIFICATE,
@@ -248,5 +247,6 @@ export const batchSteps: Step<
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchCertificates,
+    permissions: ['Microsoft.Batch/batchAccounts/certificates/read'],
   },
 ];

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -204,7 +204,7 @@ export const batchSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchBatchAccounts,
-    permissions: ['Microsoft.Batch/batchAccounts/read'],
+    rolePermissions: ['Microsoft.Batch/batchAccounts/read'],
   },
   {
     id: STEP_RM_BATCH_POOL,
@@ -217,7 +217,7 @@ export const batchSteps: AzureIntegrationStep[] = [
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchPools,
-    permissions: ['Microsoft.Batch/batchAccounts/pools/read'],
+    rolePermissions: ['Microsoft.Batch/batchAccounts/pools/read'],
   },
   {
     id: STEP_RM_BATCH_APPLICATION,
@@ -232,7 +232,7 @@ export const batchSteps: AzureIntegrationStep[] = [
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchApplications,
-    permissions: ['Microsoft.Batch/batchAccounts/applications/read'],
+    rolePermissions: ['Microsoft.Batch/batchAccounts/applications/read'],
   },
   {
     id: STEP_RM_BATCH_CERTIFICATE,
@@ -247,6 +247,6 @@ export const batchSteps: AzureIntegrationStep[] = [
       STEP_RM_BATCH_ACCOUNT,
     ],
     executionHandler: fetchBatchCertificates,
-    permissions: ['Microsoft.Batch/batchAccounts/certificates/read'],
+    rolePermissions: ['Microsoft.Batch/batchAccounts/certificates/read'],
   },
 ];

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -96,7 +96,7 @@ export const cdnSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchProfiles,
-    permissions: ['Microsoft.Cdn/profiles/read'],
+    rolePermissions: ['Microsoft.Cdn/profiles/read'],
   },
   {
     id: STEP_RM_CDN_ENDPOINTS,
@@ -108,6 +108,6 @@ export const cdnSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CDN_PROFILE],
     executionHandler: fetchEndpoints,
-    permissions: ['Microsoft.Cdn/profiles/endpoints/read'],
+    rolePermissions: ['Microsoft.Cdn/profiles/endpoints/read'],
   },
 ];

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { CdnClient } from './client';
@@ -87,9 +85,7 @@ export async function fetchEndpoints(
   );
 }
 
-export const cdnSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const cdnSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_CDN_PROFILE,
     name: 'CDN Profiles',
@@ -100,6 +96,7 @@ export const cdnSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchProfiles,
+    permissions: ['Microsoft.Cdn/profiles/read'],
   },
   {
     id: STEP_RM_CDN_ENDPOINTS,
@@ -111,5 +108,6 @@ export const cdnSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CDN_PROFILE],
     executionHandler: fetchEndpoints,
+    permissions: ['Microsoft.Cdn/profiles/endpoints/read'],
   },
 ];

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -96,7 +96,10 @@ export const cdnSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchProfiles,
-    rolePermissions: ['Microsoft.Cdn/profiles/read'],
+    rolePermissions: [
+      'Microsoft.Cdn/profiles/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_CDN_ENDPOINTS,
@@ -108,6 +111,9 @@ export const cdnSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CDN_PROFILE],
     executionHandler: fetchEndpoints,
-    rolePermissions: ['Microsoft.Cdn/profiles/endpoints/read'],
+    rolePermissions: [
+      'Microsoft.Cdn/profiles/endpoints/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/compute/index.ts
+++ b/src/steps/resource-manager/compute/index.ts
@@ -701,7 +701,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     relationships: [relationships.RESOURCE_GROUP_HAS_GALLERY],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchGalleries,
-    permissions: ['Microsoft.Compute/galleries/read'],
+    rolePermissions: ['Microsoft.Compute/galleries/read'],
   },
   {
     id: steps.SHARED_IMAGES,
@@ -710,7 +710,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     relationships: [relationships.IMAGE_GALLERY_CONTAINS_SHARED_IMAGE],
     dependsOn: [STEP_AD_ACCOUNT, steps.GALLERIES],
     executionHandler: fetchGalleryImages,
-    permissions: ['Microsoft.Compute/galleries/images/read'],
+    rolePermissions: ['Microsoft.Compute/galleries/images/read'],
   },
   {
     id: steps.SHARED_IMAGE_VERSIONS,
@@ -719,7 +719,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     relationships: [relationships.SHARED_IMAGE_HAS_VERSION],
     dependsOn: [STEP_AD_ACCOUNT, steps.SHARED_IMAGES],
     executionHandler: fetchGalleryImageVersions,
-    permissions: ['Microsoft.Compute/galleries/images/versions/read'],
+    rolePermissions: ['Microsoft.Compute/galleries/images/versions/read'],
   },
   {
     id: steps.SHARED_IMAGE_VERSION_SOURCE_RELATIONSHIPS,
@@ -748,7 +748,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchVirtualMachineImages,
-    permissions: ['Microsoft.Compute/images/read'],
+    rolePermissions: ['Microsoft.Compute/images/read'],
   },
   {
     id: STEP_RM_COMPUTE_VIRTUAL_MACHINE_DISKS,
@@ -765,7 +765,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchVirtualMachineDisks,
-    permissions: ['Microsoft.Compute/disks/read'],
+    rolePermissions: ['Microsoft.Compute/disks/read'],
   },
   {
     id: STEP_RM_COMPUTE_VIRTUAL_MACHINES,
@@ -784,7 +784,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchVirtualMachines,
-    permissions: ['Microsoft.Compute/virtualMachines/read'],
+    rolePermissions: ['Microsoft.Compute/virtualMachines/read'],
   },
   {
     id: steps.VIRTUAL_MACHINE_DISK_RELATIONSHIPS,
@@ -808,7 +808,7 @@ export const computeSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_COMPUTE_VIRTUAL_MACHINES],
     executionHandler: fetchVirtualMachineExtensions,
-    permissions: ['Microsoft.Compute/virtualMachines/extensions/read'],
+    rolePermissions: ['Microsoft.Compute/virtualMachines/extensions/read'],
   },
   {
     id: steps.VIRTUAL_MACHINE_IMAGE_RELATIONSHIPS,

--- a/src/steps/resource-manager/container-instance/index.ts
+++ b/src/steps/resource-manager/container-instance/index.ts
@@ -1,12 +1,10 @@
 import {
   Entity,
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   JobState,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { createAzureWebLinker } from '../../../azure';
@@ -218,9 +216,7 @@ export async function fetchContainerGroups(
   );
 }
 
-export const containerInstanceSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const containerInstanceSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_CONTAINER_GROUPS,
     name: 'Container Groups',
@@ -242,5 +238,6 @@ export const containerInstanceSteps: Step<
       storageSteps.STORAGE_ACCOUNTS,
     ],
     executionHandler: fetchContainerGroups,
+    permissions: ['Microsoft.ContainerInstance/containerGroups/read'],
   },
 ];

--- a/src/steps/resource-manager/container-instance/index.ts
+++ b/src/steps/resource-manager/container-instance/index.ts
@@ -238,6 +238,6 @@ export const containerInstanceSteps: AzureIntegrationStep[] = [
       storageSteps.STORAGE_ACCOUNTS,
     ],
     executionHandler: fetchContainerGroups,
-    permissions: ['Microsoft.ContainerInstance/containerGroups/read'],
+    rolePermissions: ['Microsoft.ContainerInstance/containerGroups/read'],
   },
 ];

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1ContainerRegistryManagementClient } from './client';
@@ -91,9 +89,7 @@ export async function fetchContainerRegistryWebhooks(
   );
 }
 
-export const containerRegistrySteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const containerRegistrySteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_CONTAINER_REGISTRIES,
     name: 'Container Registries',
@@ -109,6 +105,7 @@ export const containerRegistrySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchContainerRegistries,
+    permissions: ['Microsoft.ContainerRegistry/registries/read'],
   },
   {
     id: STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
@@ -117,5 +114,6 @@ export const containerRegistrySteps: Step<
     relationships: [ContainerRegistryRelationships.REGISTRY_HAS_WEBHOOK],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CONTAINER_REGISTRIES],
     executionHandler: fetchContainerRegistryWebhooks,
+    permissions: ['Microsoft.ContainerRegistry/registries/webhooks/read'],
   },
 ];

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -105,7 +105,7 @@ export const containerRegistrySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchContainerRegistries,
-    permissions: ['Microsoft.ContainerRegistry/registries/read'],
+    rolePermissions: ['Microsoft.ContainerRegistry/registries/read'],
   },
   {
     id: STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,
@@ -114,6 +114,6 @@ export const containerRegistrySteps: AzureIntegrationStep[] = [
     relationships: [ContainerRegistryRelationships.REGISTRY_HAS_WEBHOOK],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CONTAINER_REGISTRIES],
     executionHandler: fetchContainerRegistryWebhooks,
-    permissions: ['Microsoft.ContainerRegistry/registries/webhooks/read'],
+    rolePermissions: ['Microsoft.ContainerRegistry/registries/webhooks/read'],
   },
 ];

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -105,7 +105,10 @@ export const containerRegistrySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchContainerRegistries,
-    rolePermissions: ['Microsoft.ContainerRegistry/registries/read'],
+    rolePermissions: [
+      'Microsoft.ContainerRegistry/registries/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_CONTAINER_REGISTRY_WEBHOOKS,

--- a/src/steps/resource-manager/container-services/index.ts
+++ b/src/steps/resource-manager/container-services/index.ts
@@ -1,9 +1,5 @@
-import {
-  IntegrationStepExecutionContext,
-  Step,
-} from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationConfig, IntegrationStepContext } from '../../../types';
+import { AzureIntegrationStep, IntegrationStepContext } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
@@ -35,9 +31,7 @@ export async function fetchClusters(
   });
 }
 
-export const containerServicesSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const containerServicesSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_CONTAINER_SERVICES_CLUSTERS,
     name: 'Fetch Container Services Clusters',
@@ -45,5 +39,6 @@ export const containerServicesSteps: Step<
     relationships: [ContainerServicesRelationships.RESOURCE_GROUP_HAS_SERVICE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchClusters,
+    permissions: ['Microsoft.ContainerService/managedClusters/read'],
   },
 ];

--- a/src/steps/resource-manager/container-services/index.ts
+++ b/src/steps/resource-manager/container-services/index.ts
@@ -39,6 +39,6 @@ export const containerServicesSteps: AzureIntegrationStep[] = [
     relationships: [ContainerServicesRelationships.RESOURCE_GROUP_HAS_SERVICE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchClusters,
-    permissions: ['Microsoft.ContainerService/managedClusters/read'],
+    rolePermissions: ['Microsoft.ContainerService/managedClusters/read'],
   },
 ];

--- a/src/steps/resource-manager/cosmosdb/index.ts
+++ b/src/steps/resource-manager/cosmosdb/index.ts
@@ -88,6 +88,7 @@ export const cosmosdbSteps: AzureIntegrationStep[] = [
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchCosmosDBSqlDatabases,
     rolePermissions: [
+      'Microsoft.DocumentDB/databaseAccounts/read',
       'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/read',
     ],
   },

--- a/src/steps/resource-manager/cosmosdb/index.ts
+++ b/src/steps/resource-manager/cosmosdb/index.ts
@@ -87,6 +87,8 @@ export const cosmosdbSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchCosmosDBSqlDatabases,
-    permissions: ['Microsoft.DocumentDB/databaseAccounts/sqlDatabases/read'],
+    rolePermissions: [
+      'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/cosmosdb/index.ts
+++ b/src/steps/resource-manager/cosmosdb/index.ts
@@ -1,12 +1,10 @@
 import {
   createDirectRelationship,
   RelationshipClass,
-  Step,
-  IntegrationStepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { CosmosDBClient } from './client';
@@ -60,9 +58,7 @@ export async function fetchCosmosDBSqlDatabases(
   });
 }
 
-export const cosmosdbSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const cosmosdbSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_COSMOSDB_SQL_DATABASES,
     name: 'CosmosDB SQL Databases',
@@ -91,5 +87,6 @@ export const cosmosdbSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchCosmosDBSqlDatabases,
+    permissions: ['Microsoft.DocumentDB/databaseAccounts/sqlDatabases/read'],
   },
 ];

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -9,20 +9,14 @@ import { fetchMySQLDatabases } from './mysql';
 import { MySQLEntities, MySQLRelationships } from './mysql/constants';
 import { postgreSqlSteps } from './postgresql';
 import { sqlSteps } from './sql';
-import {
-  Step,
-  IntegrationStepExecutionContext,
-} from '@jupiterone/integration-sdk-core';
-import { IntegrationConfig } from '../../../types';
+import { AzureIntegrationStep } from '../../../types';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
 import {
   diagnosticSettingsEntitiesForResource,
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 
-export const databaseSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const databaseSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_DATABASE_MARIADB_DATABASES,
     name: 'MariaDB Databases',
@@ -38,6 +32,7 @@ export const databaseSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMariaDBDatabases,
+    permissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
   },
   {
     id: STEP_RM_DATABASE_MYSQL_DATABASES,
@@ -54,6 +49,7 @@ export const databaseSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMySQLDatabases,
+    permissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
   },
   ...postgreSqlSteps,
   ...sqlSteps,

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -32,7 +32,11 @@ export const databaseSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMariaDBDatabases,
-    rolePermissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
+    rolePermissions: [
+      'Microsoft.DBforMariaDB/servers/databases/read',
+      'Microsoft.DBforMariaDB/servers/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_DATABASE_MYSQL_DATABASES,
@@ -49,7 +53,11 @@ export const databaseSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMySQLDatabases,
-    rolePermissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
+    rolePermissions: [
+      'Microsoft.DBforMySQL/servers/read',
+      'Microsoft.DBforMySQL/servers/databases/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   ...postgreSqlSteps,
   ...sqlSteps,

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -32,7 +32,7 @@ export const databaseSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMariaDBDatabases,
-    permissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
+    rolePermissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
   },
   {
     id: STEP_RM_DATABASE_MYSQL_DATABASES,
@@ -49,7 +49,7 @@ export const databaseSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchMySQLDatabases,
-    permissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
+    rolePermissions: ['Microsoft.DBforMariaDB/servers/databases/read'],
   },
   ...postgreSqlSteps,
   ...sqlSteps,

--- a/src/steps/resource-manager/databases/postgresql/index.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.ts
@@ -1,13 +1,14 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStepExecutionContext,
   RelationshipClass,
-  Step,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../../azure';
-import { IntegrationConfig, IntegrationStepContext } from '../../../../types';
+import {
+  AzureIntegrationStep,
+  IntegrationStepContext,
+} from '../../../../types';
 import { getAccountEntity } from '../../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
 import { createDatabaseEntity, createDbServerEntity } from '../converters';
@@ -130,9 +131,7 @@ export async function fetchPostgreSqlServerFirewallRules(
   );
 }
 
-export const postgreSqlSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const postgreSqlSteps: AzureIntegrationStep[] = [
   {
     id: steps.SERVERS,
     name: 'PostgreSQL Servers',
@@ -148,6 +147,10 @@ export const postgreSqlSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPostgreSQLServers,
+    rolePermissions: [
+      'Microsoft.Insights/DiagnosticSettings/Read',
+      'Microsoft.DBforPostgreSQL/servers/read',
+    ],
   },
   {
     id: steps.DATABASES,
@@ -158,6 +161,7 @@ export const postgreSqlSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS],
     executionHandler: fetchPostgreSQLDatabases,
+    rolePermissions: ['Microsoft.DBforPostgreSQL/servers/databases/read'],
   },
   {
     id: steps.SERVER_FIREWALL_RULES,
@@ -168,5 +172,6 @@ export const postgreSqlSteps: Step<
     ],
     dependsOn: [steps.SERVERS],
     executionHandler: fetchPostgreSqlServerFirewallRules,
+    rolePermissions: ['Microsoft.DBforPostgreSQL/servers/firewallRules/read'],
   },
 ];

--- a/src/steps/resource-manager/databases/sql/index.ts
+++ b/src/steps/resource-manager/databases/sql/index.ts
@@ -1,13 +1,14 @@
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStepExecutionContext,
   RelationshipClass,
-  Step,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../../azure';
-import { IntegrationConfig, IntegrationStepContext } from '../../../../types';
+import {
+  AzureIntegrationStep,
+  IntegrationStepContext,
+} from '../../../../types';
 import { getAccountEntity } from '../../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
 import { createDatabaseEntity, createDbServerEntity } from '../converters';
@@ -206,9 +207,7 @@ export async function fetchSQLServerActiveDirectoryAdmins(
   );
 }
 
-export const sqlSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const sqlSteps: AzureIntegrationStep[] = [
   {
     id: steps.SERVERS,
     name: 'SQL Servers',
@@ -216,6 +215,7 @@ export const sqlSteps: Step<
     relationships: [relationships.RESOURCE_GROUP_HAS_SQL_SERVER],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchSQLServers,
+    rolePermissions: ['Microsoft.Sql/servers/read'],
   },
   {
     id: steps.SERVER_DIAGNOSTIC_SETTINGS,
@@ -226,6 +226,7 @@ export const sqlSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS],
     executionHandler: fetchSQLServerDiagnosticSettings,
+    rolePermissions: ['Microsoft.Insights/DiagnosticSettings/Read'],
   },
   {
     id: steps.DATABASES,
@@ -234,6 +235,7 @@ export const sqlSteps: Step<
     relationships: [relationships.SQL_SERVER_HAS_SQL_DATABASE],
     dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS],
     executionHandler: fetchSQLDatabases,
+    rolePermissions: ['Microsoft.Sql/servers/databases/read'],
   },
   {
     id: steps.SERVER_FIREWALL_RULES,
@@ -242,6 +244,7 @@ export const sqlSteps: Step<
     relationships: [relationships.SQL_SERVER_HAS_FIREWALL_RULE],
     dependsOn: [steps.SERVERS],
     executionHandler: fetchSQLServerFirewallRules,
+    rolePermissions: ['Microsoft.Sql/servers/firewallRules/read'],
   },
   {
     id: steps.SERVER_AD_ADMINS,
@@ -250,5 +253,6 @@ export const sqlSteps: Step<
     relationships: [relationships.SQL_SERVER_HAS_AD_ADMIN],
     dependsOn: [steps.SERVERS],
     executionHandler: fetchSQLServerActiveDirectoryAdmins,
+    rolePermissions: ['Microsoft.Sql/servers/administrators/read'],
   },
 ];

--- a/src/steps/resource-manager/dns/index.ts
+++ b/src/steps/resource-manager/dns/index.ts
@@ -94,7 +94,7 @@ export const dnsSteps: AzureIntegrationStep[] = [
     relationships: [DnsRelationships.RESOURCE_GROUP_HAS_ZONE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchZones,
-    permissions: ['Microsoft.Network/dnszones/read'],
+    rolePermissions: ['Microsoft.Network/dnszones/read'],
   },
   {
     id: STEP_RM_DNS_RECORD_SETS,
@@ -103,6 +103,6 @@ export const dnsSteps: AzureIntegrationStep[] = [
     relationships: [DnsRelationships.ZONE_HAS_RECORD_SET],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_DNS_ZONES],
     executionHandler: fetchRecordSets,
-    permissions: ['Microsoft.Network/dnszones/recordsets/read'],
+    rolePermissions: ['Microsoft.Network/dnszones/recordsets/read'],
   },
 ];

--- a/src/steps/resource-manager/dns/index.ts
+++ b/src/steps/resource-manager/dns/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1DnsManagementClient } from './client';
@@ -88,9 +86,7 @@ export async function fetchRecordSets(
   );
 }
 
-export const dnsSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const dnsSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_DNS_ZONES,
     name: 'DNS Zones',
@@ -98,6 +94,7 @@ export const dnsSteps: Step<
     relationships: [DnsRelationships.RESOURCE_GROUP_HAS_ZONE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchZones,
+    permissions: ['Microsoft.Network/dnszones/read'],
   },
   {
     id: STEP_RM_DNS_RECORD_SETS,
@@ -106,5 +103,6 @@ export const dnsSteps: Step<
     relationships: [DnsRelationships.ZONE_HAS_RECORD_SET],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_DNS_ZONES],
     executionHandler: fetchRecordSets,
+    permissions: ['Microsoft.Network/dnszones/recordsets/read'],
   },
 ];

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -241,7 +241,7 @@ export const eventGridSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridDomains,
-    permissions: ['Microsoft.EventGrid/domains/read'],
+    rolePermissions: ['Microsoft.EventGrid/domains/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
@@ -254,7 +254,7 @@ export const eventGridSteps: AzureIntegrationStep[] = [
       STEP_RM_EVENT_GRID_DOMAINS,
     ],
     executionHandler: fetchEventGridDomainTopics,
-    permissions: ['Microsoft.EventGrid/domains/topics/read'],
+    rolePermissions: ['Microsoft.EventGrid/domains/topics/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_DOMAIN_TOPIC_SUBSCRIPTIONS,
@@ -268,7 +268,9 @@ export const eventGridSteps: AzureIntegrationStep[] = [
       STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
     ],
     executionHandler: fetchEventGridDomainTopicSubscriptions,
-    permissions: ['Microsoft.EventGrid/domains/topics/eventSubscriptions/read'],
+    rolePermissions: [
+      'Microsoft.EventGrid/domains/topics/eventSubscriptions/read',
+    ],
   },
   {
     id: STEP_RM_EVENT_GRID_TOPICS,
@@ -283,7 +285,7 @@ export const eventGridSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridTopics,
-    permissions: ['Microsoft.EventGrid/topics/read'],
+    rolePermissions: ['Microsoft.EventGrid/topics/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS,
@@ -296,6 +298,6 @@ export const eventGridSteps: AzureIntegrationStep[] = [
       STEP_RM_EVENT_GRID_TOPICS,
     ],
     executionHandler: fetchEventGridTopicSubscriptions,
-    permissions: ['Microsoft.EventGrid/topics/eventSubscriptions/read'],
+    rolePermissions: ['Microsoft.EventGrid/topics/eventSubscriptions/read'],
   },
 ];

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -241,7 +241,10 @@ export const eventGridSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridDomains,
-    rolePermissions: ['Microsoft.EventGrid/domains/read'],
+    rolePermissions: [
+      'Microsoft.EventGrid/domains/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
@@ -285,7 +288,10 @@ export const eventGridSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridTopics,
-    rolePermissions: ['Microsoft.EventGrid/topics/read'],
+    rolePermissions: [
+      'Microsoft.EventGrid/topics/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS,

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -1,11 +1,9 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
@@ -227,9 +225,7 @@ export async function fetchEventGridTopicSubscriptions(
   );
 }
 
-export const eventGridSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const eventGridSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_EVENT_GRID_DOMAINS,
     name: 'Event Grid Domains',
@@ -245,6 +241,7 @@ export const eventGridSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridDomains,
+    permissions: ['Microsoft.EventGrid/domains/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
@@ -257,6 +254,7 @@ export const eventGridSteps: Step<
       STEP_RM_EVENT_GRID_DOMAINS,
     ],
     executionHandler: fetchEventGridDomainTopics,
+    permissions: ['Microsoft.EventGrid/domains/topics/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_DOMAIN_TOPIC_SUBSCRIPTIONS,
@@ -270,6 +268,7 @@ export const eventGridSteps: Step<
       STEP_RM_EVENT_GRID_DOMAIN_TOPICS,
     ],
     executionHandler: fetchEventGridDomainTopicSubscriptions,
+    permissions: ['Microsoft.EventGrid/domains/topics/eventSubscriptions/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_TOPICS,
@@ -284,6 +283,7 @@ export const eventGridSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchEventGridTopics,
+    permissions: ['Microsoft.EventGrid/topics/read'],
   },
   {
     id: STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS,
@@ -296,5 +296,6 @@ export const eventGridSteps: Step<
       STEP_RM_EVENT_GRID_TOPICS,
     ],
     executionHandler: fetchEventGridTopicSubscriptions,
+    permissions: ['Microsoft.EventGrid/topics/eventSubscriptions/read'],
   },
 ];

--- a/src/steps/resource-manager/frontdoor/index.ts
+++ b/src/steps/resource-manager/frontdoor/index.ts
@@ -2,12 +2,10 @@ import { FrontDoor } from '@azure/arm-frontdoor/esm/models';
 import {
   createDirectRelationship,
   getRawData,
-  IntegrationStepExecutionContext,
   RelationshipClass,
-  Step,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationConfig, IntegrationStepContext } from '../../../types';
+import { AzureIntegrationStep, IntegrationStepContext } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
@@ -161,9 +159,7 @@ async function fetchFrontendEndpoints(
   );
 }
 
-export const frontdoorSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const frontdoorSteps: AzureIntegrationStep[] = [
   {
     id: FrontDoorStepIds.FETCH_FRONTDOORS,
     name: 'Fetch FrontDoors',
@@ -171,6 +167,7 @@ export const frontdoorSteps: Step<
     relationships: [FrontDoorRelationships.RESOURCE_GROUP_HAS_FRONTDOOR],
     executionHandler: fetchFrontDoors,
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    permissions: ['Microsoft.Network/frontDoors/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_RULES_ENGINES,
@@ -179,6 +176,7 @@ export const frontdoorSteps: Step<
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_RULES_ENGINE],
     executionHandler: fetchRulesEngines,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
+    permissions: ['Microsoft.Network/frontDoors/rulesEngines/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_ROUTING_RULES,
@@ -187,6 +185,7 @@ export const frontdoorSteps: Step<
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_ROUTING_RULE],
     executionHandler: fetchRoutingRules,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
+    permissions: ['Microsoft.Network/frontDoors/routingRules/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_BACKEND_POOLS,
@@ -195,6 +194,7 @@ export const frontdoorSteps: Step<
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_BACKEND_POOL],
     executionHandler: fetchBackendPools,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
+    permissions: ['Microsoft.Network/frontDoors/backendPools/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_FRONTEND_ENDPOINTS,
@@ -203,5 +203,6 @@ export const frontdoorSteps: Step<
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_FRONTEND_ENDPOINT],
     executionHandler: fetchFrontendEndpoints,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
+    permissions: ['Microsoft.Network/frontDoors/frontendEndpoints/read'],
   },
 ];

--- a/src/steps/resource-manager/frontdoor/index.ts
+++ b/src/steps/resource-manager/frontdoor/index.ts
@@ -176,7 +176,6 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_RULES_ENGINE],
     executionHandler: fetchRulesEngines,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    rolePermissions: ['Microsoft.Network/frontDoors/rulesEngines/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_ROUTING_RULES,
@@ -185,7 +184,6 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_ROUTING_RULE],
     executionHandler: fetchRoutingRules,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    rolePermissions: ['Microsoft.Network/frontDoors/routingRules/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_BACKEND_POOLS,
@@ -194,7 +192,6 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_BACKEND_POOL],
     executionHandler: fetchBackendPools,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    rolePermissions: ['Microsoft.Network/frontDoors/backendPools/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_FRONTEND_ENDPOINTS,
@@ -203,6 +200,5 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_FRONTEND_ENDPOINT],
     executionHandler: fetchFrontendEndpoints,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    rolePermissions: ['Microsoft.Network/frontDoors/frontendEndpoints/read'],
   },
 ];

--- a/src/steps/resource-manager/frontdoor/index.ts
+++ b/src/steps/resource-manager/frontdoor/index.ts
@@ -167,7 +167,7 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.RESOURCE_GROUP_HAS_FRONTDOOR],
     executionHandler: fetchFrontDoors,
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
-    permissions: ['Microsoft.Network/frontDoors/read'],
+    rolePermissions: ['Microsoft.Network/frontDoors/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_RULES_ENGINES,
@@ -176,7 +176,7 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_RULES_ENGINE],
     executionHandler: fetchRulesEngines,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    permissions: ['Microsoft.Network/frontDoors/rulesEngines/read'],
+    rolePermissions: ['Microsoft.Network/frontDoors/rulesEngines/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_ROUTING_RULES,
@@ -185,7 +185,7 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_ROUTING_RULE],
     executionHandler: fetchRoutingRules,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    permissions: ['Microsoft.Network/frontDoors/routingRules/read'],
+    rolePermissions: ['Microsoft.Network/frontDoors/routingRules/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_BACKEND_POOLS,
@@ -194,7 +194,7 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_BACKEND_POOL],
     executionHandler: fetchBackendPools,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    permissions: ['Microsoft.Network/frontDoors/backendPools/read'],
+    rolePermissions: ['Microsoft.Network/frontDoors/backendPools/read'],
   },
   {
     id: FrontDoorStepIds.FETCH_FRONTEND_ENDPOINTS,
@@ -203,6 +203,6 @@ export const frontdoorSteps: AzureIntegrationStep[] = [
     relationships: [FrontDoorRelationships.FRONTDOOR_HAS_FRONTEND_ENDPOINT],
     executionHandler: fetchFrontendEndpoints,
     dependsOn: [STEP_AD_ACCOUNT, FrontDoorStepIds.FETCH_FRONTDOORS],
-    permissions: ['Microsoft.Network/frontDoors/frontendEndpoints/read'],
+    rolePermissions: ['Microsoft.Network/frontDoors/frontendEndpoints/read'],
   },
 ];

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -205,7 +205,7 @@ export const keyvaultSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchKeyVaults,
-    permissions: ['Microsoft.KeyVault/vaults/read'],
+    rolePermissions: ['Microsoft.KeyVault/vaults/read'],
   },
   {
     id: KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS,
@@ -222,7 +222,7 @@ export const keyvaultSteps: AzureIntegrationStep[] = [
     relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_KEY],
     dependsOn: [STEP_RM_KEYVAULT_VAULTS],
     executionHandler: fetchKeyVaultKeys,
-    permissions: ['Microsoft.KeyVault/vaults/keys/read'],
+    rolePermissions: ['Microsoft.KeyVault/vaults/keys/read'],
   },
   {
     id: STEP_RM_KEYVAULT_SECRETS,
@@ -231,6 +231,6 @@ export const keyvaultSteps: AzureIntegrationStep[] = [
     relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_SECRET],
     dependsOn: [STEP_RM_KEYVAULT_VAULTS],
     executionHandler: fetchKeyVaultSecrets,
-    permissions: ['Microsoft.KeyVault/vaults/secrets/read'],
+    rolePermissions: ['Microsoft.KeyVault/vaults/secrets/read'],
   },
 ];

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -205,7 +205,10 @@ export const keyvaultSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchKeyVaults,
-    rolePermissions: ['Microsoft.KeyVault/vaults/read'],
+    rolePermissions: [
+      'Microsoft.KeyVault/vaults/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS,

--- a/src/steps/resource-manager/key-vault/index.ts
+++ b/src/steps/resource-manager/key-vault/index.ts
@@ -1,14 +1,12 @@
 import {
   createDirectRelationship,
   RelationshipClass,
-  Step,
-  IntegrationStepExecutionContext,
   getRawData,
   createMappedRelationship,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import {
   ACCOUNT_ENTITY_TYPE,
   STEP_AD_ACCOUNT,
@@ -183,9 +181,7 @@ export async function fetchKeyVaultSecrets(
   );
 }
 
-export const keyvaultSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const keyvaultSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_KEYVAULT_VAULTS,
     name: 'Key Vaults',
@@ -209,6 +205,7 @@ export const keyvaultSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchKeyVaults,
+    permissions: ['Microsoft.KeyVault/vaults/read'],
   },
   {
     id: KeyVaultStepIds.KEY_VAULT_PRINCIPAL_RELATIONSHIPS,
@@ -225,6 +222,7 @@ export const keyvaultSteps: Step<
     relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_KEY],
     dependsOn: [STEP_RM_KEYVAULT_VAULTS],
     executionHandler: fetchKeyVaultKeys,
+    permissions: ['Microsoft.KeyVault/vaults/keys/read'],
   },
   {
     id: STEP_RM_KEYVAULT_SECRETS,
@@ -233,5 +231,6 @@ export const keyvaultSteps: Step<
     relationships: [KeyVaultRelationships.KEY_VAULT_CONTAINS_SECRET],
     dependsOn: [STEP_RM_KEYVAULT_VAULTS],
     executionHandler: fetchKeyVaultSecrets,
+    permissions: ['Microsoft.KeyVault/vaults/secrets/read'],
   },
 ];

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -1,6 +1,4 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   createMappedRelationship,
@@ -10,7 +8,11 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { AzureWebLinker, createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import {
+  IntegrationStepContext,
+  IntegrationConfig,
+  AzureIntegrationStep,
+} from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ManagementGroupClient } from './client';
@@ -136,9 +138,7 @@ export async function getGraphObjectsForManagementGroup(options: {
   return { managementGroup, managementGroupEntity };
 }
 
-export const managementGroupSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const managementGroupSteps: AzureIntegrationStep[] = [
   {
     id: ManagementGroupSteps.MANAGEMENT_GROUPS,
     name: 'Management Groups',
@@ -152,5 +152,6 @@ export const managementGroupSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchManagementGroups,
+    permissions: ['Microsoft.Management/managementGroups/read'],
   },
 ];

--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -152,6 +152,6 @@ export const managementGroupSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchManagementGroups,
-    permissions: ['Microsoft.Management/managementGroups/read'],
+    rolePermissions: ['Microsoft.Management/managementGroups/read'],
   },
 ];

--- a/src/steps/resource-manager/monitor/index.ts
+++ b/src/steps/resource-manager/monitor/index.ts
@@ -163,7 +163,7 @@ export const monitorSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [subscriptionSteps.SUBSCRIPTION, storageSteps.STORAGE_ACCOUNTS],
     executionHandler: fetchLogProfiles,
-    permissions: ['Microsoft.Insights/LogProfiles/Read'],
+    rolePermissions: ['Microsoft.Insights/LogProfiles/Read'],
   },
   {
     id: MonitorSteps.MONITOR_ACTIVITY_LOG_ALERTS,
@@ -172,7 +172,7 @@ export const monitorSteps: AzureIntegrationStep[] = [
     relationships: [MonitorRelationships.RESOURCE_GROUP_HAS_ACTIVITY_LOG_ALERT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchActivityLogAlerts,
-    permissions: ['Microsoft.Insights/ActivityLogAlerts/Read'],
+    rolePermissions: ['Microsoft.Insights/ActivityLogAlerts/Read'],
   },
   {
     id: MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS,

--- a/src/steps/resource-manager/monitor/index.ts
+++ b/src/steps/resource-manager/monitor/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { steps as storageSteps } from '../storage/constants';
@@ -154,9 +152,7 @@ export async function buildActivityLogScopeRelationships(
   );
 }
 
-export const monitorSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const monitorSteps: AzureIntegrationStep[] = [
   {
     id: MonitorSteps.MONITOR_LOG_PROFILES,
     name: 'Monitor Log Profiles',
@@ -167,6 +163,7 @@ export const monitorSteps: Step<
     ],
     dependsOn: [subscriptionSteps.SUBSCRIPTION, storageSteps.STORAGE_ACCOUNTS],
     executionHandler: fetchLogProfiles,
+    permissions: ['Microsoft.Insights/LogProfiles/Read'],
   },
   {
     id: MonitorSteps.MONITOR_ACTIVITY_LOG_ALERTS,
@@ -175,6 +172,7 @@ export const monitorSteps: Step<
     relationships: [MonitorRelationships.RESOURCE_GROUP_HAS_ACTIVITY_LOG_ALERT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchActivityLogAlerts,
+    permissions: ['Microsoft.Insights/ActivityLogAlerts/Read'],
   },
   {
     id: MonitorSteps.MONITOR_ACTIVITY_LOG_ALERT_SCOPE_RELATIONSHIPS,

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -758,7 +758,7 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPublicIPAddresses,
-    permissions: ['Microsoft.Network/publicIPAddresses/read'],
+    rolePermissions: ['Microsoft.Network/publicIPAddresses/read'],
   },
   {
     id: STEP_RM_NETWORK_INTERFACES,
@@ -773,7 +773,7 @@ export const networkSteps: AzureIntegrationStep[] = [
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchNetworkInterfaces,
-    permissions: ['Microsoft.Network/networkInterfaces/read'],
+    rolePermissions: ['Microsoft.Network/networkInterfaces/read'],
   },
   {
     id: STEP_RM_NETWORK_VIRTUAL_NETWORKS,
@@ -797,7 +797,7 @@ export const networkSteps: AzureIntegrationStep[] = [
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchVirtualNetworks,
-    permissions: ['Microsoft.Network/virtualNetworks/read'],
+    rolePermissions: ['Microsoft.Network/virtualNetworks/read'],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUPS,
@@ -820,7 +820,7 @@ export const networkSteps: AzureIntegrationStep[] = [
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchNetworkSecurityGroups,
-    permissions: ['Microsoft.Network/networkSecurityGroups/read'],
+    rolePermissions: ['Microsoft.Network/networkSecurityGroups/read'],
   },
   {
     id: STEP_RM_NETWORK_LOAD_BALANCERS,
@@ -838,7 +838,7 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchLoadBalancers,
-    permissions: ['Microsoft.Network/loadBalancers/read'],
+    rolePermissions: ['Microsoft.Network/loadBalancers/read'],
   },
   {
     id: STEP_RM_NETWORK_FIREWALLS,
@@ -855,7 +855,7 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAzureFirewalls,
-    permissions: ['Microsoft.Network/azurefirewalls/read'],
+    rolePermissions: ['Microsoft.Network/azurefirewalls/read'],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUP_RULE_RELATIONSHIPS,
@@ -881,7 +881,7 @@ export const networkSteps: AzureIntegrationStep[] = [
     relationships: [NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_WATCHER],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchNetworkWatchers,
-    permissions: ['Microsoft.Network/networkWatchers/read'],
+    rolePermissions: ['Microsoft.Network/networkWatchers/read'],
   },
   {
     id: STEP_RM_NETWORK_PRIVATE_ENDPOINTS,
@@ -890,7 +890,7 @@ export const networkSteps: AzureIntegrationStep[] = [
     relationships: [NetworkRelationships.RESOURCE_GROUP_HAS_PRIVATE_ENDPOINT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPrivateEndpoints,
-    permissions: ['Microsoft.Network/privateEndpoints/read'],
+    rolePermissions: ['Microsoft.Network/privateEndpoints/read'],
   },
   {
     id: STEP_RM_NETWORK_PRIVATE_ENDPOINT_SUBNET_RELATIONSHIPS,
@@ -948,6 +948,6 @@ export const networkSteps: AzureIntegrationStep[] = [
       storageSteps.STORAGE_ACCOUNTS,
     ],
     executionHandler: fetchNetworkSecurityGroupFlowLogs,
-    permissions: ['Microsoft.Network/networkWatchers/flowLogs/read'],
+    rolePermissions: ['Microsoft.Network/networkWatchers/flowLogs/read'],
   },
 ];

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -758,7 +758,10 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPublicIPAddresses,
-    rolePermissions: ['Microsoft.Network/publicIPAddresses/read'],
+    rolePermissions: [
+      'Microsoft.Network/publicIPAddresses/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_NETWORK_INTERFACES,
@@ -797,7 +800,10 @@ export const networkSteps: AzureIntegrationStep[] = [
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchVirtualNetworks,
-    rolePermissions: ['Microsoft.Network/virtualNetworks/read'],
+    rolePermissions: [
+      'Microsoft.Network/virtualNetworks/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUPS,
@@ -820,7 +826,10 @@ export const networkSteps: AzureIntegrationStep[] = [
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchNetworkSecurityGroups,
-    rolePermissions: ['Microsoft.Network/networkSecurityGroups/read'],
+    rolePermissions: [
+      'Microsoft.Network/networkSecurityGroups/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_NETWORK_LOAD_BALANCERS,
@@ -838,7 +847,10 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchLoadBalancers,
-    rolePermissions: ['Microsoft.Network/loadBalancers/read'],
+    rolePermissions: [
+      'Microsoft.Network/loadBalancers/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_NETWORK_FIREWALLS,
@@ -855,7 +867,10 @@ export const networkSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAzureFirewalls,
-    rolePermissions: ['Microsoft.Network/azurefirewalls/read'],
+    rolePermissions: [
+      'Microsoft.Network/azurefirewalls/read',
+      'Microsoft.Insights/DiagnosticSettings/Read',
+    ],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUP_RULE_RELATIONSHIPS,

--- a/src/steps/resource-manager/network/index.ts
+++ b/src/steps/resource-manager/network/index.ts
@@ -10,8 +10,6 @@ import {
   Entity,
   getRawData,
   Relationship,
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   IntegrationError,
@@ -20,7 +18,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { NetworkClient } from './client';
@@ -744,9 +742,7 @@ export async function fetchNetworkSecurityGroupFlowLogs(
   );
 }
 
-export const networkSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const networkSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_NETWORK_PUBLIC_IP_ADDRESSES,
     name: 'Public IP Addresses',
@@ -762,6 +758,7 @@ export const networkSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPublicIPAddresses,
+    permissions: ['Microsoft.Network/publicIPAddresses/read'],
   },
   {
     id: STEP_RM_NETWORK_INTERFACES,
@@ -776,6 +773,7 @@ export const networkSteps: Step<
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchNetworkInterfaces,
+    permissions: ['Microsoft.Network/networkInterfaces/read'],
   },
   {
     id: STEP_RM_NETWORK_VIRTUAL_NETWORKS,
@@ -799,6 +797,7 @@ export const networkSteps: Step<
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchVirtualNetworks,
+    permissions: ['Microsoft.Network/virtualNetworks/read'],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUPS,
@@ -821,6 +820,7 @@ export const networkSteps: Step<
       STEP_RM_RESOURCES_RESOURCE_GROUPS,
     ],
     executionHandler: fetchNetworkSecurityGroups,
+    permissions: ['Microsoft.Network/networkSecurityGroups/read'],
   },
   {
     id: STEP_RM_NETWORK_LOAD_BALANCERS,
@@ -838,6 +838,7 @@ export const networkSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchLoadBalancers,
+    permissions: ['Microsoft.Network/loadBalancers/read'],
   },
   {
     id: STEP_RM_NETWORK_FIREWALLS,
@@ -854,6 +855,7 @@ export const networkSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAzureFirewalls,
+    permissions: ['Microsoft.Network/azurefirewalls/read'],
   },
   {
     id: STEP_RM_NETWORK_SECURITY_GROUP_RULE_RELATIONSHIPS,
@@ -879,6 +881,7 @@ export const networkSteps: Step<
     relationships: [NetworkRelationships.RESOURCE_GROUP_HAS_NETWORK_WATCHER],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchNetworkWatchers,
+    permissions: ['Microsoft.Network/networkWatchers/read'],
   },
   {
     id: STEP_RM_NETWORK_PRIVATE_ENDPOINTS,
@@ -887,6 +890,7 @@ export const networkSteps: Step<
     relationships: [NetworkRelationships.RESOURCE_GROUP_HAS_PRIVATE_ENDPOINT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPrivateEndpoints,
+    permissions: ['Microsoft.Network/privateEndpoints/read'],
   },
   {
     id: STEP_RM_NETWORK_PRIVATE_ENDPOINT_SUBNET_RELATIONSHIPS,
@@ -944,5 +948,6 @@ export const networkSteps: Step<
       storageSteps.STORAGE_ACCOUNTS,
     ],
     executionHandler: fetchNetworkSecurityGroupFlowLogs,
+    permissions: ['Microsoft.Network/networkWatchers/flowLogs/read'],
   },
 ];

--- a/src/steps/resource-manager/policy-insights/index.ts
+++ b/src/steps/resource-manager/policy-insights/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   getRawData,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
@@ -156,9 +154,7 @@ export async function buildPolicyStateResourceRelationships(
   );
 }
 
-export const policyInsightSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const policyInsightSteps: AzureIntegrationStep[] = [
   {
     id: PolicyInsightSteps.SUBSCRIPTION_POLICY_STATES,
     name: 'Policy States',
@@ -166,6 +162,7 @@ export const policyInsightSteps: Step<
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchLatestPolicyStatesForSubscription,
+    permissions: ['Microsoft.PolicyInsights/policyStates/summarize/read'],
   },
   {
     id: PolicyInsightSteps.POLICY_STATE_TO_ASSIGNMENT_RELATIONSHIPS,

--- a/src/steps/resource-manager/policy-insights/index.ts
+++ b/src/steps/resource-manager/policy-insights/index.ts
@@ -162,7 +162,7 @@ export const policyInsightSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchLatestPolicyStatesForSubscription,
-    permissions: ['Microsoft.PolicyInsights/policyStates/summarize/read'],
+    rolePermissions: ['Microsoft.PolicyInsights/policyStates/summarize/read'],
   },
   {
     id: PolicyInsightSteps.POLICY_STATE_TO_ASSIGNMENT_RELATIONSHIPS,

--- a/src/steps/resource-manager/policy-insights/index.ts
+++ b/src/steps/resource-manager/policy-insights/index.ts
@@ -162,7 +162,9 @@ export const policyInsightSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchLatestPolicyStatesForSubscription,
-    rolePermissions: ['Microsoft.PolicyInsights/policyStates/summarize/read'],
+    rolePermissions: [
+      'Microsoft.PolicyInsights/policyStates/queryResults/read',
+    ],
   },
   {
     id: PolicyInsightSteps.POLICY_STATE_TO_ASSIGNMENT_RELATIONSHIPS,

--- a/src/steps/resource-manager/policy/index.ts
+++ b/src/steps/resource-manager/policy/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { PolicyEntities, PolicyRelationships, PolicySteps } from './constants';
@@ -109,9 +107,7 @@ export async function fetchPolicyDefinitionsForAssignments(
   );
 }
 
-export const policySteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const policySteps: AzureIntegrationStep[] = [
   {
     id: PolicySteps.POLICY_ASSIGNMENTS,
     name: 'Policy Assignments',
@@ -119,6 +115,7 @@ export const policySteps: Step<
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchPolicyAssignments,
+    permissions: ['Microsoft.Authorization/policyAssignments/read'],
   },
   {
     id: PolicySteps.POLICY_ASSIGNMENT_SCOPE_RELATIONSHIPS,
@@ -145,5 +142,6 @@ export const policySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, PolicySteps.POLICY_ASSIGNMENTS],
     executionHandler: fetchPolicyDefinitionsForAssignments,
+    permissions: ['Microsoft.Authorization/policyDefinitions/read'],
   },
 ];

--- a/src/steps/resource-manager/policy/index.ts
+++ b/src/steps/resource-manager/policy/index.ts
@@ -115,7 +115,7 @@ export const policySteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchPolicyAssignments,
-    permissions: ['Microsoft.Authorization/policyAssignments/read'],
+    rolePermissions: ['Microsoft.Authorization/policyAssignments/read'],
   },
   {
     id: PolicySteps.POLICY_ASSIGNMENT_SCOPE_RELATIONSHIPS,
@@ -142,6 +142,6 @@ export const policySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, PolicySteps.POLICY_ASSIGNMENTS],
     executionHandler: fetchPolicyDefinitionsForAssignments,
-    permissions: ['Microsoft.Authorization/policyDefinitions/read'],
+    rolePermissions: ['Microsoft.Authorization/policyDefinitions/read'],
   },
 ];

--- a/src/steps/resource-manager/policy/index.ts
+++ b/src/steps/resource-manager/policy/index.ts
@@ -142,6 +142,9 @@ export const policySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, PolicySteps.POLICY_ASSIGNMENTS],
     executionHandler: fetchPolicyDefinitionsForAssignments,
-    rolePermissions: ['Microsoft.Authorization/policyDefinitions/read'],
+    rolePermissions: [
+      'Microsoft.Authorization/policyDefinitions/read',
+      'Microsoft.Authorization/policySetDefinitions/read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/private-dns/index.ts
+++ b/src/steps/resource-manager/private-dns/index.ts
@@ -96,7 +96,7 @@ export const privateDnsSteps: AzureIntegrationStep[] = [
     relationships: [PrivateDnsRelationships.RESOURCE_GROUP_HAS_ZONE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPrivateZones,
-    permissions: ['Microsoft.Network/privateDnsZones/read'],
+    rolePermissions: ['Microsoft.Network/privateDnsZones/read'],
   },
   {
     id: STEP_RM_PRIVATE_DNS_RECORD_SETS,
@@ -105,6 +105,6 @@ export const privateDnsSteps: AzureIntegrationStep[] = [
     relationships: [PrivateDnsRelationships.ZONE_HAS_RECORD_SET],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_PRIVATE_DNS_ZONES],
     executionHandler: fetchPrivateRecordSets,
-    permissions: ['Microsoft.Network/privateDnsZones/recordsets/read'],
+    rolePermissions: ['Microsoft.Network/privateDnsZones/recordsets/read'],
   },
 ];

--- a/src/steps/resource-manager/private-dns/index.ts
+++ b/src/steps/resource-manager/private-dns/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { J1PrivateDnsManagementClient } from './client';
@@ -90,9 +88,7 @@ export async function fetchPrivateRecordSets(
   );
 }
 
-export const privateDnsSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const privateDnsSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_PRIVATE_DNS_ZONES,
     name: 'Private DNS Zones',
@@ -100,6 +96,7 @@ export const privateDnsSteps: Step<
     relationships: [PrivateDnsRelationships.RESOURCE_GROUP_HAS_ZONE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchPrivateZones,
+    permissions: ['Microsoft.Network/privateDnsZones/read'],
   },
   {
     id: STEP_RM_PRIVATE_DNS_RECORD_SETS,
@@ -108,5 +105,6 @@ export const privateDnsSteps: Step<
     relationships: [PrivateDnsRelationships.ZONE_HAS_RECORD_SET],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_PRIVATE_DNS_ZONES],
     executionHandler: fetchPrivateRecordSets,
+    permissions: ['Microsoft.Network/privateDnsZones/recordsets/read'],
   },
 ];

--- a/src/steps/resource-manager/redis-cache/index.ts
+++ b/src/steps/resource-manager/redis-cache/index.ts
@@ -162,7 +162,7 @@ export const redisCacheSteps: AzureIntegrationStep[] = [
     relationships: [RedisCacheRelationships.RESOURCE_GROUP_HAS_REDIS_CACHE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchRedisCaches,
-    permissions: ['Microsoft.Cache/redis/read'],
+    rolePermissions: ['Microsoft.Cache/redis/read'],
   },
   {
     id: STEP_RM_REDIS_FIREWALL_RULES,
@@ -171,7 +171,7 @@ export const redisCacheSteps: AzureIntegrationStep[] = [
     relationships: [RedisCacheRelationships.REDIS_CACHE_HAS_FIREWALL_RULE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_REDIS_CACHES],
     executionHandler: fetchRedisFirewallRules,
-    permissions: ['Microsoft.Cache/redis/firewallRules/read'],
+    rolePermissions: ['Microsoft.Cache/redis/firewallRules/read'],
   },
   {
     id: STEP_RM_REDIS_LINKED_SERVERS,
@@ -182,6 +182,6 @@ export const redisCacheSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_REDIS_CACHES],
     executionHandler: fetchRedisLinkedServers,
-    permissions: ['Microsoft.Cache/redis/linkedServers/read'],
+    rolePermissions: ['Microsoft.Cache/redis/linkedServers/read'],
   },
 ];

--- a/src/steps/resource-manager/redis-cache/index.ts
+++ b/src/steps/resource-manager/redis-cache/index.ts
@@ -1,10 +1,8 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { RedisCacheClient } from './client';
@@ -156,9 +154,7 @@ export async function fetchRedisLinkedServers(
   );
 }
 
-export const redisCacheSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const redisCacheSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_REDIS_CACHES,
     name: 'Redis Caches',
@@ -166,6 +162,7 @@ export const redisCacheSteps: Step<
     relationships: [RedisCacheRelationships.RESOURCE_GROUP_HAS_REDIS_CACHE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchRedisCaches,
+    permissions: ['Microsoft.Cache/redis/read'],
   },
   {
     id: STEP_RM_REDIS_FIREWALL_RULES,
@@ -174,6 +171,7 @@ export const redisCacheSteps: Step<
     relationships: [RedisCacheRelationships.REDIS_CACHE_HAS_FIREWALL_RULE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_REDIS_CACHES],
     executionHandler: fetchRedisFirewallRules,
+    permissions: ['Microsoft.Cache/redis/firewallRules/read'],
   },
   {
     id: STEP_RM_REDIS_LINKED_SERVERS,
@@ -184,5 +182,6 @@ export const redisCacheSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_REDIS_CACHES],
     executionHandler: fetchRedisLinkedServers,
+    permissions: ['Microsoft.Cache/redis/linkedServers/read'],
   },
 ];

--- a/src/steps/resource-manager/resources/index.ts
+++ b/src/steps/resource-manager/resources/index.ts
@@ -155,7 +155,7 @@ export const resourcesSteps: AzureIntegrationStep[] = [
     relationships: [SUBSCRIPTION_RESOURCE_GROUP_RELATIONSHIP_METADATA],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchResourceGroups,
-    permissions: ['Microsoft.Resources/subscriptions/resourceGroups/read'],
+    rolePermissions: ['Microsoft.Resources/subscriptions/resourceGroups/read'],
   },
   {
     id: STEP_RM_RESOURCES_RESOURCE_LOCKS,
@@ -164,7 +164,7 @@ export const resourcesSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchResourceGroupLocks,
-    permissions: ['Microsoft.Authorization/locks/read'],
+    rolePermissions: ['Microsoft.Authorization/locks/read'],
   },
   {
     id: STEP_RM_RESOURCES_RESOURCE_HAS_LOCK,

--- a/src/steps/resource-manager/resources/index.ts
+++ b/src/steps/resource-manager/resources/index.ts
@@ -1,7 +1,5 @@
 import {
   Entity,
-  Step,
-  IntegrationStepExecutionContext,
   ExplicitRelationship,
   createDirectRelationship,
   RelationshipClass,
@@ -10,7 +8,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ResourcesClient } from './client';
@@ -149,9 +147,7 @@ export async function buildResourceHasResourceLockRelationships(
   );
 }
 
-export const resourcesSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const resourcesSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_RESOURCES_RESOURCE_GROUPS,
     name: 'Resource Groups',
@@ -159,6 +155,7 @@ export const resourcesSteps: Step<
     relationships: [SUBSCRIPTION_RESOURCE_GROUP_RELATIONSHIP_METADATA],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchResourceGroups,
+    permissions: ['Microsoft.Resources/subscriptions/resourceGroups/read'],
   },
   {
     id: STEP_RM_RESOURCES_RESOURCE_LOCKS,
@@ -167,6 +164,7 @@ export const resourcesSteps: Step<
     relationships: [],
     dependsOn: [STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchResourceGroupLocks,
+    permissions: ['Microsoft.Authorization/locks/read'],
   },
   {
     id: STEP_RM_RESOURCES_RESOURCE_HAS_LOCK,

--- a/src/steps/resource-manager/security/index.ts
+++ b/src/steps/resource-manager/security/index.ts
@@ -1,11 +1,7 @@
-import {
-  Step,
-  IntegrationStepExecutionContext,
-  createDirectRelationship,
-} from '@jupiterone/integration-sdk-core';
+import { createDirectRelationship } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { SecurityClient } from './client';
@@ -189,9 +185,7 @@ export async function fetchSecurityCenterAutoProvisioningSettings(
   });
 }
 
-export const securitySteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const securitySteps: AzureIntegrationStep[] = [
   {
     id: SecuritySteps.ASSESSMENTS,
     name: 'Security Assessments',
@@ -199,6 +193,7 @@ export const securitySteps: Step<
     relationships: [SecurityRelationships.SUBSCRIPTION_PERFORMED_ASSESSMENT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAssessments,
+    permissions: ['Microsoft.Security/assessments/read'],
   },
   {
     id: SecuritySteps.SECURITY_CENTER_CONTACTS,
@@ -209,6 +204,7 @@ export const securitySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterContacts,
+    permissions: ['Microsoft.Security/securityContacts/read'],
   },
   {
     id: SecuritySteps.PRICING_CONFIGURATIONS,
@@ -217,6 +213,7 @@ export const securitySteps: Step<
     relationships: [SecurityRelationships.SUBSCRIPTION_HAS_PRICING_CONFIG],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterPricingConfigurations,
+    permissions: ['Microsoft.Security/pricings/read'],
   },
   {
     id: SecuritySteps.SETTINGS,
@@ -225,6 +222,7 @@ export const securitySteps: Step<
     relationships: [SecurityRelationships.SUBSCRIPTION_HAS_SETTING],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterSettings,
+    permissions: ['Microsoft.Security/pricings/read'],
   },
   {
     id: SecuritySteps.AUTO_PROVISIONING_SETTINGS,
@@ -235,5 +233,6 @@ export const securitySteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterAutoProvisioningSettings,
+    permissions: ['Microsoft.Security/autoProvisioningSettings/read'],
   },
 ];

--- a/src/steps/resource-manager/security/index.ts
+++ b/src/steps/resource-manager/security/index.ts
@@ -222,7 +222,7 @@ export const securitySteps: AzureIntegrationStep[] = [
     relationships: [SecurityRelationships.SUBSCRIPTION_HAS_SETTING],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterSettings,
-    rolePermissions: ['Microsoft.Security/pricings/read'],
+    rolePermissions: ['Microsoft.Security/settings/read'],
   },
   {
     id: SecuritySteps.AUTO_PROVISIONING_SETTINGS,

--- a/src/steps/resource-manager/security/index.ts
+++ b/src/steps/resource-manager/security/index.ts
@@ -193,7 +193,7 @@ export const securitySteps: AzureIntegrationStep[] = [
     relationships: [SecurityRelationships.SUBSCRIPTION_PERFORMED_ASSESSMENT],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchAssessments,
-    permissions: ['Microsoft.Security/assessments/read'],
+    rolePermissions: ['Microsoft.Security/assessments/read'],
   },
   {
     id: SecuritySteps.SECURITY_CENTER_CONTACTS,
@@ -204,7 +204,7 @@ export const securitySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterContacts,
-    permissions: ['Microsoft.Security/securityContacts/read'],
+    rolePermissions: ['Microsoft.Security/securityContacts/read'],
   },
   {
     id: SecuritySteps.PRICING_CONFIGURATIONS,
@@ -213,7 +213,7 @@ export const securitySteps: AzureIntegrationStep[] = [
     relationships: [SecurityRelationships.SUBSCRIPTION_HAS_PRICING_CONFIG],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterPricingConfigurations,
-    permissions: ['Microsoft.Security/pricings/read'],
+    rolePermissions: ['Microsoft.Security/pricings/read'],
   },
   {
     id: SecuritySteps.SETTINGS,
@@ -222,7 +222,7 @@ export const securitySteps: AzureIntegrationStep[] = [
     relationships: [SecurityRelationships.SUBSCRIPTION_HAS_SETTING],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterSettings,
-    permissions: ['Microsoft.Security/pricings/read'],
+    rolePermissions: ['Microsoft.Security/pricings/read'],
   },
   {
     id: SecuritySteps.AUTO_PROVISIONING_SETTINGS,
@@ -233,6 +233,6 @@ export const securitySteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, subscriptionSteps.SUBSCRIPTION],
     executionHandler: fetchSecurityCenterAutoProvisioningSettings,
-    permissions: ['Microsoft.Security/autoProvisioningSettings/read'],
+    rolePermissions: ['Microsoft.Security/autoProvisioningSettings/read'],
   },
 ];

--- a/src/steps/resource-manager/service-bus/index.ts
+++ b/src/steps/resource-manager/service-bus/index.ts
@@ -170,7 +170,7 @@ export const serviceBusSteps: AzureIntegrationStep[] = [
     relationships: [ServiceBusRelationships.RESOURCE_GROUP_HAS_NAMESPACE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchServiceBusNamespaces,
-    permissions: ['Microsoft.ServiceBus/namespaces/read'],
+    rolePermissions: ['Microsoft.ServiceBus/namespaces/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_QUEUES,
@@ -179,7 +179,7 @@ export const serviceBusSteps: AzureIntegrationStep[] = [
     relationships: [ServiceBusRelationships.NAMESPACE_HAS_QUEUE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_NAMESPACES],
     executionHandler: fetchServiceBusQueues,
-    permissions: ['Microsoft.ServiceBus/namespaces/queues/read'],
+    rolePermissions: ['Microsoft.ServiceBus/namespaces/queues/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_TOPICS,
@@ -188,7 +188,7 @@ export const serviceBusSteps: AzureIntegrationStep[] = [
     relationships: [ServiceBusRelationships.NAMESPACE_HAS_TOPIC],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_NAMESPACES],
     executionHandler: fetchServiceBusTopics,
-    permissions: ['Microsoft.ServiceBus/namespaces/topics/read'],
+    rolePermissions: ['Microsoft.ServiceBus/namespaces/topics/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_SUBSCRIPTIONS,
@@ -197,6 +197,8 @@ export const serviceBusSteps: AzureIntegrationStep[] = [
     relationships: [ServiceBusRelationships.TOPIC_HAS_SUBSCRIPTION],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_TOPICS],
     executionHandler: fetchServiceBusSubscriptions,
-    permissions: ['Microsoft.ServiceBus/namespaces/topics/subscriptions/read'],
+    rolePermissions: [
+      'Microsoft.ServiceBus/namespaces/topics/subscriptions/read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/service-bus/index.ts
+++ b/src/steps/resource-manager/service-bus/index.ts
@@ -1,12 +1,10 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { ServiceBusClient } from './client';
@@ -164,9 +162,7 @@ export async function fetchServiceBusSubscriptions(
   );
 }
 
-export const serviceBusSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const serviceBusSteps: AzureIntegrationStep[] = [
   {
     id: STEP_RM_SERVICE_BUS_NAMESPACES,
     name: 'Service Bus Namespaces',
@@ -174,6 +170,7 @@ export const serviceBusSteps: Step<
     relationships: [ServiceBusRelationships.RESOURCE_GROUP_HAS_NAMESPACE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchServiceBusNamespaces,
+    permissions: ['Microsoft.ServiceBus/namespaces/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_QUEUES,
@@ -182,6 +179,7 @@ export const serviceBusSteps: Step<
     relationships: [ServiceBusRelationships.NAMESPACE_HAS_QUEUE],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_NAMESPACES],
     executionHandler: fetchServiceBusQueues,
+    permissions: ['Microsoft.ServiceBus/namespaces/queues/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_TOPICS,
@@ -190,6 +188,7 @@ export const serviceBusSteps: Step<
     relationships: [ServiceBusRelationships.NAMESPACE_HAS_TOPIC],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_NAMESPACES],
     executionHandler: fetchServiceBusTopics,
+    permissions: ['Microsoft.ServiceBus/namespaces/topics/read'],
   },
   {
     id: STEP_RM_SERVICE_BUS_SUBSCRIPTIONS,
@@ -198,5 +197,6 @@ export const serviceBusSteps: Step<
     relationships: [ServiceBusRelationships.TOPIC_HAS_SUBSCRIPTION],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_SERVICE_BUS_TOPICS],
     executionHandler: fetchServiceBusSubscriptions,
+    permissions: ['Microsoft.ServiceBus/namespaces/topics/subscriptions/read'],
   },
 ];

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -2,14 +2,12 @@ import { StorageAccount, Kind, SkuTier } from '@azure/arm-storage/esm/models';
 import {
   createDirectRelationship,
   Entity,
-  Step,
-  IntegrationStepExecutionContext,
   RelationshipClass,
   getRawData,
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import { StorageClient, createStorageAccountServiceClient } from './client';
@@ -412,9 +410,7 @@ export async function fetchStorageTables(
   );
 }
 
-export const storageSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const storageSteps: AzureIntegrationStep[] = [
   {
     id: steps.STORAGE_ACCOUNTS,
     name: 'Storage Accounts',
@@ -431,6 +427,7 @@ export const storageSteps: Step<
       STEP_RM_KEYVAULT_VAULTS,
     ],
     executionHandler: fetchStorageAccounts,
+    permissions: ['Microsoft.Storage/storageAccounts/read'],
   },
   {
     id: steps.STORAGE_FILE_SHARES,
@@ -439,6 +436,10 @@ export const storageSteps: Step<
     relationships: [relationships.STORAGE_ACCOUNT_HAS_FILE_SHARE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageFileShares,
+    permissions: [
+      'Microsoft.Storage/storageAccounts/fileServices/shares/read',
+      'Microsoft.Storage/storageAccounts/fileServices/shares/read',
+    ],
   },
   {
     id: steps.STORAGE_CONTAINERS,
@@ -447,6 +448,9 @@ export const storageSteps: Step<
     relationships: [relationships.STORAGE_ACCOUNT_HAS_CONTAINER],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageContainers,
+    permissions: [
+      'Microsoft.Storage/storageAccounts/blobServices/containers/read',
+    ],
   },
   {
     id: steps.STORAGE_QUEUES,
@@ -455,6 +459,7 @@ export const storageSteps: Step<
     relationships: [relationships.STORAGE_ACCOUNT_HAS_QUEUE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageQueues,
+    permissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
   },
   {
     id: steps.STORAGE_TABLES,
@@ -463,5 +468,6 @@ export const storageSteps: Step<
     relationships: [relationships.STORAGE_ACCOUNT_HAS_TABLE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageTables,
+    permissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
   },
 ];

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -427,7 +427,7 @@ export const storageSteps: AzureIntegrationStep[] = [
       STEP_RM_KEYVAULT_VAULTS,
     ],
     executionHandler: fetchStorageAccounts,
-    permissions: ['Microsoft.Storage/storageAccounts/read'],
+    rolePermissions: ['Microsoft.Storage/storageAccounts/read'],
   },
   {
     id: steps.STORAGE_FILE_SHARES,
@@ -436,7 +436,7 @@ export const storageSteps: AzureIntegrationStep[] = [
     relationships: [relationships.STORAGE_ACCOUNT_HAS_FILE_SHARE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageFileShares,
-    permissions: [
+    rolePermissions: [
       'Microsoft.Storage/storageAccounts/fileServices/shares/read',
       'Microsoft.Storage/storageAccounts/fileServices/shares/read',
     ],
@@ -448,7 +448,7 @@ export const storageSteps: AzureIntegrationStep[] = [
     relationships: [relationships.STORAGE_ACCOUNT_HAS_CONTAINER],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageContainers,
-    permissions: [
+    rolePermissions: [
       'Microsoft.Storage/storageAccounts/blobServices/containers/read',
     ],
   },
@@ -459,7 +459,7 @@ export const storageSteps: AzureIntegrationStep[] = [
     relationships: [relationships.STORAGE_ACCOUNT_HAS_QUEUE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageQueues,
-    permissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
+    rolePermissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
   },
   {
     id: steps.STORAGE_TABLES,
@@ -468,6 +468,6 @@ export const storageSteps: AzureIntegrationStep[] = [
     relationships: [relationships.STORAGE_ACCOUNT_HAS_TABLE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageTables,
-    permissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
+    rolePermissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
   },
 ];

--- a/src/steps/resource-manager/storage/index.ts
+++ b/src/steps/resource-manager/storage/index.ts
@@ -427,7 +427,12 @@ export const storageSteps: AzureIntegrationStep[] = [
       STEP_RM_KEYVAULT_VAULTS,
     ],
     executionHandler: fetchStorageAccounts,
-    rolePermissions: ['Microsoft.Storage/storageAccounts/read'],
+    rolePermissions: [
+      'Microsoft.Storage/storageAccounts/read',
+      'Microsoft.Storage/storageAccounts/blobServices/read',
+      'Microsoft.Storage/storageAccounts/queueServices/read',
+      'Microsoft.Storage/storageAccounts/tableServices/read',
+    ],
   },
   {
     id: steps.STORAGE_FILE_SHARES,
@@ -437,7 +442,6 @@ export const storageSteps: AzureIntegrationStep[] = [
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageFileShares,
     rolePermissions: [
-      'Microsoft.Storage/storageAccounts/fileServices/shares/read',
       'Microsoft.Storage/storageAccounts/fileServices/shares/read',
     ],
   },
@@ -468,6 +472,8 @@ export const storageSteps: AzureIntegrationStep[] = [
     relationships: [relationships.STORAGE_ACCOUNT_HAS_TABLE],
     dependsOn: [STEP_AD_ACCOUNT, steps.STORAGE_ACCOUNTS],
     executionHandler: fetchStorageTables,
-    rolePermissions: ['Microsoft.Storage/storageAccounts/queueServices/read'],
+    rolePermissions: [
+      'Microsoft.Storage/storageAccounts/tableServices/tables/read',
+    ],
   },
 ];

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -149,7 +149,7 @@ export const subscriptionSteps: AzureIntegrationStep[] = [
     relationships: [
       ...getDiagnosticSettingsRelationshipsForResource(entities.SUBSCRIPTION),
     ],
-    dependsOn: [STEP_AD_ACCOUNT],
+    dependsOn: [steps.SUBSCRIPTION],
     executionHandler: fetchSubscriptionDiagnosticSettings,
     rolePermissions: [
       'Microsoft.OperationalInsights/workspaces/providers/Microsoft.Insights/diagnosticSettings/Read',

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -151,9 +151,7 @@ export const subscriptionSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [steps.SUBSCRIPTION],
     executionHandler: fetchSubscriptionDiagnosticSettings,
-    rolePermissions: [
-      'Microsoft.OperationalInsights/workspaces/providers/Microsoft.Insights/diagnosticSettings/Read',
-    ],
+    rolePermissions: ['Microsoft.Insights/DiagnosticSettings/Read'],
   },
   {
     id: steps.LOCATIONS,

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -1,6 +1,4 @@
 import {
-  Step,
-  IntegrationStepExecutionContext,
   RelationshipClass,
   IntegrationConfigLoadError,
   IntegrationError,
@@ -9,7 +7,7 @@ import {
 } from '@jupiterone/integration-sdk-core';
 
 import { createAzureWebLinker } from '../../../azure';
-import { IntegrationStepContext, IntegrationConfig } from '../../../types';
+import { IntegrationStepContext, AzureIntegrationStep } from '../../../types';
 import { getAccountEntity } from '../../active-directory';
 import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 import {
@@ -134,9 +132,7 @@ export async function fetchLocations(
   await jobState.setData(setDataKeys.locationNameMap, locationNameMap);
 }
 
-export const subscriptionSteps: Step<
-  IntegrationStepExecutionContext<IntegrationConfig>
->[] = [
+export const subscriptionSteps: AzureIntegrationStep[] = [
   {
     id: steps.SUBSCRIPTION,
     name: 'Subscriptions',
@@ -144,6 +140,7 @@ export const subscriptionSteps: Step<
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchSubscription,
+    permissions: ['Microsoft.Resources/subscriptions/read'],
   },
   {
     id: steps.SUBSCRIPTION_DIAGNOSTIC_SETTINGS,
@@ -154,6 +151,9 @@ export const subscriptionSteps: Step<
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchSubscriptionDiagnosticSettings,
+    permissions: [
+      'Microsoft.OperationalInsights/workspaces/providers/Microsoft.Insights/diagnosticSettings/Read',
+    ],
   },
   {
     id: steps.LOCATIONS,
@@ -163,5 +163,6 @@ export const subscriptionSteps: Step<
     mappedRelationships: [mappedRelationships.SUBSCRIPTION_USES_LOCATION],
     dependsOn: [STEP_AD_ACCOUNT, steps.SUBSCRIPTION],
     executionHandler: fetchLocations,
+    permissions: ['Microsoft.Resources/subscriptions/locations/read'],
   },
 ];

--- a/src/steps/resource-manager/subscriptions/index.ts
+++ b/src/steps/resource-manager/subscriptions/index.ts
@@ -140,7 +140,7 @@ export const subscriptionSteps: AzureIntegrationStep[] = [
     relationships: [],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchSubscription,
-    permissions: ['Microsoft.Resources/subscriptions/read'],
+    rolePermissions: ['Microsoft.Resources/subscriptions/read'],
   },
   {
     id: steps.SUBSCRIPTION_DIAGNOSTIC_SETTINGS,
@@ -151,7 +151,7 @@ export const subscriptionSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT],
     executionHandler: fetchSubscriptionDiagnosticSettings,
-    permissions: [
+    rolePermissions: [
       'Microsoft.OperationalInsights/workspaces/providers/Microsoft.Insights/diagnosticSettings/Read',
     ],
   },
@@ -163,6 +163,6 @@ export const subscriptionSteps: AzureIntegrationStep[] = [
     mappedRelationships: [mappedRelationships.SUBSCRIPTION_USES_LOCATION],
     dependsOn: [STEP_AD_ACCOUNT, steps.SUBSCRIPTION],
     executionHandler: fetchLocations,
-    permissions: ['Microsoft.Resources/subscriptions/locations/read'],
+    rolePermissions: ['Microsoft.Resources/subscriptions/locations/read'],
   },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,21 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
 
 export interface AzureIntegrationStep
   extends IntegrationStep<IntegrationConfig> {
+  /**
+   * Azure RBAC permissions that are required to ingest data from this step.
+   * These permissions are assigned to an IAM Role and bound to a principal
+   * through an IAM Role Binding. They are attached to Azure Subscription or
+   * Azure Management Groups.
+   *
+   * See https://learn.microsoft.com/en-us/azure/role-based-access-control/
+   */
   rolePermissions?: Array<string>;
+  /**
+   * Azure API Permissions assigned directly to a service principal within
+   * Azure Active Directory. Specifically, these permissions allow access to
+   * the Azure Graph API.
+   *
+   * See https://learn.microsoft.com/en-us/graph/use-the-api
+   */
   apiPermissions?: Array<string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import {
   IntegrationInstanceConfig,
+  IntegrationStep,
   IntegrationStepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
 
@@ -60,4 +61,9 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   ingestActiveDirectory?: boolean;
 
   configureSubscriptionInstances?: boolean;
+}
+
+export interface AzureIntegrationStep
+  extends IntegrationStep<IntegrationConfig> {
+  permissions?: Array<string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,5 +65,6 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
 
 export interface AzureIntegrationStep
   extends IntegrationStep<IntegrationConfig> {
-  permissions?: Array<string>;
+  rolePermissions?: Array<string>;
+  apiPermissions?: Array<string>;
 }


### PR DESCRIPTION
Context and motivation:
We must provide the required list of permissions that require a review of all the SDK calls that we are doing and collect all of them. As part of making this process more scalable, this spike ticket was created, in order to investigate a way to automate the process of collecting this permissions and adding this to jupiterone.md README automatically. This script might be migrated to the SDK in the future to apply this process to all services.

Permissions in azure could be referring to API permissions, or Role based permissions (related to RBAC azure support). We want to document each of them separately.

How it works
`yarn document:permissions` command will be added. This script imports invocationConfig variable from steps index to be able to collect permissions. This permissions will be added to the IntegrationStep array in each step as permissions. This would look like this:

```
{
    id: ...,
    name: ...,
    dependsOn: [],
    entities: [],
    relationships: [],
    executionHandler: () => {},
    apiPermissions: ['permission3', 'permission4'],
    rolePermissions: ['permission1', 'permission2'],
},
```