### PR TITLE
Remove previously added depends on

### DIFF
--- a/src/steps/resource-manager/api-management/index.test.ts
+++ b/src/steps/resource-manager/api-management/index.test.ts
@@ -11,6 +11,9 @@ import {
   setupAzureRecording,
   getMatchRequestsBy,
 } from '../../../../test/helpers/recording';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
+import { steps as storageSteps } from '../storage/constants';
 
 let recording: Recording;
 
@@ -39,7 +42,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        storageSteps.STORAGE_ACCOUNTS,
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/api-management/index.ts
+++ b/src/steps/resource-manager/api-management/index.ts
@@ -26,7 +26,6 @@ import {
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export async function fetchApiManagementServices(
   executionContext: IntegrationStepContext,
@@ -99,12 +98,9 @@ export const apiManagementSteps: AzureIntegrationStep[] = [
         ApiManagementEntities.SERVICE,
       ),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
     executionHandler: fetchApiManagementServices,
+    dependencyGraphId: 'last',
     rolePermissions: [
       'Microsoft.ApiManagement/service/read',
       'Microsoft.Insights/DiagnosticSettings/Read',

--- a/src/steps/resource-manager/batch/index.test.ts
+++ b/src/steps/resource-manager/batch/index.test.ts
@@ -11,6 +11,9 @@ import {
   STEP_RM_BATCH_CERTIFICATE,
   STEP_RM_BATCH_POOL,
 } from './constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
+import { steps as storageSteps } from '../storage/constants';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 
 let recording: Recording;
 
@@ -37,7 +40,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/batch/index.ts
+++ b/src/steps/resource-manager/batch/index.ts
@@ -35,7 +35,6 @@ import {
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { BatchAccount } from '@azure/arm-batch/esm/models';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export async function fetchBatchAccounts(
   executionContext: IntegrationStepContext,
@@ -204,11 +203,8 @@ export const batchSteps: AzureIntegrationStep[] = [
         BatchEntities.BATCH_ACCOUNT,
       ),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchBatchAccounts,
     rolePermissions: [
       'Microsoft.Batch/batchAccounts/read',

--- a/src/steps/resource-manager/cdn/index.test.ts
+++ b/src/steps/resource-manager/cdn/index.test.ts
@@ -8,6 +8,9 @@ import {
   setupAzureRecording,
   getMatchRequestsBy,
 } from '../../../../test/helpers/recording';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
+import { steps as storageSteps } from '../storage/constants';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 
 let recording: Recording;
 
@@ -34,7 +37,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,
@@ -58,7 +68,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_CDN_PROFILE,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/cdn/index.ts
+++ b/src/steps/resource-manager/cdn/index.ts
@@ -23,7 +23,6 @@ import {
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export async function fetchProfiles(
   executionContext: IntegrationStepContext,
@@ -96,11 +95,8 @@ export const cdnSteps: AzureIntegrationStep[] = [
       CdnRelationships.RESOURCE_GROUP_HAS_PROFILE,
       ...getDiagnosticSettingsRelationshipsForResource(CdnEntities.PROFILE),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchProfiles,
     rolePermissions: [
       'Microsoft.Cdn/profiles/read',
@@ -118,6 +114,7 @@ export const cdnSteps: AzureIntegrationStep[] = [
     ],
     dependsOn: [STEP_AD_ACCOUNT, STEP_RM_CDN_PROFILE],
     executionHandler: fetchEndpoints,
+    dependencyGraphId: 'last',
     rolePermissions: [
       'Microsoft.Cdn/profiles/endpoints/read',
       'Microsoft.Insights/DiagnosticSettings/Read',

--- a/src/steps/resource-manager/container-registry/index.test.ts
+++ b/src/steps/resource-manager/container-registry/index.test.ts
@@ -11,6 +11,9 @@ import {
   setupAzureRecording,
   getMatchRequestsBy,
 } from '../../../../test/helpers/recording';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
+import { steps as storageSteps } from '../storage/constants';
 
 let recording: Recording;
 
@@ -39,7 +42,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/container-registry/index.ts
+++ b/src/steps/resource-manager/container-registry/index.ts
@@ -26,7 +26,6 @@ import {
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export async function fetchContainerRegistries(
   executionContext: IntegrationStepContext,
@@ -105,11 +104,8 @@ export const containerRegistrySteps: AzureIntegrationStep[] = [
         ContainerRegistryEntities.REGISTRY,
       ),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchContainerRegistries,
     rolePermissions: [
       'Microsoft.ContainerRegistry/registries/read',

--- a/src/steps/resource-manager/databases/index.ts
+++ b/src/steps/resource-manager/databases/index.ts
@@ -16,7 +16,6 @@ import {
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export const databaseSteps: AzureIntegrationStep[] = [
   {
@@ -32,11 +31,8 @@ export const databaseSteps: AzureIntegrationStep[] = [
       MariaDBRelationships.MARIADB_SERVER_HAS_MARIADB_DATABASE,
       ...getDiagnosticSettingsRelationshipsForResource(MariaDBEntities.SERVER),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchMariaDBDatabases,
     rolePermissions: [
       'Microsoft.DBforMariaDB/servers/databases/read',
@@ -58,11 +54,8 @@ export const databaseSteps: AzureIntegrationStep[] = [
       MySQLRelationships.MYSQL_SERVER_HAS_MYSQL_DATABASE,
       ...getDiagnosticSettingsRelationshipsForResource(MySQLEntities.SERVER),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchMySQLDatabases,
     rolePermissions: [
       'Microsoft.DBforMySQL/servers/read',

--- a/src/steps/resource-manager/databases/mariadb/index.test.ts
+++ b/src/steps/resource-manager/databases/mariadb/index.test.ts
@@ -8,6 +8,9 @@ import {
   getMatchRequestsBy,
 } from '../../../../../test/helpers/recording';
 import { STEP_RM_DATABASE_MARIADB_DATABASES } from '../constants';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../../resources/constants';
+import { steps as storageSteps } from '../../storage/constants';
 
 let recording: Recording;
 
@@ -36,7 +39,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/databases/mysql/index.test.ts
+++ b/src/steps/resource-manager/databases/mysql/index.test.ts
@@ -8,6 +8,9 @@ import {
   getMatchRequestsBy,
 } from '../../../../../test/helpers/recording';
 import { STEP_RM_DATABASE_MYSQL_DATABASES } from '../constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../../resources/constants';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
+import { steps as storageSteps } from '../../storage/constants';
 
 let recording: Recording;
 
@@ -36,7 +39,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/databases/postgresql/index.test.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.test.ts
@@ -8,6 +8,9 @@ import {
   getMatchRequestsBy,
 } from '../../../../../test/helpers/recording';
 import { steps } from './constants';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../../resources/constants';
+import { steps as storageSteps } from '../../storage/constants';
 
 let recording: Recording;
 
@@ -34,7 +37,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/databases/postgresql/index.ts
+++ b/src/steps/resource-manager/databases/postgresql/index.ts
@@ -28,7 +28,6 @@ import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../../resources/constants';
 import { Server } from '@azure/arm-postgresql/esm/models';
 import { createPosgreSqlServerFirewallRuleEntity } from './converters';
 import { INGESTION_SOURCE_IDS } from '../../../../constants';
-import { steps as storageSteps } from '../../storage/constants';
 
 export async function fetchPostgreSQLServers(
   executionContext: IntegrationStepContext,
@@ -158,11 +157,8 @@ export const postgreSqlSteps: AzureIntegrationStep[] = [
         PostgreSQLEntities.SERVER,
       ),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchPostgreSQLServers,
     rolePermissions: [
       'Microsoft.Insights/DiagnosticSettings/Read',

--- a/src/steps/resource-manager/databases/sql/index.test.ts
+++ b/src/steps/resource-manager/databases/sql/index.test.ts
@@ -8,6 +8,8 @@ import {
   getMatchRequestsBy,
 } from '../../../../../test/helpers/recording';
 import { steps } from './constants';
+import { STEP_AD_ACCOUNT } from '../../../active-directory/constants';
+import { steps as storageSteps } from '../../storage/constants';
 
 let recording: Recording;
 
@@ -63,7 +65,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        steps.SERVERS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   100_000,

--- a/src/steps/resource-manager/databases/sql/index.ts
+++ b/src/steps/resource-manager/databases/sql/index.ts
@@ -32,7 +32,6 @@ import {
 import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../../resources/constants';
 import { Server } from '@azure/arm-sql/esm/models';
 import { INGESTION_SOURCE_IDS } from '../../../../constants';
-import { steps as storageSteps } from '../../storage/constants';
 
 export async function fetchSQLServers(
   executionContext: IntegrationStepContext,
@@ -227,7 +226,8 @@ export const sqlSteps: AzureIntegrationStep[] = [
     relationships: [
       ...getDiagnosticSettingsRelationshipsForResource(entities.SERVER),
     ],
-    dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS, storageSteps.STORAGE_ACCOUNTS],
+    dependsOn: [STEP_AD_ACCOUNT, steps.SERVERS],
+    dependencyGraphId: 'last',
     executionHandler: fetchSQLServerDiagnosticSettings,
     rolePermissions: ['Microsoft.Insights/DiagnosticSettings/Read'],
     ingestionSourceId: INGESTION_SOURCE_IDS.DATABASES,

--- a/src/steps/resource-manager/event-grid/index.test.ts
+++ b/src/steps/resource-manager/event-grid/index.test.ts
@@ -14,6 +14,9 @@ import {
   STEP_RM_EVENT_GRID_TOPICS,
   STEP_RM_EVENT_GRID_TOPIC_SUBSCRIPTIONS,
 } from './constants';
+import { STEP_RM_RESOURCES_RESOURCE_GROUPS } from '../resources/constants';
+import { steps as storageSteps } from '../storage/constants';
+import { STEP_AD_ACCOUNT } from '../../active-directory/constants';
 
 let recording: Recording;
 
@@ -40,7 +43,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   1000_000,
@@ -114,7 +124,14 @@ test(
       stepTestConfig.instanceConfig,
     );
 
-    const stepResults = await executeStepWithDependencies(stepTestConfig);
+    const stepResults = await executeStepWithDependencies({
+      ...stepTestConfig,
+      dependencyStepIds: [
+        STEP_AD_ACCOUNT,
+        STEP_RM_RESOURCES_RESOURCE_GROUPS,
+        storageSteps.STORAGE_ACCOUNTS,
+      ],
+    });
     expect(stepResults).toMatchStepMetadata(stepTestConfig);
   },
   1000_000,

--- a/src/steps/resource-manager/event-grid/index.ts
+++ b/src/steps/resource-manager/event-grid/index.ts
@@ -37,7 +37,6 @@ import {
   getDiagnosticSettingsRelationshipsForResource,
 } from '../utils/createDiagnosticSettingsEntitiesAndRelationshipsForResource';
 import { INGESTION_SOURCE_IDS } from '../../../constants';
-import { steps as storageSteps } from '../storage/constants';
 
 export async function fetchEventGridDomains(
   executionContext: IntegrationStepContext,
@@ -242,11 +241,8 @@ export const eventGridSteps: AzureIntegrationStep[] = [
         EventGridEntities.DOMAIN,
       ),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchEventGridDomains,
     rolePermissions: [
       'Microsoft.EventGrid/domains/read',
@@ -296,11 +292,8 @@ export const eventGridSteps: AzureIntegrationStep[] = [
       EventGridRelationships.RESOURCE_GROUP_HAS_TOPIC,
       ...getDiagnosticSettingsRelationshipsForResource(EventGridEntities.TOPIC),
     ],
-    dependsOn: [
-      STEP_AD_ACCOUNT,
-      STEP_RM_RESOURCES_RESOURCE_GROUPS,
-      storageSteps.STORAGE_ACCOUNTS,
-    ],
+    dependsOn: [STEP_AD_ACCOUNT, STEP_RM_RESOURCES_RESOURCE_GROUPS],
+    dependencyGraphId: 'last',
     executionHandler: fetchEventGridTopics,
     rolePermissions: [
       'Microsoft.EventGrid/topics/read',


### PR DESCRIPTION
Removed previously added dependsOn storageSteps.STORAGE_ACCOUNTS. While the steps do require the storageAccounts to be ingested in order to create the relationship between a diagnosticSetting and its storage account, it doesn't make sense for the step to be disabled if storage account is.
Therefore, for now, I'm removing the dependsOn I added, and enabling the dependencyGraphId: 'last' so that we can control on the tests that if the storageAccount exists, the relationship gets created, and to improve the chances we create the relationship on an actual run.

Further work might be needed to split the diagnosticsettings logic for all steps.
