### PR TITLE
Handle key and secret permissions errors

### DIFF
--- a/src/steps/resource-manager/key-vault/client.ts
+++ b/src/steps/resource-manager/key-vault/client.ts
@@ -54,6 +54,21 @@ export class KeyVaultClient extends Client {
           name: IntegrationWarnEventName.MissingPermission,
           description: `Missing a Key Vault access policy. A Key Vault access policy determines whether a given security principal can perform different operations on Key Vault secrets, keys and certificates. Please follow the steps outlined here https://go.microsoft.com/fwlink/?linkid=2125287 and assign a "list" key permission in order to fetch these keys for your Key Vault ${vaultUri}.`,
         });
+      } else if (
+        err.statusCode === 401 &&
+        err.message.toString().includes('AKV10032')
+      ) {
+        //https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-configure-cross-tenant-existing-account?tabs=azure-portal
+        //We could have cases where an AD has the keyvault but we need to access the keys
+        //using another tenant. For now, lets just skip this cases.
+        this.logger.warn(
+          { err: err, vaultUri: vaultUri },
+          'Failed to retrieve a VaultKey',
+        );
+        this.logger.publishWarnEvent({
+          name: IntegrationWarnEventName.MissingEntity,
+          description: `This tenant/application is not allowed to access to keys for vault ${vaultUri}`,
+        });
       } else {
         throw err;
       }
@@ -81,6 +96,21 @@ export class KeyVaultClient extends Client {
         this.logger.publishWarnEvent({
           name: IntegrationWarnEventName.MissingPermission,
           description: `Missing a Key Vault access policy. A Key Vault access policy determines whether a given security principal can perform different operations on Key Vault secrets, keys and certificates. Please follow the steps outlined here https://go.microsoft.com/fwlink/?linkid=2125287 and assign a "list" secret permission in order to fetch these secrets for your Key Vault ${vaultUri}.`,
+        });
+      } else if (
+        err.statusCode === 401 &&
+        err.message.toString().includes('AKV10032')
+      ) {
+        //https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-configure-cross-tenant-existing-account?tabs=azure-portal
+        //We could have cases where an AD has the keyvault but we need to access the secrets
+        //using another tenant. For now, lets just skip this cases.
+        this.logger.warn(
+          { err: err, vaultUri: vaultUri },
+          'Failed to retrieve a VaultSevret',
+        );
+        this.logger.publishWarnEvent({
+          name: IntegrationWarnEventName.MissingEntity,
+          description: `This tenant/application is not allowed to access to secrets for vault ${vaultUri}`,
         });
       } else {
         throw err;

--- a/src/steps/resource-manager/key-vault/client.ts
+++ b/src/steps/resource-manager/key-vault/client.ts
@@ -67,7 +67,7 @@ export class KeyVaultClient extends Client {
         );
         this.logger.publishWarnEvent({
           name: IntegrationWarnEventName.MissingEntity,
-          description: `This tenant/application is not allowed to access to keys for vault ${vaultUri}`,
+          description: `This tenant/application is not allowed to access keys for vault ${vaultUri}`,
         });
       } else {
         throw err;
@@ -106,11 +106,11 @@ export class KeyVaultClient extends Client {
         //using another tenant. For now, lets just skip this cases.
         this.logger.warn(
           { err: err, vaultUri: vaultUri },
-          'Failed to retrieve a VaultSevret',
+          'Failed to retrieve a VaultSecret',
         );
         this.logger.publishWarnEvent({
           name: IntegrationWarnEventName.MissingEntity,
-          description: `This tenant/application is not allowed to access to secrets for vault ${vaultUri}`,
+          description: `This tenant/application is not allowed to access secrets for vault ${vaultUri}`,
         });
       } else {
         throw err;


### PR DESCRIPTION
"RestError: AKV10032: Invalid issuer. Expected one of https://sts.windows.net/5ae1af62-9505-4097-a69a-c1553ef7840e/, https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/, https://sts.windows.net/e2d54eb5-3869-4f70-8578-dee5fc7331f4/, found https://sts.windows.net/e5385570-36f1-4d50-aaf8-db2f87aa884a/. \n[...]"

We are requesting the keys with the wrong tenant/application. All of our integrations are single tenant based, so it would be impossible to ingest!