### PR TITLE
INT-7311 Duplicated key on relationship.

### DIFF
--- a/src/steps/resource-manager/authorization/index.ts
+++ b/src/steps/resource-manager/authorization/index.ts
@@ -244,13 +244,18 @@ export async function fetchClassicAdministrators(
   await jobState.addEntity(classicAdministratorGroupEntity);
 
   await client.iterateClassicAdministrators(async (ca) => {
-    await jobState.addRelationship(
-      createClassicAdministratorHasUserMappedRelationship({
+    const classicAdministratorHasUserRelationship = createClassicAdministratorHasUserMappedRelationship(
+      {
         webLinker,
         classicAdministratorGroupEntity,
         data: ca,
-      }),
+      },
     );
+    if (
+      !(await jobState.hasKey(classicAdministratorHasUserRelationship._key))
+    ) {
+      await jobState.addRelationship(classicAdministratorHasUserRelationship);
+    }
   });
 }
 


### PR DESCRIPTION
The logs show 
`Caused By: Error: Duplicate _key detected (_key=azure_classic_admin_group|has|FORWARD:_type=azure_user:userPrincipalName=something@something.com)`

For now, we should not create a relationship if the key for that relationship exists in the jobstate.