### PR TITLE
Fix(INT-6993): Some provider API Errors where being displayed incorrectly

### DIFF
--- a/src/azure/resource-manager/client.test.ts
+++ b/src/azure/resource-manager/client.test.ts
@@ -127,3 +127,58 @@ test('request should expose node-fetch error codes', async () => {
     'Provider API failed at fake-resource: ECONNRESET Error message for system error',
   );
 });
+
+test('request should expose Azure RestError status and text', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop: any = () => {};
+  const azureRequest = {
+    url: 'some-url',
+    method: 'GET' as any,
+    headers: {
+      set: noop,
+      get: noop,
+      contains: noop,
+      remove: noop,
+      rawHeaders: noop,
+      headerNames: noop,
+      headerValues: noop,
+      headersArray: noop,
+      clone: noop,
+      toJson: noop,
+    },
+    withCredentials: false,
+    timeout: 1000,
+    validateRequestProperties: noop,
+    clone: noop,
+    prepare: noop,
+  };
+
+  await expect(
+    request(
+      () => {
+        throw new AzureRestError(
+          'Error message for azure rest error',
+          'Error Code',
+          400,
+          azureRequest,
+          {
+            request: azureRequest,
+            status: 400,
+            headers: azureRequest.headers,
+          },
+          {
+            error: {
+              code: 'FeatureNotSupportedForAccount',
+              message: 'Table is not supported for the account',
+            },
+          },
+        );
+      },
+      createMockIntegrationLogger(),
+      'fake-resource',
+      1000,
+    ),
+  ).rejects.toThrow(
+    'Provider API failed at fake-resource: 400 Table is not supported for the account',
+  );
+});

--- a/src/azure/resource-manager/client.ts
+++ b/src/azure/resource-manager/client.ts
@@ -277,8 +277,8 @@ export async function request<T extends ResourceResponse>(
       let status = '';
       let statusText = '';
       if (err instanceof AzureRestError) {
-        status = err.body?.code;
-        statusText = err.body?.message;
+        status = err.body?.code ?? err.body?.error?.code;
+        statusText = err.body?.message ?? err.body?.error?.message;
       } else if (err instanceof FetchError) {
         status = err.code!;
         statusText = err.message;

--- a/src/azure/resource-manager/client.ts
+++ b/src/azure/resource-manager/client.ts
@@ -277,7 +277,7 @@ export async function request<T extends ResourceResponse>(
       let status = '';
       let statusText = '';
       if (err instanceof AzureRestError) {
-        status = err.body?.code ?? err.body?.error?.code;
+        status = err.body?.code ?? err.response?.status;
         statusText = err.body?.message ?? err.body?.error?.message;
       } else if (err instanceof FetchError) {
         status = err.code!;


### PR DESCRIPTION
When an API error ocurred related to an AzureRestError, it was displayed as:

`Provider API failed at policyInsights.policyStates: undefined undefined`

Now we get:

`Provider API failed at policyInsights.policyStates: AuthorizationFailed The client '[...]' with object id '[...]' does not have authorization to perform action 'Microsoft.PolicyInsights/policyStates/queryResults/read' over scope '/subscriptions/[...]' or the scope is invalid. If access was recently granted, please refresh your credentials.`