### PR TITLE
Int 7422 disable steps legacy subscriptions

### DIFF
--- a/src/__recordings__/getStepStartStates_2244155193/recording.har
+++ b/src/__recordings__/getStepStartStates_2244155193/recording.har
@@ -1,0 +1,512 @@
+{
+  "log": {
+    "_recordingName": "getStepStartStates",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "4eab979841c1f2185e48b484c23ec3e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 178,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "5c4f8943-e44d-4a24-8415-7d1343012da5"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.1.28"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.microsoftonline.com"
+            },
+            {
+              "name": "content-length",
+              "value": 178
+            }
+          ],
+          "headersSize": 414,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.microsoftonline.com/19ae0f99-6fc6-444b-bd54-97504efc66ad/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 1468,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1468,
+            "text": "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1682344511\",\"not_before\":\"1682340611\",\"resource\":\"https://management.azure.com/\",\"access_token\":\"[REDACTED]\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2023-05-24T12:55:11.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "5c4f8943-e44d-4a24-8415-7d1343012da5"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "9905839b-0ac6-46f2-9998-c4dbf73e1700"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.15175.8 - SCUS ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Apr 2023 12:55:11 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "1468"
+            }
+          ],
+          "headersSize": 807,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-24T12:55:11.058Z",
+        "time": 496,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 496
+        }
+      },
+      {
+        "_id": "5b659db4e0ea98de8227750eb75526ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "7680d167-0d42-4db3-86dc-13b27f130f4e"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Darwin-22.4.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1695,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 503,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 503,
+            "text": "{\"value\":[{\"id\":\"/subscriptions/193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"193f89dc-6225-4a80-bacb-96b32fbf6dd0\",\"displayName\":\"jupiterone-integration-dev\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/78d77376-1e6c-45ae-976b-9d1ef243d933\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"78d77376-1e6c-45ae-976b-9d1ef243d933\",\"displayName\":\"test-disabled-subscription\",\"state\":\"Disabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}},{\"id\":\"/subscriptions/f4e36c12-e09f-44c8-b660-69594ee88137\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"f4e36c12-e09f-44c8-b660-69594ee88137\",\"displayName\":\"Access to Azure Active Directory\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-tenant-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "007e97e7-1fbc-409d-a05f-ed35a64bd696"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "007e97e7-1fbc-409d-a05f-ed35a64bd696"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "BRAZILSOUTH:20230424T125513Z:007e97e7-1fbc-409d-a05f-ed35a64bd696"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Apr 2023 12:55:13 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "503"
+            }
+          ],
+          "headersSize": 586,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-24T12:55:11.592Z",
+        "time": 1695,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1695
+        }
+      },
+      {
+        "_id": "a3cd148353af2f1b9c11a963fe64a66a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-language",
+              "value": "en-US"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-ms-client-request-id",
+              "value": "bde821cb-4673-4185-988b-ba01e67d89d6"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@azure/arm-subscriptions/2.0.0 ms-rest-azure-js/2.0.1 ms-rest-js/2.0.7 Node/v14.18.0 OS/(x64-Darwin-22.4.0)"
+            },
+            {
+              "_fromType": "array",
+              "name": "cookie",
+              "value": ""
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "management.azure.com"
+            }
+          ],
+          "headersSize": 1786,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "2016-06-01"
+            }
+          ],
+          "url": "https://management.azure.com/subscriptions/f4e36c12-e09f-44c8-b660-69594ee88137?api-version=2016-06-01"
+        },
+        "response": {
+          "bodySize": 342,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 342,
+            "text": "{\"id\":\"/subscriptions/f4e36c12-e09f-44c8-b660-69594ee88137\",\"authorizationSource\":\"RoleBased\",\"subscriptionId\":\"f4e36c12-e09f-44c8-b660-69594ee88137\",\"displayName\":\"Access to Azure Active Directory\",\"state\":\"Enabled\",\"subscriptionPolicies\":{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"PayAsYouGo_2014-09-01\",\"spendingLimit\":\"Off\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-ms-ratelimit-remaining-subscription-reads",
+              "value": "11999"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "7339a152-4b7b-4e85-bb0b-c6ecfcfea06e"
+            },
+            {
+              "name": "x-ms-correlation-request-id",
+              "value": "7339a152-4b7b-4e85-bb0b-c6ecfcfea06e"
+            },
+            {
+              "name": "x-ms-routing-request-id",
+              "value": "BRAZILSOUTH:20230424T125514Z:7339a152-4b7b-4e85-bb0b-c6ecfcfea06e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Apr 2023 12:55:13 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "342"
+            }
+          ],
+          "headersSize": 592,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-04-24T12:55:13.308Z",
+        "time": 736,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 736
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
Disabled all the steps for subscriptions named 'Access to Azure Active Directory'
These subscriptions do NOT host Azure AD. These are legacy subscriptions that can no longer be managed by customer portal. We decided not to execute any step, just show an event.
 If (almost) any step executes we get:
` The current subscription type is not permitted to perform operations on any provider namespace. Please use a different subscription.`
  More info: [legacy subscriptions](https://www.jasonfritts.me/2020/04/07/what-is-the-access-to-azure-active-directory-subscription-for/#:%7E:text=The%20%E2%80%9CAccess%20to%20Azure%20Active%20Directory%E2%80%9D%20subscriptions%20are%20a%20legacy,portal.azure.com)