### PR TITLE
Change target filter key to id

### DIFF
--- a/src/steps/resource-manager/management-groups/index.ts
+++ b/src/steps/resource-manager/management-groups/index.ts
@@ -113,7 +113,7 @@ export async function getGraphObjectsForManagementGroup(options: {
           _mapping: {
             sourceEntityKey: managementGroupEntity._key,
             relationshipDirection: RelationshipDirection.FORWARD,
-            targetFilterKeys: [['_type', 'id']],
+            targetFilterKeys: [['id']],
             targetEntity: {
               _type: SubscriptionEntities.SUBSCRIPTION._type,
               id: child.id,


### PR DESCRIPTION
Jira issue - https://jupiterone.atlassian.net/browse/INT-8687

TLDR, The azure integration is creating an entity from a relationship but the way its being created it is setting a _key that is different from the actual entity so the mapper can not adopt the initial entity.

Note that id and key are the same value on Klarna
<img width="839" alt="image" src="https://github.com/JupiterOne/graph-azure/assets/84300304/62acd9a0-eda8-4f3a-b98f-27085234b7d9">
